### PR TITLE
Fix scroll with zoom calculation bug

### DIFF
--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
@@ -405,10 +405,9 @@ public class FlixelCamera extends FlixelBasic {
    * {@link com.badlogic.gdx.utils.viewport.Viewport#unproject(com.badlogic.gdx.math.Vector2)} or rendering.
    * Safe to call every frame; {@link #update(float)} ends with this.
    *
-   * <p>Drawables use scroll-local batch coordinates ({@code worldPos - scroll}, see {@link FlixelSprite#draw}).
-   * The orthographic camera must look at the center of that space {@code (viewW/2, viewH/2)}, not
-   * {@code scroll + view/2}, or the frustum disagrees with batch vertices whenever {@code scroll != 0}
-   * (broken follow, split-screen drift).
+   * <p>Drawables use view (batch) coordinates from {@link #worldToViewX(float, float)} /
+   * {@link #worldToViewY(float, float)} (see {@link FlixelSprite#draw}).
+   * The orthographic camera looks at the center of that space {@code (viewW/2, viewH/2)}.
    */
   public void applyLibCameraTransform() {
     if (camera instanceof OrthographicCamera ortho) {
@@ -464,9 +463,11 @@ public class FlixelCamera extends FlixelBasic {
    * @param point The world-space point to focus on.
    */
   public void focusOn(Vector2 point) {
+    // Scroll = point - full camera buffer/2, not inner view/2, so
+    // worldToView* centers stay correct when zoom != 1 (see worldToViewX).
     scroll.set(
-      point.x - getViewWidth() / 2f,
-      point.y - getViewHeight() / 2f
+      point.x - width * 0.5f,
+      point.y - height * 0.5f
     );
   }
 
@@ -482,9 +483,7 @@ public class FlixelCamera extends FlixelBasic {
     float fsy = followScrollFactorY(target);
     float tx = target.getX() + target.getWidth() / 2f + targetOffset.x + followLead.x;
     float ty = target.getY() + target.getHeight() / 2f + targetOffset.y + followLead.y;
-    float vw = getViewWidth();
-    float vh = getViewHeight();
-    scroll.set(scrollForFollowCenterAxis(tx, vw, fsx), scrollForFollowCenterAxis(ty, vh, fsy));
+    scroll.set(scrollXForFollowCenter(tx, fsx), scrollYForFollowCenter(ty, fsy));
     updateScroll();
   }
 
@@ -502,42 +501,31 @@ public class FlixelCamera extends FlixelBasic {
   }
 
   /**
-   * Scroll coordinate so the follow target’s visual center (see {@link FlixelSprite#draw}) matches the viewport
-   * center: solves {@code tx - scroll * sx = scroll + viewW/2} i.e. {@code scroll = (tx - viewW/2) / (sx + 1)}.
-   * When {@code sx} is ~1, uses classic Flixel behavior {@code scroll = tx - viewW/2} so existing games stay
-   * unchanged.
-   *
-   * @param tx The target x position.
-   * @param viewW The full view width or height from {@link #getViewWidth()} / {@link #getViewHeight()}.
-   * @param sx The scroll factor x.
-   * @return The scroll coordinate.
+   * {@code scroll.x} so {@link #worldToViewX(float, float)} for the follow focus world X and {@code sx} is at the
+   * view center: {@code (tx - margin - viewW/2) / sx}.
    */
-  private static float scrollForFollowCenterAxis(float tx, float viewW, float sx) {
-    float half = viewW * 0.5f;
-    if (Math.abs(sx - 1f) < 1e-4f) {
-      return tx - half;
-    }
-    return (tx - half) / (sx + 1f);
+  private float scrollXForFollowCenter(float tx, float sx) {
+    return (tx - getViewMarginX() - getViewWidth() * 0.5f) / sx;
+  }
+
+  private float scrollYForFollowCenter(float ty, float sy) {
+    return (ty - getViewMarginY() - getViewHeight() * 0.5f) / sy;
   }
 
   /**
-   * Like {@link #scrollForFollowCenterAxis} for dead-zone edge targets (numerator is already the scroll delta for
-   * {@code sx=1} space, e.g. {@code tx - deadzone.x}).
-   *
-   * @param numerator The numerator of the scroll delta.
-   * @param sx The scroll factor x.
-   * @return The scroll coordinate.
+   * {@code scroll} value when a deadzone edge is hit; see {@code tx - deadzone.x} or similar in {@link #updateFollow}.
    */
-  private static float scrollForFollowEdgeAxis(float numerator, float sx) {
-    if (Math.abs(sx - 1f) < 1e-4f) {
-      return numerator;
-    }
-    return numerator / (sx + 1f);
+  private float scrollXForFollowEdge(float numerator, float sx) {
+    return (numerator - getViewMarginX()) / sx;
+  }
+
+  private float scrollYForFollowEdge(float numerator, float sy) {
+    return (numerator - getViewMarginY()) / sy;
   }
 
   /**
-   * Camera follow uses the same batch-space math as {@link FlixelSprite#draw} ({@code wx = x - scroll * sx}) and
-   * {@link #applyLibCameraTransform} (ortho center {@code = view/2} in scroll-local space).
+   * Camera follow uses the same view-space contract as {@link #worldToViewX(float, float)} and
+   * {@link FlixelSprite#draw}.
    *
    * @param elapsed Seconds elapsed since the last frame.
    */
@@ -552,11 +540,8 @@ public class FlixelCamera extends FlixelBasic {
     float tx = target.getX() + target.getWidth() / 2f + targetOffset.x + followLead.x;
     float ty = target.getY() + target.getHeight() / 2f + targetOffset.y + followLead.y;
 
-    float vw = getViewWidth();
-    float vh = getViewHeight();
-
-    float desiredX = scrollForFollowCenterAxis(tx, vw, fsx);
-    float desiredY = scrollForFollowCenterAxis(ty, vh, fsy);
+    float desiredX = scrollXForFollowCenter(tx, fsx);
+    float desiredY = scrollYForFollowCenter(ty, fsy);
 
     if (followLerp >= 1.0f) {
       scroll.set(desiredX, desiredY);
@@ -570,17 +555,17 @@ public class FlixelCamera extends FlixelBasic {
       float dzBottom = dzTop + deadzone.height;
 
       if (tx < dzLeft) {
-        desiredX = scrollForFollowEdgeAxis(tx - deadzone.x, fsx);
+        desiredX = scrollXForFollowEdge(tx - deadzone.x, fsx);
       } else if (tx > dzRight) {
-        desiredX = scrollForFollowEdgeAxis(tx - deadzone.x - deadzone.width, fsx);
+        desiredX = scrollXForFollowEdge(tx - deadzone.x - deadzone.width, fsx);
       } else {
         desiredX = scroll.x;
       }
 
       if (ty < dzTop) {
-        desiredY = scrollForFollowEdgeAxis(ty - deadzone.y, fsy);
+        desiredY = scrollYForFollowEdge(ty - deadzone.y, fsy);
       } else if (ty > dzBottom) {
-        desiredY = scrollForFollowEdgeAxis(ty - deadzone.y - deadzone.height, fsy);
+        desiredY = scrollYForFollowEdge(ty - deadzone.y - deadzone.height, fsy);
       } else {
         desiredY = scroll.y;
       }
@@ -1095,48 +1080,44 @@ public class FlixelCamera extends FlixelBasic {
     return tmpRect.set(getViewMarginLeft(), getViewMarginTop(), getViewWidth(), getViewHeight());
   }
 
+  /**
+   * Converts a world X into this camera’s view (batch) X.
+   * Parallax uses the object’s scroll factor on {@link #scroll} only; zoom is handled by {@link #getViewMarginX()}.
+   *
+   * @param worldX World-space X.
+   * @param scrollFactor Parallax factor ({@code 1} = moves fully with the camera).
+   * @return View-space X (same space as {@link FlixelSprite#draw} before the libGDX projection).
+   */
+  public float worldToViewX(float worldX, float scrollFactor) {
+    return worldX - scroll.x * scrollFactor - getViewMarginX();
+  }
+
+  /**
+   * Converts a world Y into this camera’s view (batch) Y.
+   *
+   * @param worldY World-space Y.
+   * @param scrollFactor Parallax factor ({@code 1} = moves fully with the camera).
+   * @return View-space Y.
+   * @see #worldToViewX(float, float)
+   */
+  public float worldToViewY(float worldY, float scrollFactor) {
+    return worldY - scroll.y * scrollFactor - getViewMarginY();
+  }
+
   public float getZoom() {
     return zoom;
   }
 
   /**
    * Sets the zoom level. {@code 1} = 1:1, {@code 2} = 2x magnification (world appears larger).
-   * Cameras always zoom toward their center.
-   *
-   * <p>Scroll is nudged by the same delta {@link #scrollForFollowCenterAxis} would apply when only
-   * {@link #getViewWidth()} / {@link #getViewHeight()} change, so zoom matches the follow / draw
-   * contract ({@code tx - scroll * sx = view/2 + scroll} for non-unit factors). The old
-   * {@code (viewOld - viewNew) / 2} adjustment is only correct for the classic {@code sx = 1}
-   * branch; fractional scroll factors otherwise drift on zoom.
+   * Cameras always zoom toward their center. {@link #getViewWidth()} and margins update with zoom;
+   * {@link #worldToViewX(float, float)} / {@link #worldToViewY(float, float)} keep parallax and foreground aligned.
+   * Scroll is not auto-adjusted here (same idea as HaxeFlixel's {@code set_zoom}).
    *
    * @param zoom The new zoom level.
    */
   public void setZoom(float zoom) {
-    float oldZoom = this.zoom;
-    float vwOld = width / oldZoom;
-    float vhOld = height / oldZoom;
-    this.zoom = zoom;
-    float vwNew = width / this.zoom;
-    float vhNew = height / this.zoom;
-
-    float fsx;
-    float fsy;
-    float ax;
-    float ay;
-    if (target != null) {
-      fsx = followScrollFactorX(target);
-      fsy = followScrollFactorY(target);
-      ax = target.getX() + target.getWidth() / 2f + targetOffset.x + followLead.x;
-      ay = target.getY() + target.getHeight() / 2f + targetOffset.y + followLead.y;
-    } else {
-      fsx = 1f;
-      fsy = 1f;
-      ax = scroll.x + vwOld / 2f;
-      ay = scroll.y + vhOld / 2f;
-    }
-    scroll.x += scrollForFollowCenterAxis(ax, vwNew, fsx) - scrollForFollowCenterAxis(ax, vwOld, fsx);
-    scroll.y += scrollForFollowCenterAxis(ay, vhNew, fsy) - scrollForFollowCenterAxis(ay, vhOld, fsy);
-
+    this.zoom = (zoom <= 0f) ? defaultZoom : zoom;
     applyZoom();
     if (target != null && style != null && style != FollowStyle.NO_DEAD_ZONE) {
       updateDeadzoneForStyle();
@@ -1144,7 +1125,7 @@ public class FlixelCamera extends FlixelBasic {
   }
 
   /**
-   * Restores scroll and zoom together without running {@link #setZoom(float)}'s recentering logic.
+   * Restores scroll and zoom together without re-running follow or deadzone setup.
    * Used when leaving debug pause so inspect-tool mutations can be reverted exactly as they were before.
    *
    * @param scrollX World scroll X to restore.
@@ -1215,9 +1196,6 @@ public class FlixelCamera extends FlixelBasic {
     this.regionMode = regionMode;
   }
 
-  /**
-   * Returns the current screen-region mode.
-   */
   public RegionMode getRegionMode() {
     return regionMode;
   }

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
@@ -1103,16 +1103,40 @@ public class FlixelCamera extends FlixelBasic {
    * Sets the zoom level. {@code 1} = 1:1, {@code 2} = 2x magnification (world appears larger).
    * Cameras always zoom toward their center.
    *
+   * <p>Scroll is nudged by the same delta {@link #scrollForFollowCenterAxis} would apply when only
+   * {@link #getViewWidth()} / {@link #getViewHeight()} change, so zoom matches the follow / draw
+   * contract ({@code tx - scroll * sx = view/2 + scroll} for non-unit factors). The old
+   * {@code (viewOld - viewNew) / 2} adjustment is only correct for the classic {@code sx = 1}
+   * branch; fractional scroll factors otherwise drift on zoom.
+   *
    * @param zoom The new zoom level.
    */
   public void setZoom(float zoom) {
     float oldZoom = this.zoom;
+    float vwOld = width / oldZoom;
+    float vhOld = height / oldZoom;
     this.zoom = zoom;
-    // Keep the center of the view fixed in world space so zoom happens from center, not from the left edge.
-    float centerX = scroll.x + width / (2f * oldZoom);
-    float centerY = scroll.y + height / (2f * oldZoom);
-    scroll.x = centerX - width / (2f * this.zoom);
-    scroll.y = centerY - height / (2f * this.zoom);
+    float vwNew = width / this.zoom;
+    float vhNew = height / this.zoom;
+
+    float fsx;
+    float fsy;
+    float ax;
+    float ay;
+    if (target != null) {
+      fsx = followScrollFactorX(target);
+      fsy = followScrollFactorY(target);
+      ax = target.getX() + target.getWidth() / 2f + targetOffset.x + followLead.x;
+      ay = target.getY() + target.getHeight() / 2f + targetOffset.y + followLead.y;
+    } else {
+      fsx = 1f;
+      fsy = 1f;
+      ax = scroll.x + vwOld / 2f;
+      ay = scroll.y + vhOld / 2f;
+    }
+    scroll.x += scrollForFollowCenterAxis(ax, vwNew, fsx) - scrollForFollowCenterAxis(ax, vwOld, fsx);
+    scroll.y += scrollForFollowCenterAxis(ay, vhNew, fsy) - scrollForFollowCenterAxis(ay, vhOld, fsy);
+
     applyZoom();
     if (target != null && style != null && style != FollowStyle.NO_DEAD_ZONE) {
       updateDeadzoneForStyle();

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelObject.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelObject.java
@@ -905,12 +905,12 @@ public class FlixelObject extends FlixelBasic implements FlixelDebugDrawable {
 
   @Override
   public float getDebugDrawX(FlixelCamera cam) {
-    return getX() - cam.scroll.x * getScrollX();
+    return cam.worldToViewX(getX(), getScrollX());
   }
 
   @Override
   public float getDebugDrawY(FlixelCamera cam) {
-    return getY() - cam.scroll.y * getScrollY();
+    return cam.worldToViewY(getY(), getScrollY());
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
@@ -357,8 +357,8 @@ public class FlixelSprite extends FlixelObject {
       return;
     }
     FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.getCamera();
-    float wx = getX() - cam.scroll.x * scrollX;
-    float wy = getY() - cam.scroll.y * scrollY;
+    float wx = cam.worldToViewX(getX(), scrollX);
+    float wy = cam.worldToViewY(getY(), scrollY);
     if (currentFrame != null) {
       float oX = currentFrame.originalWidth / 2f;
       float oY = currentFrame.originalHeight / 2f;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/text/FlixelText.java
@@ -743,8 +743,8 @@ public class FlixelText extends FlixelSprite {
     rebuildIfDirty();
 
     FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.getCamera();
-    float wx = getX() - cam.scroll.x * getScrollX();
-    float wy = getY() - cam.scroll.y * getScrollY();
+    float wx = cam.worldToViewX(getX(), getScrollX());
+    float wy = cam.worldToViewY(getY(), getScrollY());
 
     float scaleX = getScaleX();
     float scaleY = getScaleY();

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/ui/FlixelBar.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/ui/FlixelBar.java
@@ -665,8 +665,8 @@ public class FlixelBar extends FlixelSprite {
         py += cam.scroll.y * getScrollY();
       }
     } else if (cam != null) {
-      px -= cam.scroll.x * getScrollX();
-      py -= cam.scroll.y * getScrollY();
+      px = cam.worldToViewX(px, getScrollX());
+      py = cam.worldToViewY(py, getScrollY());
     }
 
     float w = getWidth();


### PR DESCRIPTION
## Description

This pull request fixes a bug that causes a `FlixelObject` to not properly (and visually) stay in place when its scroll factor is different and the zoom changes on a `FlixelCamera`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [ ] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
