### PR TITLE
Fix crash with libGDX unable to load empty strings as icons

### DIFF
--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
@@ -7,6 +7,9 @@
 
 package me.stringdotjar.flixelgdx.backend.lwjgl3;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Application;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowAdapter;
@@ -25,7 +28,8 @@ public class FlixelLwjgl3Launcher {
 
   /**
    * Launches the LWJGL3 version of the Flixel game in {@link FlixelRuntimeMode#RELEASE RELEASE}
-   * mode and with a default configuration object.
+   * mode and with a default configuration object. This should be called from the main method of the
+   * libGDX LWJGL3 launcher class, and the game instance should be created in the same general area.
    *
    * @param game The game instance to launch.
    */
@@ -39,7 +43,7 @@ public class FlixelLwjgl3Launcher {
    * libGDX LWJGL3 launcher class, and the game instance should be created in the same general area.
    *
    * @param game The game instance to launch.
-   * @param icons Window icon paths.
+   * @param icons Window icon paths. Make sure your icons actually exist and are valid!
    */
   public static void launch(FlixelGame game, String... icons) {
     launch(game, FlixelRuntimeMode.RELEASE, icons);
@@ -52,7 +56,7 @@ public class FlixelLwjgl3Launcher {
    *
    * @param game The game instance to launch.
    * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
-   * @param icons Window icon paths.
+   * @param icons Window icon paths. Make sure your icons actually exist and are valid!
    */
   public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode, String... icons) {
     Lwjgl3ApplicationConfiguration configuration = new Lwjgl3ApplicationConfiguration();
@@ -64,7 +68,12 @@ public class FlixelLwjgl3Launcher {
     } else {
       configuration.setWindowedMode(game.getViewWidth(), game.getViewHeight());
     }
-    configuration.setWindowIcon(icons);
+    // Ensure the icons are not null, empty, or whitespace only.
+    configuration.setWindowIcon(Arrays.stream(icons)
+      .filter(Objects::nonNull)
+      .map(String::trim)
+      .filter(s -> !s.isEmpty())
+      .toArray(String[]::new));
     configuration.setWindowListener(new Lwjgl3WindowAdapter() {
       @Override
       public void focusGained() {


### PR DESCRIPTION
## Description

This PR fixes a crash that allowed developers to pass broken strings as window icons.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [ ] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
