### PR TITLE
Fix critical bug with desktop natives not being included automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ www-test/
 .metadata/
 /android/bin/
 /core/bin/
+flixelgdx-*/bin/
 /lwjgl2/bin/
 /lwjgl3/bin/
 /html/bin/

--- a/build.gradle
+++ b/build.gradle
@@ -184,6 +184,27 @@ configure(subprojects.findAll { it.name != 'flixelgdx-test' && it.name != 'flixe
             rootProject.configureFlixelMavenPom(delegate)
           }
         }
+
+        named('maven', MavenPublication) {
+          pom.withXml {
+            def dependenciesNode = asNode().appendNode('dependencies')
+
+            // Function to add a classified dependency
+            def addNatives = { gId, aId, ver, classifier ->
+              def dep = dependenciesNode.appendNode('dependency')
+              dep.appendNode('groupId', gId)
+              dep.appendNode('artifactId', aId)
+              dep.appendNode('version', ver)
+              dep.appendNode('classifier', classifier)
+              dep.appendNode('scope', 'compile')
+            }
+
+            // Force the natives into the POM
+            addNatives('com.badlogicgames.gdx', 'gdx-platform', gdxVersion, 'natives-desktop')
+            addNatives('com.badlogicgames.gdx', 'gdx-freetype-platform', gdxVersion, 'natives-desktop')
+            addNatives('games.rednblack.miniaudio', 'gdx-miniaudio-platform', miniaudioVersion, 'natives-desktop')
+          }
+        }
       }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,16 @@ subprojects { Project p ->
   }
 }
 
+// JitPack rewrites published Gradle module metadata (.module) and drops thirdPartyCompatibility
+// entries (artifactSelector / classifiers like natives-desktop). Gradle then resolves the wrong
+// libGDX artifacts. POMs still declare classifiers correctly; skip publishing .module so consumers
+// use the POM (and are not misled by JitPack-stripped metadata).
+subprojects {
+  tasks.matching { it.name.startsWith('generateMetadataFileFor') }.configureEach {
+    enabled = false
+  }
+}
+
 configure(subprojects.findAll { it.name != 'flixelgdx-test' && it.name != 'flixelgdx-teavm-plugin' }) {
   apply plugin: 'maven-publish'
   afterEvaluate {
@@ -182,36 +192,6 @@ configure(subprojects.findAll { it.name != 'flixelgdx-test' && it.name != 'flixe
             artifactId = project.name
             version = project.version
             rootProject.configureFlixelMavenPom(delegate)
-          }
-        }
-      }
-    }
-  }
-}
-
-// Force natives for the published artifacts uploaded to Maven Central and JitPack
-// so that way developers aren't required to add the natives-desktop modules every time.
-configure(subprojects.findAll { it.name == 'flixelgdx-lwjgl3' }) {
-  afterEvaluate {
-    publishing {
-      publications {
-        named('maven', MavenPublication) {
-          pom.withXml {
-            // Find or create the dependencies node
-            def dependenciesNode = asNode().get('dependencies')[0] ?: asNode().appendNode('dependencies')
-
-            def addNatives = { gId, aId, ver, classifier ->
-              def dep = dependenciesNode.appendNode('dependency')
-              dep.appendNode('groupId', gId)
-              dep.appendNode('artifactId', aId)
-              dep.appendNode('version', ver)
-              dep.appendNode('classifier', classifier)
-              dep.appendNode('scope', 'compile')
-            }
-
-            addNatives('com.badlogicgames.gdx', 'gdx-platform', gdxVersion, 'natives-desktop')
-            addNatives('com.badlogicgames.gdx', 'gdx-freetype-platform', gdxVersion, 'natives-desktop')
-            addNatives('games.rednblack.miniaudio', 'gdx-miniaudio-platform', miniaudioVersion, 'natives-desktop')
           }
         }
       }

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ configure(subprojects.findAll { p -> p.name != 'flixelgdx-core' && p.name != 'fl
 subprojects {
   // JitPack serves artifacts as com.github.<user>.<repo>; POMs must use the same groupId for
   // transitive flixelgdx modules or Gradle looks up me.stringdotjar.flixelgdx on other repos and fails.
-  group = System.getenv('JITPACK') == 'true' ? 'com.github.stringdotjar.flixelgdx' : 'me.stringdotjar.flixelgdx'
+  group = "$groupId"
   version = "$projectVersion"
   ext.appName = 'flixelgdx'
   repositories {
@@ -184,12 +184,22 @@ configure(subprojects.findAll { it.name != 'flixelgdx-test' && it.name != 'flixe
             rootProject.configureFlixelMavenPom(delegate)
           }
         }
+      }
+    }
+  }
+}
 
+// Force natives for the published artifacts uploaded to Maven Central and JitPack
+// so that way developers aren't required to add the natives-desktop modules every time.
+configure(subprojects.findAll { it.name == 'flixelgdx-lwjgl3' }) {
+  afterEvaluate {
+    publishing {
+      publications {
         named('maven', MavenPublication) {
           pom.withXml {
-            def dependenciesNode = asNode().appendNode('dependencies')
+            // Find or create the dependencies node
+            def dependenciesNode = asNode().get('dependencies')[0] ?: asNode().appendNode('dependencies')
 
-            // Function to add a classified dependency
             def addNatives = { gId, aId, ver, classifier ->
               def dep = dependenciesNode.appendNode('dependency')
               dep.appendNode('groupId', gId)
@@ -199,7 +209,6 @@ configure(subprojects.findAll { it.name != 'flixelgdx-test' && it.name != 'flixe
               dep.appendNode('scope', 'compile')
             }
 
-            // Force the natives into the POM
             addNatives('com.badlogicgames.gdx', 'gdx-platform', gdxVersion, 'natives-desktop')
             addNatives('com.badlogicgames.gdx', 'gdx-freetype-platform', gdxVersion, 'natives-desktop')
             addNatives('games.rednblack.miniaudio', 'gdx-miniaudio-platform', miniaudioVersion, 'natives-desktop')


### PR DESCRIPTION
## Description

This pull request fixes a critical issue that originally did not automatically include the desktop natives when using the framework as a dependency, causing FlixelGDX games to crash when `lwjgl3:run` was executed, and it was followed with a libGDX runtime error which could not extract the native files (due to them not being included).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
