### PR TITLE
Remove the resetGame() method

### DIFF
--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
@@ -33,7 +33,6 @@ import me.stringdotjar.flixelgdx.debug.FlixelDebugWatchManager;
 import me.stringdotjar.flixelgdx.group.FlixelGroupable;
 import me.stringdotjar.flixelgdx.logging.FlixelLogFileHandler;
 import me.stringdotjar.flixelgdx.logging.FlixelStackTraceProvider;
-import me.stringdotjar.flixelgdx.text.FlixelFontRegistry;
 import me.stringdotjar.flixelgdx.util.FlixelConstants;
 import me.stringdotjar.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import me.stringdotjar.flixelgdx.input.mouse.FlixelMouseManager;
@@ -255,7 +254,7 @@ public final class Flixel {
   @NotNull
   private static FlixelGame game;
 
-  /** The camera currently being drawn in {@link FlixelGame#draw()}, or {@code null} if not in a camera pass. */
+  /** The camera currently being drawn in {@link FlixelGame#draw(com.badlogic.gdx.graphics.g2d.Batch)}. */
   @Nullable
   private static FlixelCamera drawCamera;
 
@@ -264,7 +263,7 @@ public final class Flixel {
   private static FlixelAlerter alerter;
 
   /** Has the global manager been initialized yet? */
-  private static boolean initialized = false;
+  protected static boolean initialized = false;
 
   /** System used to detect where a log comes from when a log is created. **/
   @NotNull
@@ -300,7 +299,7 @@ public final class Flixel {
   protected static float elapsed = 0f;
 
   /**
-   * Global time scale for frame-based timers ({@link me.stringdotjar.flixelgdx.util.timer.FlixelTimer}). {@code 1f} is
+   * Global timescale for frame-based timers ({@link me.stringdotjar.flixelgdx.util.timer.FlixelTimer}). {@code 1f} is
    * normal speed; lower slows timers, higher speeds them up. Does not change {@link #elapsed} itself.
    */
   private static float timeScale = 1f;
@@ -343,12 +342,8 @@ public final class Flixel {
    * Initializes the entire Flixel system.
    *
    * <p>This gets called BEFORE {@link FlixelGame#create()} is executed.
-   * It sets up every core system that Flixel needs to work, such as {@link FlixelAssetManager},
-   * audio system, key input manager,
-   * logger, backend systems for different platforms, and more.
-   *
-   * <p>Normally called once at startup. After {@link #resetGame()}, {@code initialized} is cleared and this may run
-   * again to rebuild global subsystems on the same {@link FlixelGame} instance.
+   * It sets up every core system that Flixel needs to work, such as {@link FlixelAssetManager}, audio system,
+   * key input manager, logger, backend systems for different platforms, and more.
    *
    * @param gameInstance The {@link FlixelGame} instance to use.
    * @throws IllegalStateException If Flixel has already been initialized.
@@ -982,17 +977,6 @@ public final class Flixel {
   }
 
   /**
-   * Same as {@link #switchState(FlixelState)}. Prefer {@code switchState} directly; this method exists for older
-   * call sites.
-   *
-   * @deprecated Use {@link #switchState(FlixelState)}.
-   */
-  @Deprecated
-  public static void resetState(@NotNull FlixelState newRoot) {
-    switchState(Objects.requireNonNull(newRoot, "newRoot"));
-  }
-
-  /**
    * Refreshes the current state by creating a new instance from the factory last set by
    * {@link #switchState(FlixelState, boolean, boolean, Supplier)}. Does nothing if the factory is {@code null}.
    *
@@ -1003,52 +987,6 @@ public final class Flixel {
     FlixelState next = currentStateFactory != null ? currentStateFactory.get() : null;
     if (next != null) {
       switchState(next);
-    }
-  }
-
-  /**
-   * Full session teardown. Sets {@code initialized} to {@code false}, destroys audio and tears down the current
-   * {@link FlixelGame} via {@link FlixelGame#reset()} (stage/batch/state/world only, not a full
-   * {@link FlixelGame#destroy()} application shutdown) and clears cameras/state/debug references.
-   *
-   * <p>Re-initializes the <strong>same</strong> {@link FlixelGame} instance passed to the first {@link
-   * #initialize(FlixelGame)}. libGDX keeps the original {@code ApplicationListener} reference (e.g. {@code
-   * Lwjgl3Application(game, ...)}); allocating a new {@code FlixelGame} would leave rendering on a dead instance
-   * and break statics (null batch, etc.).
-   *
-   * <p>Unlike {@link #resetState()}, this is intended for a cold restart from code. Call on the <strong>main
-   * libGDX thread</strong>. The window keeps running. This method does not call {@code Gdx.app.exit()}.
-   */
-  public static void resetGame() {
-    if (!initialized) {
-      return;
-    }
-    FlixelGame listener = Objects.requireNonNull(game, "Flixel game cannot be null!");
-    initialized = false;
-    FlixelTimer.cancelAll();
-    try {
-      listener.reset();
-    } catch (Exception ignored) {
-      // Ignore.
-    }
-    state = null;
-    currentStateFactory = null;
-    drawCamera = null;
-    debugOverlay = null;
-    if (assets != null) {
-      assets.dispose();
-      assets = null;
-    }
-    FlixelTween.resetRegistry();
-    FlixelFontRegistry.dispose();
-    System.gc();
-    Flixel.initialize(listener);
-    listener.create();
-    // libGDX only invokes ApplicationListener#create() once per run; after a cold reset we must re-sync
-    // window dimensions ourselves. Otherwise, cameras keep constructor sizing (often viewSize, not the real
-    // framebuffer) and the main loop can appear frozen or split viewports stay misaligned until a resize.
-    if (Gdx.graphics != null) {
-      listener.resize(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
     }
   }
 
@@ -1407,6 +1345,12 @@ public final class Flixel {
     return antialiasing;
   }
 
+  /**
+   * Sets antialiasing to be applied to all {@link FlixelSprite} objects.
+   * Automatically updates the current state.
+   *
+   * @param enabled If antialiasing should be applied to all current and any future {@link FlixelSprite} objects.
+   */
   public static void setAntialiasing(boolean enabled) {
     if (enabled == antialiasing) {
       return;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelGame.java
@@ -94,9 +94,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   protected Vector2 windowSize;
 
   /**
-   * Produces the root {@link FlixelState} each time {@link #create()} runs (including after {@link Flixel#resetGame()}).
-   * Use {@code () -> new MyState()} for a fresh instance per session, or {@code () -> sharedState} to reuse one
-   * object (its {@link FlixelState#destroy()} / {@link FlixelState#create()} lifecycle still runs via {@link Flixel#switchState}).
+   * Produces the root {@link FlixelState} each time {@link #create()} runs. Use {@code () -> new MyState()} for a fresh
+   * instance per session, or {@code () -> sharedState} to reuse one object
+   * (its {@link FlixelState#destroy()} / {@link FlixelState#create()} lifecycle still runs via {@link Flixel#switchState}).
    */
   @NotNull
   protected Supplier<FlixelState> initialStateFactory;
@@ -143,6 +143,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   /** When true, skips gameplay/state/camera follow updates (debug pause). */
   private boolean gamePaused = false;
 
+  /** When true, calls {@link #destroy()} and {@link #create()}, which resets the game. */
+  protected volatile boolean resetRequested = false;
+
   /** 2D array of saved camera scroll values when the game is paused for debugging. */
   @Nullable
   private float[][] debugPauseCameraScroll;
@@ -161,10 +164,10 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * Creates a new game instance with the details specified.
    *
    * @param title The title of the game's window.
-   * @param initialScreen The initial screen to load when the game starts.
+   * @param initialState The initial screen to load when the game starts.
    */
-  public FlixelGame(String title, FlixelState initialScreen) {
-    this(title, 640, 360, initialScreen, 60, true, false);
+  public FlixelGame(String title, FlixelState initialState) {
+    this(title, 640, 360, initialState, 60, true, false);
   }
 
   /**
@@ -173,10 +176,10 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * @param title The title of the game's window.
    * @param width The starting width of the game's window and how wide the camera should be.
    * @param height The starting height of the game's window and how tall the camera should be.
-   * @param initialScreen The initial screen to load when the game starts.
+   * @param initialState The initial screen to load when the game starts.
    */
-  public FlixelGame(String title, int width, int height, FlixelState initialScreen) {
-    this(title, width, height, initialScreen, 60, true, false);
+  public FlixelGame(String title, int width, int height, FlixelState initialState) {
+    this(title, width, height, initialState, 60, true, false);
   }
 
   /**
@@ -185,11 +188,11 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * @param title The title of the game's window.
    * @param width The starting width of the game's window and how wide the camera should be.
    * @param height The starting height of the game's window and how tall the camera should be.
-   * @param initialScreen The initial screen to load when the game starts.
+   * @param initialState The initial screen to load when the game starts.
    * @param framerate The framerate of how fast the game should update and render.
    */
-  public FlixelGame(String title, int width, int height, FlixelState initialScreen, int framerate) {
-    this(title, width, height, initialScreen, framerate, true, false);
+  public FlixelGame(String title, int width, int height, FlixelState initialState, int framerate) {
+    this(title, width, height, initialState, framerate, true, false);
   }
 
   /**
@@ -198,12 +201,12 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * @param title The title of the game's window.
    * @param width The starting width of the game's window and how wide the camera should be.
    * @param height The starting height of the game's window and how tall the camera should be.
-   * @param initialScreen The initial screen to load when the game starts.
+   * @param initialState The initial screen to load when the game starts.
    * @param framerate The framerate of how fast the game should update and render.
    * @param vsync Should the game use VSync to limit the framerate to the monitor's refresh rate?
    */
-  public FlixelGame(String title, int width, int height, FlixelState initialScreen, int framerate, boolean vsync) {
-    this(title, width, height, initialScreen, framerate, vsync, false);
+  public FlixelGame(String title, int width, int height, FlixelState initialState, int framerate, boolean vsync) {
+    this(title, width, height, initialState, framerate, vsync, false);
   }
 
   /**
@@ -212,20 +215,25 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * @param title The title of the game's window.
    * @param width The starting width of the game's window and how wide the camera should be.
    * @param height The starting height of the game's window and how tall the camera should be.
-   * @param initialScreen The initial screen to load when the game starts.
+   * @param initialState The initial screen to load when the game starts.
    * @param framerate The framerate of how fast the game should update and render.
    * @param vsync Should the game use VSync to limit the framerate to the monitor's refresh rate?
    * @param fullscreen Should the game start in fullscreen mode?
    */
-  public FlixelGame(String title, int width, int height, FlixelState initialScreen, int framerate, boolean vsync, boolean fullscreen) {
-    this(title, width, height, () -> initialScreen, framerate, vsync, fullscreen);
+  public FlixelGame(String title, int width, int height, FlixelState initialState, int framerate, boolean vsync, boolean fullscreen) {
+    this(title, width, height, () -> initialState, framerate, vsync, fullscreen);
   }
 
   /**
-   * Same as {@link #FlixelGame(String, int, int, FlixelState, int, boolean, boolean)} but supplies a new root state
-   * from a factory (recommended after {@link Flixel#resetGame()} so each cold start can use {@code new MyState()}).
+   * Creates a new game instance with the details specified.
    *
-   * @param initialStateFactory Non-null supplier; invoked from {@link #create()} to obtain the root state.
+   * @param title The title of the game's window.
+   * @param width The starting width of the game's window and how wide the camera should be.
+   * @param height The starting height of the game's window and how tall the camera should be.
+   * @param initialStateFactory The initial screen to load when the game starts as a supplier factory.
+   * @param framerate The framerate of how fast the game should update and render.
+   * @param vsync Should the game use VSync to limit the framerate to the monitor's refresh rate?
+   * @param fullscreen Should the game start in fullscreen mode?
    */
   public FlixelGame(String title, int width, int height, @NotNull Supplier<FlixelState> initialStateFactory, int framerate, boolean vsync, boolean fullscreen) {
     this.title = title;
@@ -252,6 +260,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   @Override
   public void create() {
     configureCrashHandler(); // This should ALWAYS be called first no matter what!
+
+    isClosed = false;
+    isClosing = false;
 
     batch = new SpriteBatch();
     cameras = new Array<>(FlixelCamera[]::new);
@@ -318,7 +329,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   }
 
   /**
-   * Updates the logic of the game's loop.
+   * Updates the logic of the game loop.
    *
    * @param elapsed The amount of time that occurred in the last frame.
    */
@@ -355,9 +366,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       }
 
       // Update all cameras.
-      FlixelCamera[] cameraItems = cameras.items;
-      for (int i = 0, n = cameras.size; i < n; i++) {
-        cameraItems[i].update(elapsed);
+      for (FlixelCamera camera : cameras) {
+        camera.update(elapsed);
       }
     }
 
@@ -447,33 +457,27 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * running, so it is not necessary to override this method in most cases. However, it can be overridden to
    * perform custom updating/rendering before the game is updated/rendered.
    *
-   * <p>This method is kept non-final for compatibility with existing projects that want to extend to this class
-   * and use its structured game loop. It's advised to override {@link #update(float)} and {@link #draw(Batch)} instead to
-   * perform custom updating and rendering.
+   * <p>You should not (and cannot) override this method. You are encouraged to override either {@link #update(float)}
+   * or {@link #draw(Batch)} instead, as they separate logic and rendering correctly.
    *
    * @see #update(float)
    * @see #draw(Batch)
    * @see ApplicationListener#render()
    */
   @Override
-  public void render() {
-    float rawDelta = Gdx.graphics.getDeltaTime();
+  public final void render() {
+    float rawDelta = Gdx.graphics != null ? Gdx.graphics.getDeltaTime() : FlixelConstants.Graphics.MIN_ELAPSED;
     float elapsed = Math.max(FlixelConstants.Graphics.MIN_ELAPSED, Math.min(rawDelta, FlixelConstants.Graphics.MAX_ELAPSED));
     Flixel.elapsed = elapsed;
 
     windowSize.x = Gdx.graphics.getWidth();
     windowSize.y = Gdx.graphics.getHeight();
-
     fullscreen = Gdx.graphics.isFullscreen();
 
     if (!autoPause || isFocused) {
       update(elapsed);
     }
     draw(batch);
-  }
-
-  public boolean isGamePaused() {
-    return gamePaused;
   }
 
   /**
@@ -543,6 +547,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     isFocused = true;
     if (autoPause && !isMinimized && !gamePaused) {
       Flixel.sound.resume();
+      Gdx.graphics.setContinuousRendering(true);
+      Gdx.graphics.requestRendering();
     }
     Flixel.Signals.windowFocused.dispatch();
   }
@@ -552,6 +558,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     isFocused = false;
     if (autoPause) {
       Flixel.sound.pause();
+      Gdx.graphics.setContinuousRendering(false);
     }
     Flixel.Signals.windowUnfocused.dispatch();
   }
@@ -560,13 +567,14 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * Called when the user minimizes the game's window.
    *
    * @param iconified Whether the window is iconified (minimized) or not. This parameter is provided
-   * for compatibility with the window listener in the LWJGL3 (desktop) launcher.
+   *   for compatibility with the window listener in the LWJGL3 (desktop) launcher.
    */
   public void onWindowMinimized(boolean iconified) {
     isMinimized = iconified;
     isFocused = false;
     if (autoPause) {
       Flixel.sound.pause();
+      Gdx.graphics.setContinuousRendering(false);
     }
     Flixel.Signals.windowMinimized.dispatch();
   }
@@ -599,13 +607,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     return autoPause;
   }
 
-  /**
-   * Gets called when the game is closing to perform custom cleanup
-   * after core resources are disposed and before the log thread shuts down, so any
-   * logs written here (e.g., via {@link Flixel#info}) are persisted to the log file.
-   */
-  protected void close() {}
-
   /** @see #destroy() */
   @Override
   public void dispose() {
@@ -613,10 +614,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   }
 
   /**
-   * Destroys the game and all of its resources. Note that this closes the game entirely.
-   * If you want to reset the game without closing it, use {@link #reset()} instead.
-   *
-   * @see #reset()
+   * Destroys the game and all of its resources. Note that this doesn't close the game entirely.
+   * If you want to close the entire game, use {@link Application#exit()}.
    */
   @Override
   public void destroy() {
@@ -624,29 +623,10 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       return;
     }
     isClosing = true;
-    teardownSessionCore(true);
-    isClosed = true;
-  }
 
-  /**
-   * Tears down this session's cameras, state, stage, and batch without application-exit semantics.
-   * No {@link Flixel#stopFileLogging()}, ANSI uninstall, or {@code postGameClose} signal, and does not dispose
-   * {@link Flixel#assets} or {@link Flixel#sound} (callers such as {@link Flixel#resetGame()} own those). Leaves
-   * {@link #isClosed()} {@code false} so the process can call {@link Flixel#initialize(FlixelGame)} again.
-   */
-  public void reset() {
-    if (batch == null && stage == null) {
-      return;
-    }
-    teardownSessionCore(false);
-    isClosing = false;
-    isClosed = false;
-  }
+    Flixel.setDrawCamera(null);
 
-  private void teardownSessionCore(boolean permanentShutdown) {
-    if (permanentShutdown) {
-      Flixel.Signals.preGameClose.dispatch();
-    }
+    Flixel.Signals.preGameClose.dispatch();
 
     FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
     if (debugOverlay != null) {
@@ -656,6 +636,16 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       debugOverlay.destroy();
       Flixel.clearDebugOverlay();
     }
+
+    InputProcessor processor = Gdx.input.getInputProcessor();
+    if (processor instanceof InputMultiplexer multiplexer) {
+      multiplexer.clear();
+    }
+
+    FlixelTween.cancelActiveTweens();
+    FlixelTween.clearTweenPools();
+    FlixelTween.resetRegistry();
+    FlixelTimer.cancelAll();
 
     if (Flixel.getState() != null) {
       Flixel.getState().destroy();
@@ -673,15 +663,21 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       bgTexture = null;
     }
 
-    if (permanentShutdown) {
-      if (Flixel.assets != null) {
-        Flixel.assets.dispose();
-      }
-      if (Flixel.sound != null) {
+    if (Flixel.assets != null) {
+      Flixel.assets.dispose();
+      Flixel.assets = null;
+    }
+    if (Flixel.sound != null) {
+      if (Flixel.initialized) {
         Flixel.sound.destroy();
+      } else {
+        Flixel.sound.resetSession(); // Game will crash if Flixel.resetGame() used destroy() instead!
       }
     }
 
+    for (FlixelCamera camera : cameras) {
+      camera.destroy();
+    }
     cameras = null;
     debugPauseCameraScroll = null;
     debugPauseCameraZoom = null;
@@ -689,13 +685,12 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
     FlixelFontRegistry.dispose();
 
-    if (permanentShutdown) {
-      close();
+    Flixel.Signals.postGameClose.dispatch();
 
-      Flixel.Signals.postGameClose.dispatch();
+    // Stop file logging after the whole game closes so that way any logs made can be stored!
+    Flixel.stopFileLogging();
 
-      Flixel.stopFileLogging();
-    }
+    isClosed = true;
   }
 
   /**
@@ -808,6 +803,10 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       return;
     }
     this.bgColor.set(bgColor);
+  }
+
+  public boolean isGamePaused() {
+    return gamePaused;
   }
 
   public boolean isMinimized() {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
@@ -45,9 +45,9 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
   /**
    * Stops session audio and rebuilds SFX and music groups on the existing engine.
    *
-   * <p>Use during {@link me.stringdotjar.flixelgdx.Flixel#resetGame()} instead
-   * of {@link #destroy()} so the native backend is not torn down and re-created
-   * in one frame (which can break PulseAudio and similar backends).
+   * <p>Use this instead of {@link #destroy()} so the native backend is not torn down and re-created
+   * in one frame (which can break PulseAudio and similar backends) unless you know for sure you don't want to
+   * use the audio system anymore.
    */
   public void resetSession() {
     if (music != null) {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelColor.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelColor.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
  * Mutable color wrapper that owns a single {@link Color} instance for stable tinting
  * and tween endpoints without per-frame allocations.
  */
-public final class FlixelColor {
+public class FlixelColor {
 
   @NotNull
   private final Color color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelGitUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelGitUtil.java
@@ -24,6 +24,7 @@ public final class FlixelGitUtil {
    * @param isModified Does the current repository have any changes made to it?
    */
   public record RepoInfo(String commit, String branch, String remoteUrl, String isModified) {
+
     @Override
     public String commit() {
       if (commit == null || commit.isBlank()) {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelSpriteUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelSpriteUtil.java
@@ -562,7 +562,7 @@ public final class FlixelSpriteUtil {
   }
 
   /**
-   * Midpoint of the sprite AABB in world space. Reuses {@code out} when non-null.
+   * Midpoint of the given sprite's hitbox in world space. Reuses {@code out} when non-null.
    *
    * @param sprite The sprite to get the midpoint of.
    * @param out The vector to store the midpoint in.

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelString.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelString.java
@@ -45,7 +45,7 @@ import java.util.function.Supplier;
  * to build text without touching {@link CharArray} at call sites. {@link #charBuffer()} remains available for
  * advanced interop with libGDX APIs that require a raw {@link CharArray}.
  */
-public final class FlixelString implements CharSequence {
+public class FlixelString implements CharSequence {
 
   private final CharArray buffer;
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimer.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimer.java
@@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>The timer is removed from its manager before the final callback runs.
  */
-public final class FlixelTimer implements FlixelUpdatable, FlixelDestroyable, Pool.Poolable {
+public class FlixelTimer implements FlixelUpdatable, FlixelDestroyable, Pool.Poolable {
 
   /** Whether the timer is currently active. */
   public boolean active;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/package-info.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/package-info.java
@@ -11,8 +11,6 @@
  *     and {@link me.stringdotjar.flixelgdx.util.timer.FlixelTimer#loop(float, me.stringdotjar.flixelgdx.util.timer.FlixelTimerListener, int)}.</li>
  *   <li>Scaling: {@link me.stringdotjar.flixelgdx.FlixelGame} passes {@code elapsed} times {@link me.stringdotjar.flixelgdx.Flixel#getTimeScale()} into
  *     {@link me.stringdotjar.flixelgdx.util.timer.FlixelTimerManager#update(float)}.</li>
- *   <li>Lifecycle: {@link me.stringdotjar.flixelgdx.Flixel#resetGame()} and {@link me.stringdotjar.flixelgdx.Flixel#initialize(me.stringdotjar.flixelgdx.FlixelGame)}
- *     call {@link me.stringdotjar.flixelgdx.util.timer.FlixelTimerManager#cancelAll()} so cold restarts do not leak callbacks.</li>
  *   <li>Pooled instances: do not store {@link me.stringdotjar.flixelgdx.util.timer.FlixelTimer} references across {@link me.stringdotjar.flixelgdx.util.timer.FlixelTimer#cancel()} or completion;
  *     the manager returns them to an internal {@link com.badlogic.gdx.utils.Pool}.</li>
  * </ul>


### PR DESCRIPTION
## Description

This PR removes the `resetGame()` method from the framework, as we (like many others) have to fight libGDX to properly restart the game.

We might possibly add this back in the future, but as of right now, we won't support it, as based on how libGDX is designed, there's no easy nor efficient way to properly execute this kind of functionality without hacky workarounds and potentially breaking the framework.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [ ] My PR targets the **develop** branch, not master/main.
- [ ] My code follows the code style of this project (if any code was added or changed).
- [ ] I have performed a self-review of my own code (if any code was added or changed).
- [ ] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [ ] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
