### PR TITLE
Rework asset management system to be more stable

### DIFF
--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelBasic.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelBasic.java
@@ -15,14 +15,13 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * This is the most generic Flixel object. Both {@link FlixelObject} and {@link FlixelCamera}
- * extend this class. It has no size, position, or graphical data, only lifecycle flags and
- * a unique ID.
+ * extend this class. It has no size, position, or graphical data, only lifecycle flags and a unique ID.
  *
  * <p>Prefer {@link #kill()} when an object should stop updating and drawing but might be {@link #revive()}d later
  * (bullets, particles, pooled gameplay objects). Call {@link #destroy()} when you are done with the instance for good:
  * it clears lifecycle state and, in subclasses such as {@link FlixelSprite}, releases graphics and
  * other resources. {@link #dispose()} and {@link #reset()} (for {@link com.badlogic.gdx.utils.Pool}) delegate to
- * {@link #destroy()}, which aligns with libGDX&rsquo;s {@link com.badlogic.gdx.utils.Disposable} expectations.
+ * {@link #destroy()}, which aligns with libGDX's {@link com.badlogic.gdx.utils.Disposable} expectations.
  *
  * <table border="1">
  *   <caption><strong>Lifecycle cheat sheet</strong></caption>
@@ -36,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
  *       <td>{@link #destroy()} (drops resources you may still want)</td>
  *     </tr>
  *     <tr>
- *       <td>Reuse a &ldquo;dead&rdquo; slot in a {@link me.stringdotjar.flixelgdx.group.FlixelBasicGroup}</td>
+ *       <td>Reuse a "dead" slot in a {@link me.stringdotjar.flixelgdx.group.FlixelBasicGroup}</td>
  *       <td>{@link me.stringdotjar.flixelgdx.group.FlixelBasicGroup#recycle()} or {@link #revive()} after {@link #kill()}</td>
  *       <td>{@link #destroy()} unless you truly discard the instance</td>
  *     </tr>
@@ -82,7 +81,7 @@ public class FlixelBasic implements FlixelUpdatable, FlixelDrawable, FlixelDestr
   /** Controls whether {@link #update(float)} and {@link #draw(Batch)} are automatically called. */
   public boolean exists = true;
 
-  /** Controls whether {@link #draw(Batch)} is automatically called. */
+  /** Controls whether {@code this} object should be displayed on the screen. */
   public boolean visible = true;
 
   /** Cameras this object may render on. {@code null} or an empty array means every camera. */
@@ -154,8 +153,7 @@ public class FlixelBasic implements FlixelUpdatable, FlixelDrawable, FlixelDestr
   }
 
   /**
-   * Brings this object back to life by setting {@link #alive} and {@link #exists} to
-   * {@code true}.
+   * Brings this object back to life by setting {@link #alive} and {@link #exists} to {@code true}.
    */
   public void revive() {
     alive = true;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
@@ -222,7 +222,7 @@ public class FlixelSprite extends FlixelObject {
    * @return {@code this} sprite for chaining.
    */
   public FlixelSprite loadGraphic(String assetKey) {
-    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(assetKey, FlixelGraphic.class).retain();
+    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(assetKey, FlixelGraphic.class);
     Texture t = requireOrLoad(g);
     return loadGraphic(g, t.getWidth(), t.getHeight());
   }
@@ -239,7 +239,7 @@ public class FlixelSprite extends FlixelObject {
    * @return {@code this} sprite for chaining.
    */
   public FlixelSprite loadGraphic(String assetKey, int frameWidth) {
-    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(assetKey, FlixelGraphic.class).retain();
+    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(assetKey, FlixelGraphic.class);
     Texture t = requireOrLoad(g);
     return loadGraphic(g, frameWidth, t.getHeight());
   }
@@ -257,7 +257,7 @@ public class FlixelSprite extends FlixelObject {
    * @return {@code this} sprite for chaining.
    */
   public FlixelSprite loadGraphic(String assetKey, int frameWidth, int frameHeight) {
-    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(assetKey, FlixelGraphic.class).retain();
+    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(assetKey, FlixelGraphic.class);
     return loadGraphic(g, frameWidth, frameHeight);
   }
 
@@ -331,8 +331,8 @@ public class FlixelSprite extends FlixelObject {
    * {@link FlixelAnimationController#loadSparrowFrames(String, com.badlogic.gdx.utils.XmlReader.Element)} only;
    * not a general API for game code.
    *
-   * @param newGraphic Graphic wrapper already {@code retain()}ed by the caller.
-   * @param parsedFrames Frames built from the XML (may be empty).
+   * @param newGraphic Graphic from {@link me.stringdotjar.flixelgdx.Flixel#ensureAssets()}{@code .obtainWrapper}(...)} (implicit retain).
+   * @param parsedFrames Frames built from the XML (which may be empty).
    */
   public void applySparrowAtlas(@NotNull FlixelGraphic newGraphic, @NotNull Array<FlixelFrame> parsedFrames) {
     if (graphic != null) {
@@ -412,8 +412,7 @@ public class FlixelSprite extends FlixelObject {
   }
 
   /**
-   * Sets how large the graphic is drawn on screen (in pixels), without changing which part of the
-   * texture is used.
+   * Sets how large the graphic is drawn on screen (in pixels), without changing which part of the texture is used.
    *
    * <p>This adjusts {@link #setScale(float, float)} so the full current frame/region maps to the
    * given size. It does <em>not</em> change {@link TextureRegion} bounds: {@code

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Frame-based clips, Sparrow/XML atlases, and playback use a {@link FlixelAnimationController} that is
  * <strong>not</strong> allocated by default (saves memory for large sprite counts on the order of thousands of
- * extra sprites before overhead dominates). Call {@link #ensureAnimation()} or {@link #setAnimation(FlixelAnimationController)}
+ * extra sprites before overhead dominates). Call {@link #ensureAnimation()} or assign a controller directly
  * when you need clips, then use {@code sprite.ensureAnimation().playAnimation(...)}, {@code loadSparrowFrames(...)}, etc.
  *
  * <p>It is common to extend {@code FlixelSprite} for your own game's needs; for example, a
@@ -48,7 +48,7 @@ public class FlixelSprite extends FlixelObject {
   protected Array<FlixelFrame> atlasFrames;
 
   /**
-   * Optional animation controller; {@code null} until {@link #ensureAnimation()} or {@link #setAnimation(FlixelAnimationController)}.
+   * Heavy controller object for handling animations. {@code null} until {@link #ensureAnimation()} or assigned directly.
    */
   @Nullable
   public FlixelAnimationController animation;
@@ -103,7 +103,18 @@ public class FlixelSprite extends FlixelObject {
 
   /** Constructs a new FlixelSprite with default values. */
   public FlixelSprite() {
-    super();
+    this(0, 0);
+  }
+
+  public FlixelSprite(float x,  float y) {
+    this(x, y, null);
+  }
+
+  public FlixelSprite(float x, float y, String graphicAssetKey) {
+    super(x, y);
+    if (graphicAssetKey != null && graphicAssetKey.isEmpty()) {
+      loadGraphic(graphicAssetKey);
+    }
   }
 
   /**
@@ -115,10 +126,6 @@ public class FlixelSprite extends FlixelObject {
       animation = new FlixelAnimationController(this);
     }
     return animation;
-  }
-
-  public void setAnimation(@Nullable FlixelAnimationController animation) {
-    this.animation = animation;
   }
 
   /**
@@ -239,7 +246,7 @@ public class FlixelSprite extends FlixelObject {
 
   /**
    * Loads a cached graphic by key. The texture can be preloaded via {@link FlixelGraphic#queueLoad()}
-   * and {@code Flixel.assets.update()} in a loading state.
+   * and {@link FlixelAssetManager#update()} in a loading state.
    *
    * <p>This method falls back to a synchronous load if the texture is not loaded yet.
    * Preloading is still strongly recommended to avoid mid-frame stalls.

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationController.java
@@ -117,7 +117,7 @@ public class FlixelAnimationController implements FlixelUpdatable {
    */
   @NotNull
   public FlixelSprite loadSparrowFrames(@NotNull String textureKey, @NotNull XmlReader.Element xmlRoot) {
-    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(textureKey, FlixelGraphic.class).retain();
+    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(textureKey, FlixelGraphic.class);
     Texture texture;
     try {
       texture = g.requireTexture();

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationController.java
@@ -29,9 +29,8 @@ import java.util.Comparator;
 
 /**
  * Playback state and clip registration for {@link FlixelSprite} animations. Obtain a controller with
- * {@link FlixelSprite#ensureAnimation()} (or assign via {@link FlixelSprite#setAnimation(FlixelAnimationController)}),
- * then call {@code sprite.ensureAnimation().loadSparrowFrames(...)}, {@code .playAnimation(...)}, etc. Decouples
- * animation timing from rendering and physics.
+ * {@link FlixelSprite#ensureAnimation()} (or assign one directly), then call {@code sprite.ensureAnimation().loadSparrowFrames(...)},
+ * {@code .playAnimation(...)}, etc. Decouples animation timing from rendering and physics.
  */
 public class FlixelAnimationController implements FlixelUpdatable {
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAsset.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAsset.java
@@ -12,9 +12,10 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Typed handle for one asset path + class, with optional {@code persist} and refcount.
  *
- * <p>Obtain pooled handles with {@link FlixelAssetManager#obtainTypedAsset(String, Class)} (cached on
- * {@link me.stringdotjar.flixelgdx.Flixel#assets}). {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic} and
- * {@link me.stringdotjar.flixelgdx.audio.FlixelSound} also implement this contract where applicable.
+ * <p>Handles are cached on {@link me.stringdotjar.flixelgdx.Flixel#assets}. {@link FlixelAssetManager#obtainTypedAsset(String, Class)}
+ * and {@link FlixelAssetManager#obtainWrapper(String, Class)} implicitly {@link #retain()}; use {@link FlixelAssetManager#ensureTypedAsset}
+ * / {@link FlixelAssetManager#ensureWrapper} when you must not change the refcount. {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}
+ * and {@link me.stringdotjar.flixelgdx.audio.FlixelSound} also implement this contract where applicable.
  *
  * <p>Prefer {@link #queueLoad()} in a loading state and {@code Flixel.assets.update()} each frame.
  *

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
@@ -217,6 +217,38 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
    */
   void clearNonPersist();
 
+  /**
+   * Returns the default {@link FlixelAsset#isPersist()} value assigned to newly created pooled handles
+   * ({@link FlixelTypedAsset} and subclasses created through this manager). When {@code true}, new handles
+   * stay in the manager cache when their reference count is zero and {@link #clearNonPersist()} runs, so
+   * loaded data can remain in memory across state switches until {@link #clear()} or {@link FlixelAsset#setPersist(boolean)}.
+   * When {@code false}, new handles may be removed on {@code clearNonPersist()} once unreferenced.
+   *
+   * <p>Owned wrappers (see {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic} and {@code isOwned()} on
+   * {@link FlixelPooledWrapper}) use {@code persist == false} regardless of this setting so synthetic textures
+   * are always eligible for eviction when refcount is zero.
+   *
+   * <p><b>Owned versus persist</b> (see also {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}):
+   * <ul>
+   *   <li><b>Owned</b> - Structural: this handle wraps a dedicated {@link com.badlogic.gdx.graphics.Texture} that
+   *     the framework disposes when the wrapper leaves the pool (for example pixmap or caller-supplied textures).
+   *     Not a user toggle; determined by how the graphic was created.</li>
+   *   <li><b>Persist</b> - Policy: whether an unreferenced pooled handle is kept in the cache when
+   *     {@code clearNonPersist()} runs. Applies to normal path-keyed graphics; owned graphics ignore persist for
+   *     that eviction pass so they are always removed at refcount zero.</li>
+   * </ul>
+   *
+   * @return Default persist flag for new typed and path-pooled handles.
+   */
+  boolean getGlobalPersist();
+
+  /**
+   * Sets {@link #getGlobalPersist()}. Does not change {@code persist} on handles already in the cache.
+   *
+   * @param globalPersist default for future {@link FlixelTypedAsset} and similar creations
+   */
+  void setGlobalPersist(boolean globalPersist);
+
   /** Clears all cached assets, regardless if {@link FlixelAsset#isPersist()} is true or not. */
   void clear();
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
@@ -28,6 +28,18 @@ import org.jetbrains.annotations.Nullable;
  * infers a source from the file extension via the per-manager extension registry; it is convenient but
  * ambiguous if extensions collide or custom content is used—register mappings with
  * {@link #registerExtension(String, Function)} or use {@link #load(FlixelSource)} instead.
+ *
+ * <p><b>If you ever forget which method to use when it comes to handles, here's a quick reminder:</b>
+ * <ul>
+ *   <li><b>{@code peek...}</b>: “Is there already a handle for this key?” This should be read only; it may return {@code null}.
+ *     It does not create a handle nor does it change the reference count.</li>
+ *   <li><b>{@code ensure...}</b>: “Make sure the handle exists.” Get or create the canonical instance and automatically
+ *     create a handle if it doesn't exist. The reference count for that said asset handle is unchanged (use when
+ *     another layer will {@link FlixelAsset#retain()}, or for inspection).</li>
+ *   <li><b>{@code obtain...}</b>: “Give me the handle and count me as a user.” Get or create the asset handle, then
+ *     automatically call {@link FlixelAsset#retain()} for {@link FlixelAsset} handles. Call {@link FlixelAsset#release()} when done
+ *     (e.g. {@link me.stringdotjar.flixelgdx.FlixelSprite#destroy()} for graphics loaded via {@code obtainWrapper}).</li>
+ * </ul>
  */
 public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
 
@@ -192,7 +204,10 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
   void finishLoadingAsset(@NotNull String fileName);
 
   /**
-   * @return Diagnostic string from the underlying {@link AssetManager} (refs, dependencies).
+   * @return Multi-line diagnostics: every asset loaded in the underlying {@link AssetManager} with libGDX
+   *   reference counts (load/unload/dependency bookkeeping), plus Flixel {@code retain}/{@code release}
+   *   counts where {@link #peekTypedAsset} or texture {@link #peekWrapper} handles exist, then optional
+   *   sections for wrapper-only keys (e.g. synthetic owned textures) and typed handles not currently loaded.
    */
   @NotNull
   String getDiagnostics();
@@ -201,6 +216,9 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
    * Clears non-persistent pooled wrappers and {@link FlixelAsset} handles with zero reference counts.
    */
   void clearNonPersist();
+
+  /** Clears all cached assets, regardless if {@link FlixelAsset#isPersist()} is true or not. */
+  void clear();
 
   /**
    * Allocates a unique key for a caller-constructed wrapper (e.g. {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}
@@ -224,7 +242,30 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
   void registerWrapperFactory(@NotNull FlixelWrapperFactory<?> factory);
 
   /**
-   * Returns or creates a pooled wrapper of the given type for {@code key}.
+   * Returns or creates a pooled wrapper for {@code key} without changing its reference count.
+   *
+   * <p><b>Beginner shorthand:</b> “Make sure the label exists”. Note this does not claim usage, but the
+   * wrapper will be created if it doesn't exist.
+   *
+   * <p>Use when you need the canonical instance for inspection or to hand off to another API that
+   * will call {@link FlixelAsset#retain()} itself. For normal ownership, prefer {@link #obtainWrapper}.
+   *
+   * @param key Cache key (e.g. asset path for a {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}).
+   * @param wrapperType Wrapper class registered with {@link #registerWrapperFactory}.
+   * @param <W> Wrapper type.
+   * @return Pooled wrapper instance.
+   */
+  @NotNull
+  <W> W ensureWrapper(@NotNull String key, @NotNull Class<W> wrapperType);
+
+  /**
+   * Returns or creates a pooled wrapper and increments its reference count when it implements {@link FlixelAsset}.
+   *
+   * <p><b>Beginner shorthand:</b> “Give me the shared handle and count me as a user.” This method automatically calls
+   * {@link FlixelAsset#retain()} when executed. Note that you should
+   *
+   * <p>Equivalent to {@link #ensureWrapper} followed by {@link FlixelAsset#retain()} for {@link FlixelAsset} wrappers.
+   * Call {@link FlixelAsset#release()} when done (e.g. from {@link me.stringdotjar.flixelgdx.FlixelSprite#destroy()}).
    *
    * @param key Cache key (e.g. asset path for a {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}).
    * @param wrapperType Wrapper class registered by the implementation (e.g. {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}.class).
@@ -237,6 +278,9 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
   /**
    * Returns a pooled wrapper if present, or {@code null}.
    *
+   * <p><b>Beginner shorthand:</b> “Is there already a handle?”. This is read only; if the
+   * cached wrapper doesn't exist, then it returns {@code null}.
+   *
    * @param key Cache key.
    * @param wrapperType Wrapper class.
    * @param <W> Wrapper type.
@@ -246,10 +290,31 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
   <W> W peekWrapper(@NotNull String key, @NotNull Class<W> wrapperType);
 
   /**
-   * Obtains or creates a typed {@link FlixelAsset} handle for the given key and runtime type.
+   * Returns or creates a typed {@link FlixelAsset} handle without changing its reference count.
+   *
+   * <p><b>Beginner shorthand:</b> “Make sure the typed handle exists”. Note that this does not automatically call
+   * {@link FlixelAsset#retain()}, you still have to manually execute it yourself.
+   *
+   * <p>For ownership, prefer {@link #obtainTypedAsset} which automatically calls {@link FlixelAsset#retain()}.
    *
    * @param assetKey Asset key.
-   * @param type LibGDX-loaded asset type.
+   * @param type libGDX-loaded asset type.
+   * @param <T> Asset type.
+   * @return Cached or new handle.
+   */
+  @NotNull
+  <T> FlixelAsset<T> ensureTypedAsset(@NotNull String assetKey, @NotNull Class<T> type);
+
+  /**
+   * Returns or creates a typed handle and increments its reference count.
+   *
+   * <p><b>Beginner shorthand:</b> “Give me the typed handle and count me as a user.” This method automatically calls
+   * {@link FlixelAsset#retain()} when executed.
+   *
+   * <p>Call {@link FlixelAsset#release()} when the owner is done, or use {@link #ensureTypedAsset} for zero-ref access.
+   *
+   * @param assetKey Asset key.
+   * @param type libGDX-loaded asset type.
    * @param <T> Asset type.
    * @return Cached or new handle.
    */
@@ -258,6 +323,8 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
 
   /**
    * Peeks at a typed asset handle without creating it.
+   *
+   * <p><b>Beginner shorthand:</b> “Is there already a typed handle?”—look only; never creates; refcount unchanged.
    *
    * @param assetKey Asset key.
    * @param type Asset type.
@@ -268,8 +335,17 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
 
   /**
    * Unloads and removes non-persistent typed asset handles with zero reference counts.
+   *
+   * @param respectPersist If {@link FlixelAsset#isPersist()} should be taken into consideration or should be ignored.
    */
-  void clearNonPersistTypedAssets();
+  void clearWrapperAssets(boolean respectPersist);
+
+  /**
+   * Unloads and removes non-persistent typed asset handles with zero reference counts.
+   *
+   * @param respectPersist If {@link FlixelAsset#isPersist()} should be taken into consideration or should be ignored.
+   */
+  void clearTypedAssets(boolean respectPersist);
 
   /**
    * @return The underlying libGDX {@link AssetManager} for advanced use (loaders, descriptors, raw APIs).

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -65,6 +65,9 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   /** Per-instance extension (e.g. {@code .png}) to source factory for {@link #load(String)}. */
   private final ConcurrentHashMap<String, Function<String, FlixelSource<?>>> extensionRegistry = new ConcurrentHashMap<>();
 
+  /** Default {@link FlixelTypedAsset#isPersist()} for handles created after construction; see {@link #getGlobalPersist()}. */
+  private boolean globalPersist = false;
+
   /** FlixelString object to prevent allocation every time {@link #getDiagnostics()} is called. */
   private final FlixelString diagnosticsString = new FlixelString();
 
@@ -415,6 +418,16 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
       return g != null ? g.getRefCount() : 0;
     }
     return 0;
+  }
+
+  @Override
+  public boolean getGlobalPersist() {
+    return globalPersist;
+  }
+
+  @Override
+  public void setGlobalPersist(boolean globalPersist) {
+    this.globalPersist = globalPersist;
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -594,4 +594,3 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     }
   }
 }
-

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -17,10 +17,14 @@ import com.badlogic.gdx.utils.ObjectMap;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
+
+import com.badlogic.gdx.graphics.Texture;
 
 import me.stringdotjar.flixelgdx.audio.FlixelSoundSource;
 import me.stringdotjar.flixelgdx.audio.FlixelSoundSourceLoader;
@@ -314,41 +318,115 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @Override
   public String getDiagnostics() {
     diagnosticsString.clear();
-    diagnosticsString.concat("------------------------- WRAPPER ASSETS -------------------------\n");
-    for (ObjectMap.Entry<Class<?>, FlixelWrapperFactory<?>> entry : wrapperFactories.iterator()) {
-      var factory = entry.value;
-      factory.forEachWrappedAsset(asset -> {
-        // TODO: Find a way where we don't have to hardcode this.
-        if (asset instanceof FlixelTypedAsset a) {
-          diagnosticsString
-            .concat("\tKey: ")
-            .concat(a.getAssetKey())
-            .concat(", Type: ")
-            .concat(a.getType().getName())
-            .concat(", RefCount: ")
-            .concat(a.getRefCount())
-            .concat("\n");
+    if (manager == null) {
+      diagnosticsString.concat("(asset manager disposed)\n");
+      return diagnosticsString.toString();
+    }
+
+    // Output loaded assets in the libGDX AssetManager.
+    diagnosticsString.concat("------------------------- LOADED ASSETS -------------------------\n");
+    Array<String> assetNames = manager.getAssetNames();
+    Set<String> managerKeys = new HashSet<>(Math.max(16, assetNames.size * 2));
+    synchronized (manager) {
+      for (int i = 0; i < assetNames.size; i++) {
+        String fileName = assetNames.get(i);
+        managerKeys.add(fileName);
+        Class<?> type = manager.getAssetType(fileName);
+        int libRefs = manager.getReferenceCount(fileName);
+        int flixelRefs = type != null ? flixelRefCountForLoadedAsset(fileName, type) : 0;
+        diagnosticsString
+          .concat("\tKey: ")
+          .concat(fileName)
+          .concat(", Type: ")
+          .concat(type != null ? type.getName() : "?")
+          .concat(", Flixel refs: ")
+          .concat(flixelRefs)
+          .concat(", libGDX refs: ")
+          .concat(libRefs);
+        Array<String> deps = manager.getDependencies(fileName);
+        if (deps != null && deps.size > 0) {
+          diagnosticsString.concat(", deps: [");
+          for (int d = 0; d < deps.size; d++) {
+            if (d > 0) {
+              diagnosticsString.concat(", ");
+            }
+            diagnosticsString.concat(deps.get(d));
+          }
+          diagnosticsString.concat("]");
         }
+        diagnosticsString.concat("\n");
+      }
+    }
+
+    // Output wrapper-only assets that are not loaded in the libGDX AssetManager.
+    diagnosticsString.concat("------------------------- WRAPPER-ONLY -------------------------\n");
+    for (ObjectMap.Entry<Class<?>, FlixelWrapperFactory<?>> entry : wrapperFactories.iterator()) {
+      FlixelWrapperFactory<?> factory = entry.value;
+      factory.forEachWrappedAsset(asset -> {
+        if (!(asset instanceof FlixelTypedAsset<?> a)) {
+          return;
+        }
+        if (managerKeys.contains(a.getAssetKey())) {
+          return;
+        }
+        diagnosticsString
+          .concat("\tKey: ")
+          .concat(a.getAssetKey())
+          .concat(", Type: ")
+          .concat(a.getType().getName())
+          .concat(", Flixel refs: ")
+          .concat(a.getRefCount())
+          .concat(", libGDX refs: n/a")
+          .concat("\n");
       });
     }
-    diagnosticsString.concat("------------------------- TYPED ASSETS -------------------------\n");
+
+    // Output typed assets that are not loaded in the libGDX AssetManager.
+    diagnosticsString.concat("------------------------- TYPED HANDLES -------------------------\n");
     for (FlixelTypedAsset<?> asset : typedAssetCache.values()) {
+      if (manager != null && manager.isLoaded(asset.getAssetKey(), asset.getType())) {
+        continue;
+      }
       diagnosticsString
         .concat("\tKey: ")
         .concat(asset.getAssetKey())
         .concat(", Type: ")
-        .concat(asset.getType())
-        .concat(", RefCount: ")
+        .concat(asset.getType().getName())
+        .concat(", Flixel refs: ")
         .concat(asset.getRefCount())
+        .concat(", libGDX refs: n/a")
         .concat("\n");
     }
+
     return diagnosticsString.toString();
+  }
+
+  /**
+   * Flixel {@code retain}/{@code release} count for a key already loaded in {@link AssetManager}: explicit
+   * {@link FlixelTypedAsset} if present, else {@link FlixelGraphic} for textures.
+   */
+  private int flixelRefCountForLoadedAsset(@NotNull String fileName, @NotNull Class<?> type) {
+    FlixelAsset<?> typed = peekTypedAsset(fileName, type);
+    if (typed != null) {
+      return typed.getRefCount();
+    }
+    if (type == Texture.class) {
+      FlixelGraphic g = peekWrapper(fileName, FlixelGraphic.class);
+      return g != null ? g.getRefCount() : 0;
+    }
+    return 0;
   }
 
   @Override
   public void clearNonPersist() {
-    clearNonPersistWrappers();
-    clearNonPersistTypedAssets();
+    clearWrapperAssets(true);
+    clearTypedAssets(true);
+  }
+
+  @Override
+  public void clear() {
+    clearWrapperAssets(false);
+    clearTypedAssets(false);
   }
 
   @Override
@@ -407,12 +485,22 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @NotNull
   @Override
   @SuppressWarnings("unchecked")
-  public <W> W obtainWrapper(@NotNull String key, @NotNull Class<W> wrapperType) {
+  public <W> W ensureWrapper(@NotNull String key, @NotNull Class<W> wrapperType) {
     FlixelWrapperFactory<?> f = wrapperFactories.get(wrapperType);
     if (f == null) {
       throw new IllegalArgumentException("No wrapper factory registered for: " + wrapperType.getName());
     }
     return ((FlixelWrapperFactory<W>) f).obtainKeyed(this, key);
+  }
+
+  @NotNull
+  @Override
+  public <W> W obtainWrapper(@NotNull String key, @NotNull Class<W> wrapperType) {
+    W w = ensureWrapper(key, wrapperType);
+    if (w instanceof FlixelAsset<?> fa) {
+      fa.retain();
+    }
+    return w;
   }
 
   @Nullable
@@ -429,7 +517,7 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @NotNull
   @Override
   @SuppressWarnings("unchecked")
-  public <T> FlixelAsset<T> obtainTypedAsset(@NotNull String assetKey, @NotNull Class<T> type) {
+  public <T> FlixelAsset<T> ensureTypedAsset(@NotNull String assetKey, @NotNull Class<T> type) {
     AssetId id = new AssetId(assetKey, type);
     FlixelTypedAsset<?> existing = typedAssetCache.get(id);
     if (existing != null) {
@@ -440,26 +528,40 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     return created;
   }
 
+  @NotNull
+  @Override
+  public <T> FlixelAsset<T> obtainTypedAsset(@NotNull String assetKey, @NotNull Class<T> type) {
+    FlixelAsset<T> a = ensureTypedAsset(assetKey, type);
+    a.retain();
+    return a;
+  }
+
   @Nullable
   @Override
   public FlixelAsset<?> peekTypedAsset(@NotNull String assetKey, @NotNull Class<?> type) {
     return typedAssetCache.get(new AssetId(assetKey, type));
   }
 
-  private void clearNonPersistWrappers() {
-    for (FlixelWrapperFactory<?> f : wrapperFactories.values()) {
-      f.clearNonPersist(this);
+  @Override
+  public void clearWrapperAssets(boolean respectPersist) {
+    if (respectPersist) {
+      for (FlixelWrapperFactory<?> f : wrapperFactories.values()) {
+        f.clearNonPersist(this);
+      }
+    } else {
+      for (FlixelWrapperFactory<?> f : wrapperFactories.values()) {
+        f.clearAll();
+      }
     }
   }
 
   @Override
-  public void clearNonPersistTypedAssets() {
-
+  public void clearTypedAssets(boolean respectPersist) {
     Array<AssetId> toRemove = null;
     for (ObjectMap.Entry<AssetId, FlixelTypedAsset<?>> e : typedAssetCache) {
       FlixelAsset<?> a = e.value;
       if (a == null) continue;
-      if (a.isPersist()) continue;
+      if (respectPersist && a.isPersist()) continue;
       if (a.getRefCount() > 0) continue;
 
       if (manager.isLoaded(a.getAssetKey(), a.getType())) {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -18,14 +18,17 @@ import com.badlogic.gdx.utils.ObjectMap;
 import java.io.File;
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 import me.stringdotjar.flixelgdx.audio.FlixelSoundSource;
 import me.stringdotjar.flixelgdx.audio.FlixelSoundSourceLoader;
+import me.stringdotjar.flixelgdx.graphics.FlixelGraphic;
 import me.stringdotjar.flixelgdx.graphics.FlixelGraphicSource;
 import me.stringdotjar.flixelgdx.graphics.FlixelGraphicWrapperFactory;
 
+import me.stringdotjar.flixelgdx.util.FlixelString;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -58,6 +61,9 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   /** Per-instance extension (e.g. {@code .png}) to source factory for {@link #load(String)}. */
   private final ConcurrentHashMap<String, Function<String, FlixelSource<?>>> extensionRegistry = new ConcurrentHashMap<>();
 
+  /** FlixelString object to prevent allocation every time {@link #getDiagnostics()} is called. */
+  private final FlixelString diagnosticsString = new FlixelString();
+
   private record AssetId(@NotNull String key, @NotNull Class<?> type) {
     @Override
     public boolean equals(Object o) {
@@ -77,11 +83,8 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     manager = new AssetManager();
     manager.setLoader(String.class, new FlixelStringAssetLoader(manager.getFileHandleResolver()));
     manager.setLoader(FlixelSoundSource.class, new FlixelSoundSourceLoader(manager.getFileHandleResolver()));
-    registerDefaultExtensionMappings();
-    registerWrapperFactory(new FlixelGraphicWrapperFactory());
-  }
 
-  private void registerDefaultExtensionMappings() {
+    // Register the default extensions for loading assets with just their path.
     Function<String, FlixelSource<?>> graphic = FlixelGraphicSource::new;
     registerExtension(".png", graphic);
     registerExtension(".jpg", graphic);
@@ -98,6 +101,8 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     registerExtension(".txt", text);
     registerExtension(".xml", text);
     registerExtension(".json", text);
+
+    registerWrapperFactory(new FlixelGraphicWrapperFactory());
   }
 
   @NotNull
@@ -153,6 +158,22 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   }
 
   @Override
+  public <T> void load(@NotNull String fileName, @NotNull Class<T> type) {
+    manager.load(fileName, type);
+  }
+
+  @Override
+  public void load(@NotNull FlixelSource<?> source) {
+    Objects.requireNonNull(source, "source cannot be null.");
+    load(source.getAssetKey(), source.getType());
+  }
+
+  @Override
+  public void load(@NotNull AssetDescriptor<?> assetDescriptor) {
+    manager.load(assetDescriptor);
+  }
+
+  @Override
   public void registerExtension(@NotNull String extension, @NotNull Function<String, FlixelSource<?>> factory) {
     if (extension == null) {
       throw new IllegalArgumentException("extension cannot be null.");
@@ -176,24 +197,6 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @Override
   public AssetManager getManager() {
     return manager;
-  }
-
-  @Override
-  public <T> void load(@NotNull String fileName, @NotNull Class<T> type) {
-    manager.load(fileName, type);
-  }
-
-  @Override
-  public void load(@NotNull FlixelSource<?> source) {
-    if (source == null) {
-      throw new IllegalArgumentException("Source cannot be null.");
-    }
-    load(source.getAssetKey(), source.getType());
-  }
-
-  @Override
-  public void load(@NotNull AssetDescriptor<?> assetDescriptor) {
-    manager.load(assetDescriptor);
   }
 
   @Override
@@ -310,7 +313,36 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @NotNull
   @Override
   public String getDiagnostics() {
-    return manager.getDiagnostics();
+    diagnosticsString.clear();
+    diagnosticsString.concat("------------------------- WRAPPER ASSETS -------------------------\n");
+    for (ObjectMap.Entry<Class<?>, FlixelWrapperFactory<?>> entry : wrapperFactories.iterator()) {
+      var factory = entry.value;
+      factory.forEachWrappedAsset(asset -> {
+        // TODO: Find a way where we don't have to hardcode this.
+        if (asset instanceof FlixelTypedAsset a) {
+          diagnosticsString
+            .concat("\tKey: ")
+            .concat(a.getAssetKey())
+            .concat(", Type: ")
+            .concat(a.getType().getName())
+            .concat(", RefCount: ")
+            .concat(a.getRefCount())
+            .concat("\n");
+        }
+      });
+    }
+    diagnosticsString.concat("------------------------- TYPED ASSETS -------------------------\n");
+    for (FlixelTypedAsset<?> asset : typedAssetCache.values()) {
+      diagnosticsString
+        .concat("\tKey: ")
+        .concat(asset.getAssetKey())
+        .concat(", Type: ")
+        .concat(asset.getType())
+        .concat(", RefCount: ")
+        .concat(asset.getRefCount())
+        .concat("\n");
+    }
+    return diagnosticsString.toString();
   }
 
   @Override
@@ -368,10 +400,7 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   }
 
   @SuppressWarnings("unchecked")
-  private <W> void registerWrapperUnchecked(
-    @NotNull FlixelWrapperFactory<W> factory,
-    @NotNull FlixelPooledWrapper wrapper
-  ) {
+  private <W> void registerWrapperUnchecked(@NotNull FlixelWrapperFactory<W> factory, @NotNull FlixelPooledWrapper wrapper) {
     factory.registerInstance(this, (W) wrapper);
   }
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelPooledWrapper.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelPooledWrapper.java
@@ -33,7 +33,9 @@ public interface FlixelPooledWrapper {
   }
 
   /**
-   * Checks if {@code this} wrapper is owned.
+   * Whether this wrapper holds a dedicated resource the pool must dispose (for example {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}
+   * with a pixmap or caller texture). This is structural, not the same as {@link FlixelAsset#isPersist()}; see
+   * {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic} and {@link FlixelAssetManager#getGlobalPersist()}.
    *
    * @return {@code true} if the wrapper is owned, {@code false} otherwise.
    */

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
@@ -15,8 +15,8 @@ import org.jetbrains.annotations.Nullable;
 /**
  * Default pooled implementation of {@link FlixelAsset}; constructed only via
  * {@link FlixelAssetManager#ensureTypedAsset(String, Class)} / {@link FlixelAssetManager#obtainTypedAsset(String, Class)}
- * or framework subclasses. New handles default to {@code persist == true} so {@code clearNonPersist} keeps
- * loaded data in memory when the refcount drops to zero. Call {@link #setPersist(boolean)} {@code false} to allow eviction.
+ * or framework subclasses. New handles default to {@link FlixelAssetManager#getGlobalPersist()} so {@code clearNonPersist}
+ * either keeps or drops unreferenced handles accordingly. Call {@link #setPersist(boolean)} to override per handle.
  *
  * @param <T> Asset type.
  */
@@ -49,7 +49,7 @@ public class FlixelTypedAsset<T> implements FlixelAsset<T> {
     this.assetManager = assetManager;
     this.assetKey = assetKey;
     this.type = type;
-    this.persist = true;
+    this.persist = assetManager.getGlobalPersist();
     this.refCount = 0;
   }
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
@@ -7,12 +7,16 @@
 
 package me.stringdotjar.flixelgdx.asset;
 
+import java.util.Objects;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Default pooled implementation of {@link FlixelAsset}; constructed only via
- * {@link FlixelAssetManager#obtainTypedAsset(String, Class)} or framework subclasses.
+ * {@link FlixelAssetManager#ensureTypedAsset(String, Class)} / {@link FlixelAssetManager#obtainTypedAsset(String, Class)}
+ * or framework subclasses. New handles default to {@code persist == true} so {@code clearNonPersist} keeps
+ * loaded data in memory when the refcount drops to zero. Call {@link #setPersist(boolean)} {@code false} to allow eviction.
  *
  * @param <T> Asset type.
  */
@@ -39,19 +43,13 @@ public class FlixelTypedAsset<T> implements FlixelAsset<T> {
     @NotNull String assetKey,
     @NotNull Class<T> type
   ) {
-    if (assetManager == null) {
-      throw new IllegalArgumentException("Asset manager cannot be null.");
-    }
-    if (assetKey == null || assetKey.isEmpty()) {
-      throw new IllegalArgumentException("Asset key cannot be null/empty.");
-    }
-    if (type == null) {
-      throw new IllegalArgumentException("Type cannot be null.");
-    }
+    Objects.requireNonNull(assetManager, "Asset manager cannot be null.");
+    Objects.requireNonNull(assetKey, "Asset key cannot be null/empty.");
+    Objects.requireNonNull(type, "Type cannot be null.");
     this.assetManager = assetManager;
     this.assetKey = assetKey;
     this.type = type;
-    this.persist = false;
+    this.persist = true;
     this.refCount = 0;
   }
 
@@ -135,7 +133,7 @@ public class FlixelTypedAsset<T> implements FlixelAsset<T> {
    */
   @NotNull
   public FlixelAsset<T> get(@NotNull String otherAssetKey, @NotNull Class<T> otherType) {
-    return assetManager.obtainTypedAsset(otherAssetKey, otherType);
+    return assetManager.ensureTypedAsset(otherAssetKey, otherType);
   }
 
   @Nullable

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperFactory.java
@@ -7,12 +7,18 @@
 
 package me.stringdotjar.flixelgdx.asset;
 
+import com.badlogic.gdx.utils.ObjectMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Consumer;
 
 /**
  * Creates and pools wrapper instances for a single wrapper type. Register with
  * {@link FlixelAssetManager#registerWrapperFactory(FlixelWrapperFactory)}.
+ *
+ * <p>Implementations for their object map should make its key type as {@link String}, and its
+ * value type as the wrapper object {@link W}.
  *
  * @param <W> Concrete wrapper type (e.g. {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}).
  */
@@ -36,6 +42,9 @@ public interface FlixelWrapperFactory<W> {
 
   /** Disposes all non-persistent wrapper objects. */
   void clearNonPersist(@NotNull FlixelAssetManager assets);
+
+  /** Accepts a {@link Consumer} and iterates through the cached objects in {@code this} factory. */
+  void forEachWrappedAsset(Consumer<W> consumer);
 
   /** Disposes all wrapper objects. */
   void clearAll();

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperFactory.java
@@ -7,7 +7,6 @@
 
 package me.stringdotjar.flixelgdx.asset;
 
-import com.badlogic.gdx.utils.ObjectMap;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperSource.java
@@ -13,8 +13,8 @@ import org.jetbrains.annotations.NotNull;
  * An asset {@link FlixelSource} that also has a pooled Flixel wrapper type {@code W} (e.g.
  * {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic} for textures).
  *
- * <p>Use {@link #obtainWrapper(FlixelAssetManager)} to get the canonical wrapper for {@link #getAssetKey()};
- * the manager does not add texture- or type-specific methods—only {@link FlixelAssetManager#obtainWrapper(String, Class)}.
+ * <p>Use {@link #obtainWrapper(FlixelAssetManager)} for the canonical wrapper without refcount changes
+ * ({@link FlixelAssetManager#ensureWrapper}); use {@link FlixelAssetManager#obtainWrapper(String, Class)} when you need an implicit {@link FlixelAsset#retain()}.
  *
  * @param <T> Runtime type loaded from the asset manager (e.g. {@link com.badlogic.gdx.graphics.Texture}).
  * @param <W> Pooled wrapper type (e.g. {@link me.stringdotjar.flixelgdx.graphics.FlixelGraphic}).
@@ -22,19 +22,19 @@ import org.jetbrains.annotations.NotNull;
 public interface FlixelWrapperSource<T, W> extends FlixelSource<T> {
 
   /**
-   * @return The wrapper class used with {@link FlixelAssetManager#obtainWrapper(String, Class)}.
+   * @return The wrapper class used with {@link FlixelAssetManager#ensureWrapper(String, Class)}.
    */
   @NotNull
   Class<W> wrapperType();
 
   /**
-   * Returns or creates the pooled wrapper for this source’s key (does not {@code retain}).
+   * Returns or creates the pooled wrapper for this source’s key (does not change refcount).
    *
    * @param assets Asset manager that owns the wrapper cache.
    * @return Cached or new wrapper instance.
    */
   @NotNull
   default W obtainWrapper(@NotNull FlixelAssetManager assets) {
-    return assets.obtainWrapper(getAssetKey(), wrapperType());
+    return assets.ensureWrapper(getAssetKey(), wrapperType());
   }
 }

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
@@ -7,8 +7,9 @@
 
 package me.stringdotjar.flixelgdx.audio;
 
+import me.stringdotjar.flixelgdx.Flixel;
 import me.stringdotjar.flixelgdx.FlixelDestroyable;
-import me.stringdotjar.flixelgdx.util.FlixelPathsUtil;
+import me.stringdotjar.flixelgdx.asset.FlixelAssetManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -21,6 +22,11 @@ import com.badlogic.gdx.utils.Disposable;
  * <p>Access via {@link me.stringdotjar.flixelgdx.Flixel#sound}. Supports
  * separate groups for sound effects and music, global master volume, and
  * automatic pause when the game loses focus (and resume when it regains focus).
+ *
+ * <p>For internal paths, {@link #play} and {@link #playMusic} resolve audio through
+ * {@link Flixel#ensureAssets()}, which uses a loaded {@link FlixelSoundSource} when present,
+ * otherwise enqueue and block-load that source before creating a {@link FlixelSound}.
+ * External paths still bypass the asset manager and hit the backend directly.
  */
 public class FlixelAudioManager implements FlixelDestroyable, Disposable {
 
@@ -151,7 +157,7 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
   /**
    * Plays a new sound effect (SFX group).
    *
-   * @param path Path to the sound (internal or resolved via {@link FlixelPathsUtil}).
+   * @param path Internal asset key / path, or external path when {@code external} is {@code true}.
    * @return The new {@link FlixelSound} instance.
    */
   @NotNull
@@ -211,14 +217,8 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
   @NotNull
   public FlixelSound play(@NotNull String path, float volume, boolean looping,
                            @Nullable Object group, boolean external) {
-    String resolvedPath = external ? path : FlixelPathsUtil.resolveAudioPath(path);
     Object targetGroup = (group != null) ? group : sfxGroup;
-    FlixelSoundBackend backend = factory.createSound(resolvedPath, (short) 0, targetGroup, external);
-    FlixelSound flixelSound = new FlixelSound(backend);
-    flixelSound.setVolume(volume);
-    flixelSound.setLooped(looping);
-    flixelSound.play();
-    return flixelSound;
+    return createAndPlaySoundFromPath(path, external, volume, looping, targetGroup);
   }
 
   /**
@@ -269,15 +269,54 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
   @NotNull
   public FlixelSound playMusic(@NotNull String path, float volume, boolean looping, boolean external) {
     if (music != null) {
-      music.stop();
+      music.destroy();
+      music = null;
     }
-    String resolvedPath = external ? path : FlixelPathsUtil.resolveAudioPath(path);
-    FlixelSoundBackend backend = factory.createSound(resolvedPath, (short) 0, musicGroup, external);
-    music = new FlixelSound(backend);
-    music.setVolume(volume);
-    music.setLooped(looping);
-    music.play();
+    music = createAndPlaySoundFromPath(path, external, volume, looping, musicGroup);
     return music;
+  }
+
+  /**
+   * Builds a new {@link FlixelSound} for {@code path}, starts playback, and returns it.
+   *
+   * <p>When {@code external} is {@code false}, uses {@link Flixel#ensureAssets()} to read or
+   * synchronously load a {@link FlixelSoundSource} for {@code path}, then {@link FlixelSoundSource#create(Object)}
+   * with {@code targetGroup}. External paths keep the previous behavior: direct backend creation from {@code path}.
+   *
+   * @param path The path to the sound file.
+   * @param external If {@code true}, the path is used as-is (for external files).
+   * @param volume The volume to play the sound at.
+   * @param looping If {@code true}, the sound will loop.
+   * @param targetGroup The group to play the sound in.
+   * @return The new {@link FlixelSound} instance.
+   */
+  @NotNull
+  private FlixelSound createAndPlaySoundFromPath(
+    @NotNull String path,
+    boolean external,
+    float volume,
+    boolean looping,
+    @NotNull Object targetGroup
+  ) {
+    if (external) {
+      FlixelSoundBackend backend = factory.createSound(path, (short) 0, targetGroup, true);
+      FlixelSound s = new FlixelSound(backend);
+      s.setVolume(volume);
+      s.setLooped(looping);
+      s.play();
+      return s;
+    }
+    FlixelAssetManager assets = Flixel.ensureAssets();
+    if (!assets.isLoaded(path, FlixelSoundSource.class)) {
+      assets.load(path, FlixelSoundSource.class);
+      assets.finishLoadingAsset(path);
+    }
+    FlixelSoundSource source = assets.get(path, FlixelSoundSource.class);
+    FlixelSound flixelSound = source.create(targetGroup);
+    flixelSound.setVolume(volume);
+    flixelSound.setLooped(looping);
+    flixelSound.play();
+    return flixelSound;
   }
 
   /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSound.java
@@ -32,10 +32,9 @@ import com.badlogic.gdx.utils.Array;
  * sounds).
  *
  * <p>This class implements {@link FlixelAsset}{@code <FlixelSoundBackend>} for
- * a shared refcount / {@code persist} contract. {@link #persist} controls
- * whether this {@code FlixelSound} is treated as long-lived in game state (e.g.
- * not killed on substate switches). Use {@link #retain()} / {@link #release()}
- * if you mirror pooled-asset semantics for sounds you manage manually.
+ * a refcount contract: each instance {@link #retain()}s once in the backend constructor,
+ * and {@link #destroy()} {@link #release()}s to balance it. Use extra {@link #retain()} /
+ * {@link #release()} for advanced sharing. {@link #persist} controls substate behavior.
  *
  * @see me.stringdotjar.flixelgdx.asset.FlixelAssetManager#resolveAudioPath(String)
  */
@@ -106,6 +105,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
     super();
     this.sound = sound;
     this.assetKey = "__flixel_sound__/" + ID;
+    retain();
   }
 
   /**
@@ -665,6 +665,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
 
   @Override
   public void destroy() {
+    release();
     super.destroy();
     clearAudioEffectChain();
     cancelFadeTween();

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSource.java
@@ -97,8 +97,7 @@ public final class FlixelSoundSource implements FlixelSource<FlixelSoundSource> 
   }
 
   /**
-   * Convenience constructor from a libGDX file handle (uses
-   * {@code handle.path()} as key).
+   * Convenience constructor from a libGDX file handle (uses {@code handle.path()} as key).
    *
    * @param handle The file handle to the audio file.
    * @return A new sound source.

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphic.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphic.java
@@ -27,6 +27,18 @@ import org.jetbrains.annotations.Nullable;
  * Wrapper instances are pooled in {@link me.stringdotjar.flixelgdx.asset.FlixelAssetManager} so
  * multiple sprites can share policy state.
  *
+ * <p><b>Owned versus persist</b>:
+ * <ul>
+ *   <li><b>Owned</b> - Structural. This graphic was built with a non-null dedicated {@link Texture} (for example
+ *     {@code makeGraphic} or {@code loadGraphic(Texture, ...)}). The framework disposes that texture when the wrapper
+ *     is evicted from the pool. {@code isOwned()} is true. Not a user toggle.</li>
+ *   <li><b>Persist</b> - Policy. For path-keyed pooled graphics, whether an unreferenced wrapper survives
+ *     {@link me.stringdotjar.flixelgdx.asset.FlixelAssetManager#clearNonPersist()}. New non-owned graphics use
+ *     {@link me.stringdotjar.flixelgdx.asset.FlixelAssetManager#getGlobalPersist()} by default. Owned graphics always
+ *     use {@code persist == false} and are always removed on {@code clearNonPersist()} when refcount is zero, so
+ *     {@code persist} does not block eviction of synthetic textures.</li>
+ * </ul>
+ *
  * <p>Lifecycle ({@code persist}, refcount) is tracked here; keyed texture loading is implemented in
  * {@link me.stringdotjar.flixelgdx.asset.FlixelAssetManager} ({@link me.stringdotjar.flixelgdx.Flixel#assets}).
  *
@@ -47,16 +59,19 @@ public final class FlixelGraphic extends FlixelTypedAsset<Texture> implements Fl
     this(assetManager, assetKey, null);
   }
 
-  public FlixelGraphic(@NotNull FlixelAssetManager assetManager, @NotNull String key, @Nullable Texture ownedTexture) {
-    super(assetManager, key, Texture.class);
+  public FlixelGraphic(@NotNull FlixelAssetManager assetManager, @NotNull String assetKey, @Nullable Texture ownedTexture) {
+    super(assetManager, assetKey, Texture.class);
     this.owned = (ownedTexture != null);
     this.ownedTexture = ownedTexture;
+    if (this.owned) {
+      setPersist(false);
+    }
   }
 
   @NotNull
   @Override
   public FlixelGraphic setPersist(boolean persist) {
-    super.setPersist(persist);
+    super.setPersist(!owned ? persist : false); // If the graphic is owned, then we don't want to change the persist state.
     return this;
   }
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicSource.java
@@ -18,7 +18,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Cached graphic "source" (asset) that can provide a pooled {@link FlixelGraphic} wrapper.
  *
- * <p>Ownership is explicit: {@link #get()} does not retain, while {@link #acquire()} retains.
+ * <p>{@link #get()} uses {@link FlixelAssetManager#ensureWrapper} (no refcount change).
+ * {@link #acquire()} uses {@link FlixelAssetManager#obtainWrapper} (implicit {@link me.stringdotjar.flixelgdx.asset.FlixelAsset#retain()}).
  *
  * <p>Uses generic {@link FlixelAssetManager#obtainWrapper(String, Class)} via {@link FlixelWrapperSource};
  * the loaded texture is required with {@link #require(FlixelAssetManager)} (same as {@link #requireTexture(FlixelAssetManager)}).
@@ -50,16 +51,16 @@ public final class FlixelGraphicSource implements FlixelWrapperSource<Texture, F
     return FlixelGraphic.class;
   }
 
-  /** Returns the pooled wrapper for this asset key (does not retain). */
+  /** Returns the pooled wrapper for this asset key (does not change refcount). */
   @NotNull
   public FlixelGraphic get() {
-    return obtainWrapper(Flixel.ensureAssets());
+    return Flixel.ensureAssets().ensureWrapper(assetKey, FlixelGraphic.class);
   }
 
-  /** Returns the pooled wrapper and retains it (explicit ownership). */
+  /** Returns the pooled wrapper with implicit {@link me.stringdotjar.flixelgdx.asset.FlixelAsset#retain()}. */
   @NotNull
   public FlixelGraphic acquire() {
-    return obtainWrapper(Flixel.ensureAssets()).retain();
+    return Flixel.ensureAssets().obtainWrapper(assetKey, FlixelGraphic.class);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
@@ -18,6 +18,8 @@ import me.stringdotjar.flixelgdx.asset.FlixelWrapperFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.function.Consumer;
+
 /**
  * Pooled {@link FlixelGraphic} factory for {@link FlixelAssetManager#obtainWrapper(String, Class)}.
  */
@@ -84,6 +86,13 @@ public final class FlixelGraphicWrapperFactory implements FlixelWrapperFactory<F
       for (int i = 0; i < toRemove.size; i++) {
         cache.remove(toRemove.get(i));
       }
+    }
+  }
+
+  @Override
+  public void forEachWrappedAsset(Consumer<FlixelGraphic> consumer) {
+    for (FlixelGraphic graphic : cache.values()) {
+      consumer.accept(graphic);
     }
   }
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
@@ -98,6 +98,12 @@ public final class FlixelGraphicWrapperFactory implements FlixelWrapperFactory<F
 
   @Override
   public void clearAll() {
+    for (FlixelGraphic graphic : cache.values()) {
+      var texture = graphic.getOwnedTexture();
+      if (texture != null) {
+        texture.dispose();
+      }
+    }
     cache.clear();
   }
 }

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
@@ -62,7 +62,6 @@ public final class FlixelGraphicWrapperFactory implements FlixelWrapperFactory<F
     for (ObjectMap.Entry<String, FlixelGraphic> e : cache) {
       FlixelGraphic g = e.value;
       if (g == null) continue;
-      if (g.isPersist()) continue;
       if (g.getRefCount() > 0) continue;
 
       if (g.isOwned()) {
@@ -70,8 +69,9 @@ public final class FlixelGraphicWrapperFactory implements FlixelWrapperFactory<F
         if (t != null) {
           t.dispose();
         }
-      } else if (am != null) {
-        if (am.isLoaded(g.getAssetKey(), Texture.class)) {
+      } else {
+        if (g.isPersist()) continue;
+        if (am != null && am.isLoaded(g.getAssetKey(), Texture.class)) {
           am.unload(g.getAssetKey());
         }
       }

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -162,8 +162,83 @@ public class FlixelKeyInputManager {
   /**
    * Returns whether at least one of the given keys is currently pressed.
    *
-   * @param keys key codes to check
-   * @return {@code true} if any key in the array is pressed and input is enabled.
+   * @param k1 The first key code to check.
+   * @return {@code true} if any key in the given list is pressed and input is enabled.
+   */
+  public boolean anyPressed(int k1) {
+    return enabled && pressed(k1);
+  }
+
+  /**
+   * Returns whether at least one of the given keys is currently pressed.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @return {@code true} if any key in the given list is pressed and input is enabled.
+   */
+  public boolean anyPressed(int k1, int k2) {
+    return enabled && (pressed(k1) || pressed(k2));
+  }
+
+  /**
+   * Returns whether at least one of the given keys is currently pressed.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @return {@code true} if any key in the given list is pressed and input is enabled.
+   */
+  public boolean anyPressed(int k1, int k2, int k3) {
+    return enabled && (pressed(k1) || pressed(k2) || pressed(k3));
+  }
+
+  /**
+   * Returns whether at least one of the given keys is currently pressed.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @return {@code true} if any key in the given list is pressed and input is enabled.
+   */
+  public boolean anyPressed(int k1, int k2, int k3, int k4) {
+    return enabled && (pressed(k1) || pressed(k2) || pressed(k3) || pressed(k4));
+  }
+
+  /**
+   * Returns whether at least one of the given keys is currently pressed.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @param k5 The fifth key code to check.
+   * @return {@code true} if any key in the given list is pressed and input is enabled.
+   */
+  public boolean anyPressed(int k1, int k2, int k3, int k4, int k5) {
+    return enabled && (pressed(k1) || pressed(k2) || pressed(k3) || pressed(k4) || pressed(k5));
+  }
+
+  /**
+   * Returns whether at least one of the given keys is currently pressed.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @param k5 The fifth key code to check.
+   * @param k6 The sixth key code to check.
+   * @return {@code true} if any key in the given list is pressed and input is enabled.
+   */
+  public boolean anyPressed(int k1, int k2, int k3, int k4, int k5, int k6) {
+    return enabled && (pressed(k1) || pressed(k2) || pressed(k3) || pressed(k4) || pressed(k5) || pressed(k6));
+  }
+
+  /**
+   * Returns whether at least one of the given keys is currently pressed.
+   *
+   * @param keys The keys to check.
+   * @return {@code true} if any key in the given list is pressed and input is enabled.
    */
   public boolean anyPressed(int... keys) {
     if (!enabled || keys == null) {
@@ -180,8 +255,95 @@ public class FlixelKeyInputManager {
   /**
    * Returns whether at least one of the given keys was just pressed this frame.
    *
-   * @param keys key codes to check
+   * @param k1 The first key code to check.
    * @return true if any key in the array was just pressed and input is enabled
+   */
+  public boolean anyJustPressed(int k1) {
+    return enabled && Gdx.input.isKeyJustPressed(k1);
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just pressed this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @return {@code true} if any key in the given list was just pressed and input is enabled.
+   */
+  public boolean anyJustPressed(int k1, int k2) {
+    return enabled && (Gdx.input.isKeyJustPressed(k1) || Gdx.input.isKeyJustPressed(k2));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just pressed this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @return {@code true} if any key in the given list was just pressed and input is enabled.
+   */
+  public boolean anyJustPressed(int k1, int k2, int k3) {
+    return enabled && (Gdx.input.isKeyJustPressed(k1) || Gdx.input.isKeyJustPressed(k2) || Gdx.input.isKeyJustPressed(k3));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just pressed this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @return {@code true} if any key in the given list was just pressed and input is enabled.
+   */
+  public boolean anyJustPressed(int k1, int k2, int k3, int k4) {
+    return enabled
+      && (Gdx.input.isKeyJustPressed(k1) || Gdx.input.isKeyJustPressed(k2) || Gdx.input.isKeyJustPressed(k3) || Gdx.input.isKeyJustPressed(k4));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just pressed this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @param k5 The fifth key code to check.
+   * @return {@code true} if any key in the given list was just pressed and input is enabled.
+   */
+  public boolean anyJustPressed(int k1, int k2, int k3, int k4, int k5) {
+    return enabled
+      && (Gdx.input.isKeyJustPressed(k1)
+        || Gdx.input.isKeyJustPressed(k2)
+        || Gdx.input.isKeyJustPressed(k3)
+        || Gdx.input.isKeyJustPressed(k4)
+        || Gdx.input.isKeyJustPressed(k5));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just pressed this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @param k5 The fifth key code to check.
+   * @param k6 The sixth key code to check.
+   * @return {@code true} if any key in the given list was just pressed and input is enabled.
+   */
+  public boolean anyJustPressed(int k1, int k2, int k3, int k4, int k5, int k6) {
+    return enabled
+      && (Gdx.input.isKeyJustPressed(k1)
+        || Gdx.input.isKeyJustPressed(k2)
+        || Gdx.input.isKeyJustPressed(k3)
+        || Gdx.input.isKeyJustPressed(k4)
+        || Gdx.input.isKeyJustPressed(k5)
+        || Gdx.input.isKeyJustPressed(k6));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just pressed this frame.
+   *
+   * @param keys The keys to check.
+   * @return {@code true} if any key in the given list was just pressed and input is enabled.
    */
   public boolean anyJustPressed(int... keys) {
     if (!enabled || keys == null) {
@@ -198,7 +360,83 @@ public class FlixelKeyInputManager {
   /**
    * Returns whether at least one of the given keys was just released this frame.
    *
-   * @param keys Keys to check if they were just released.
+   * @param k1 The first key code to check.
+   * @return {@code true} if any key in the given list was just released and input is enabled.
+   */
+  public boolean anyJustReleased(int k1) {
+    return enabled && justReleased(k1);
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just released this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @return {@code true} if any key in the given list was just released and input is enabled.
+   */
+  public boolean anyJustReleased(int k1, int k2) {
+    return enabled && (justReleased(k1) || justReleased(k2));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just released this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @return {@code true} if any key in the given list was just released and input is enabled.
+   */
+  public boolean anyJustReleased(int k1, int k2, int k3) {
+    return enabled && (justReleased(k1) || justReleased(k2) || justReleased(k3));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just released this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @return {@code true} if any key in the given list was just released and input is enabled.
+   */
+  public boolean anyJustReleased(int k1, int k2, int k3, int k4) {
+    return enabled && (justReleased(k1) || justReleased(k2) || justReleased(k3) || justReleased(k4));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just released this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @param k5 The fifth key code to check.
+   * @return {@code true} if any key in the given list was just released and input is enabled.
+   */
+  public boolean anyJustReleased(int k1, int k2, int k3, int k4, int k5) {
+    return enabled && (justReleased(k1) || justReleased(k2) || justReleased(k3) || justReleased(k4) || justReleased(k5));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just released this frame.
+   *
+   * @param k1 The first key code to check.
+   * @param k2 The second key code to check.
+   * @param k3 The third key code to check.
+   * @param k4 The fourth key code to check.
+   * @param k5 The fifth key code to check.
+   * @param k6 The sixth key code to check.
+   * @return {@code true} if any key in the given list was just released and input is enabled.
+   */
+  public boolean anyJustReleased(int k1, int k2, int k3, int k4, int k5, int k6) {
+    return enabled
+      && (justReleased(k1) || justReleased(k2) || justReleased(k3) || justReleased(k4) || justReleased(k5) || justReleased(k6));
+  }
+
+  /**
+   * Returns whether at least one of the given keys was just released this frame.
+   *
+   * @param keys The keys to check.
    * @return {@code true} if any key in the given list was just released and input is enabled.
    */
   public boolean anyJustReleased(int... keys) {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
@@ -994,7 +994,13 @@ public abstract class FlixelTween implements Pool.Poolable {
    * want a full reset (as {@link me.stringdotjar.flixelgdx.Flixel#switchState} does when {@code clearTweens} is true).
    */
   public static void cancelActiveTweens() {
-    globalManager.getActiveTweens().forEach(tween -> tween.cancel());
+    Array<FlixelTween> list = globalManager.getActiveTweens();
+    for (int i = list.size - 1; i >= 0; i--) {
+      FlixelTween t = list.get(i);
+      if (t != null) {
+        t.cancel();
+      }
+    }
   }
 
   public static FlixelTweenManager getGlobalManager() {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTweenManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTweenManager.java
@@ -14,8 +14,8 @@ import java.util.function.Supplier;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
-import com.badlogic.gdx.utils.SnapshotArray;
 
 import me.stringdotjar.flixelgdx.tween.builders.FlixelAbstractTweenBuilder;
 import me.stringdotjar.flixelgdx.tween.settings.FlixelTweenSettings;
@@ -31,6 +31,10 @@ import me.stringdotjar.flixelgdx.tween.settings.FlixelTweenType;
  * <p>Uses a registry: each tween type is registered with its builder class and a pool factory.
  * Only registered types can be used with {@link FlixelTween#tween(Class, Class)}. Call
  * {@link #clearPools()} when clearing state (e.g. on state switch) to release pooled instances.
+ *
+ * <p>Active tweens use an unordered {@link Array}: removals swap with the last element (no
+ * {@link com.badlogic.gdx.utils.SnapshotArray} copy-on-write), so the per-frame update path stays
+ * allocation-free even when tweens finish and unregister.
  */
 public class FlixelTweenManager {
 
@@ -48,8 +52,8 @@ public class FlixelTweenManager {
   /** Registry: tween type -> (builder class, pool). */
   private final Map<Class<? extends FlixelTween>, TweenTypeRegistration> registry = new HashMap<>();
 
-  /** Array where all current active tweens are stored. */
-  protected final SnapshotArray<FlixelTween> activeTweens = new SnapshotArray<>(FlixelTween[]::new);
+  /** Active tweens; unordered so {@link #removeTween} is O(1) without snapshot copies. */
+  protected final Array<FlixelTween> activeTweens = new Array<>(false, 16, FlixelTween[]::new);
 
   /**
    * Registers a tween type with its builder factory and a pool factory for creating new tween instances when the pool is empty.
@@ -128,14 +132,15 @@ public class FlixelTweenManager {
   /**
    * Updates all active tweens that are stored and updated in {@code this} manager.
    *
-   * <p>Iterates in reverse so that finished ONESHOT tweens can be removed by index
-   * without skipping elements or traversing null padding beyond the array's valid size.
+   * <p>The finish pass runs in reverse order so {@link FlixelTween#finish()} can remove tweens
+   * (swap-with-last removal) without skipping entries.
    *
    * @param elapsed The amount of time that has passed since the last frame.
    */
   public void update(float elapsed) {
-    FlixelTween[] items = activeTweens.begin();
-    for (int i = 0; i < activeTweens.size; i++) {
+    FlixelTween[] items = activeTweens.items;
+    int n = activeTweens.size;
+    for (int i = 0; i < n; i++) {
       FlixelTween tween = items[i];
       if (tween == null || !tween.isActive()) {
         continue;
@@ -143,8 +148,8 @@ public class FlixelTweenManager {
       tween.update(elapsed);
     }
 
-    for (int i = 0; i < activeTweens.size; i++) {
-      FlixelTween tween = items[i];
+    for (int i = activeTweens.size - 1; i >= 0; i--) {
+      FlixelTween tween = activeTweens.items[i];
       if (tween != null && tween.isFinished()) {
         if (tween.manager != this) {
           continue;
@@ -152,8 +157,6 @@ public class FlixelTweenManager {
         tween.finish();
       }
     }
-
-    activeTweens.end();
   }
 
   /**
@@ -205,7 +208,7 @@ public class FlixelTweenManager {
     }
   }
 
-  public SnapshotArray<FlixelTween> getActiveTweens() {
+  public Array<FlixelTween> getActiveTweens() {
     return activeTweens;
   }
 
@@ -220,19 +223,14 @@ public class FlixelTweenManager {
     if (object == null) {
       throw new IllegalArgumentException("Object to cancel tweens of cannot be null");
     }
-    FlixelTween[] items = activeTweens.begin();
-    try {
-      for (int i = activeTweens.size - 1; i >= 0; i--) {
-        FlixelTween tween = items[i];
-        if (tween == null || !tween.isActive()) {
-          continue;
-        }
-        if (matchesTweenOf(tween, object, fieldPaths)) {
-          tween.cancel();
-        }
+    for (int i = activeTweens.size - 1; i >= 0; i--) {
+      FlixelTween tween = activeTweens.items[i];
+      if (tween == null || !tween.isActive()) {
+        continue;
       }
-    } finally {
-      activeTweens.end();
+      if (matchesTweenOf(tween, object, fieldPaths)) {
+        tween.cancel();
+      }
     }
   }
 
@@ -252,27 +250,22 @@ public class FlixelTweenManager {
     }
     // Iterate in reverse to avoid issues with ONESHOT tweens calling removeTween from finish(), which shrinks the list.
     // Forward iteration would skip the tween that shifted into the index we just advanced past (same pattern as cancelTweensOf).
-    FlixelTween[] items = activeTweens.begin();
-    try {
-      for (int i = activeTweens.size - 1; i >= 0; i--) {
-        FlixelTween tween = items[i];
-        if (tween == null || !tween.isActive()) {
-          continue;
-        }
-        if (!matchesTweenOf(tween, object, fieldPaths)) {
-          continue;
-        }
-        FlixelTweenSettings settings = tween.getTweenSettings();
-        if (settings != null && settings.getType().isLooping()) {
-          continue;
-        }
-        tween.update(Float.MAX_VALUE);
-        if (tween.isFinished()) {
-          tween.finish();
-        }
+    for (int i = activeTweens.size - 1; i >= 0; i--) {
+      FlixelTween tween = activeTweens.items[i];
+      if (tween == null || !tween.isActive()) {
+        continue;
       }
-    } finally {
-      activeTweens.end();
+      if (!matchesTweenOf(tween, object, fieldPaths)) {
+        continue;
+      }
+      FlixelTweenSettings settings = tween.getTweenSettings();
+      if (settings != null && settings.getType().isLooping()) {
+        continue;
+      }
+      tween.update(Float.MAX_VALUE);
+      if (tween.isFinished()) {
+        tween.finish();
+      }
     }
   }
 
@@ -280,24 +273,19 @@ public class FlixelTweenManager {
    * Completes all active non-looping tweens.
    */
   public void completeAll() {
-    FlixelTween[] items = activeTweens.begin();
-    try {
-      for (int i = activeTweens.size - 1; i >= 0; i--) {
-        FlixelTween tween = items[i];
-        if (tween == null || !tween.isActive()) {
-          continue;
-        }
-        FlixelTweenSettings settings = tween.getTweenSettings();
-        if (settings != null && settings.getType().isLooping()) {
-          continue;
-        }
-        tween.update(Float.MAX_VALUE);
-        if (tween.isFinished()) {
-          tween.finish();
-        }
+    for (int i = activeTweens.size - 1; i >= 0; i--) {
+      FlixelTween tween = activeTweens.items[i];
+      if (tween == null || !tween.isActive()) {
+        continue;
       }
-    } finally {
-      activeTweens.end();
+      FlixelTweenSettings settings = tween.getTweenSettings();
+      if (settings != null && settings.getType().isLooping()) {
+        continue;
+      }
+      tween.update(Float.MAX_VALUE);
+      if (tween.isFinished()) {
+        tween.finish();
+      }
     }
   }
 
@@ -312,24 +300,19 @@ public class FlixelTweenManager {
     if (type == null) {
       throw new IllegalArgumentException("Type to complete tweens of cannot be null");
     }
-    FlixelTween[] items = activeTweens.begin();
-    try {
-      for (int i = activeTweens.size - 1; i >= 0; i--) {
-        FlixelTween tween = items[i];
-        if (tween == null || !tween.isActive() || !type.isInstance(tween)) {
-          continue;
-        }
-        FlixelTweenSettings settings = tween.getTweenSettings();
-        if (settings != null && settings.getType().isLooping()) {
-          continue;
-        }
-        tween.update(Float.MAX_VALUE);
-        if (tween.isFinished()) {
-          tween.finish();
-        }
+    for (int i = activeTweens.size - 1; i >= 0; i--) {
+      FlixelTween tween = activeTweens.items[i];
+      if (tween == null || !tween.isActive() || !type.isInstance(tween)) {
+        continue;
       }
-    } finally {
-      activeTweens.end();
+      FlixelTweenSettings settings = tween.getTweenSettings();
+      if (settings != null && settings.getType().isLooping()) {
+        continue;
+      }
+      tween.update(Float.MAX_VALUE);
+      if (tween.isFinished()) {
+        tween.finish();
+      }
     }
   }
 
@@ -346,22 +329,18 @@ public class FlixelTweenManager {
     if (object == null) {
       throw new IllegalArgumentException("Object to check for tweens of cannot be null");
     }
-    FlixelTween[] items = activeTweens.begin();
-    try {
-      for (int i = 0; i < activeTweens.size; i++) {
-        FlixelTween tween = items[i];
-        if (tween != null && tween.isActive() && matchesTweenOf(tween, object, fieldPaths)) {
-          return true;
-        }
+    for (int i = 0; i < activeTweens.size; i++) {
+      FlixelTween tween = activeTweens.items[i];
+      if (tween != null && tween.isActive() && matchesTweenOf(tween, object, fieldPaths)) {
+        return true;
       }
-    } finally {
-      activeTweens.end();
     }
     return false;
   }
 
   /**
-   * Invokes {@code action} for each active tween (current snapshot order).
+   * Invokes {@code action} for each active tween. Iteration is from the end of the backing array
+   * downward so {@code action} may cancel or remove tweens without skipping entries.
    *
    * @param action The action to invoke for each active tween.
    * @throws NullPointerException If the action is null.
@@ -370,17 +349,11 @@ public class FlixelTweenManager {
     if (action == null) {
       throw new IllegalArgumentException("Action cannot be null");
     }
-    // We use a try/finally to ensure the array is always ended, even if an exception is thrown.
-    FlixelTween[] items = activeTweens.begin();
-    try {
-      for (int i = 0; i < activeTweens.size; i++) {
-        FlixelTween tween = items[i];
-        if (tween != null) {
-          action.accept(tween);
-        }
+    for (int i = activeTweens.size - 1; i >= 0; i--) {
+      FlixelTween tween = activeTweens.items[i];
+      if (tween != null) {
+        action.accept(tween);
       }
-    } finally {
-      activeTweens.end();
     }
   }
 
@@ -392,7 +365,12 @@ public class FlixelTweenManager {
    * register the tween types again.
    */
   public void resetRegistry() {
-    forEach(FlixelTween::cancel);
+    for (int i = activeTweens.size - 1; i >= 0; i--) {
+      FlixelTween t = activeTweens.items[i];
+      if (t != null) {
+        t.cancel();
+      }
+    }
     clearPools();
     activeTweens.clear();
     registry.clear();


### PR DESCRIPTION
## Description

Closes #114 

This pull request fixes an issue with the `getDiagnostics()` method in the `FlixelDefaultAssetManager` class. Originally, it returned what the underlying libGDX `AssetManager` had stored, but it never returned the correct results, specifically for reference counts for how many objects were using an asset.

It also reworks the asset system to automatically handle reference counts for you without having to touch them directly (although you still can if you choose to and you know what you're doing, of course). Additionally, it adds a global persist flag for whether loaded assets should stay in memory when `Flixel.switchState()` is called.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
