### PR TITLE
Fix bug with unlocked framerate breaking camera following

### DIFF
--- a/.cursor/rules/code-quality.mdc
+++ b/.cursor/rules/code-quality.mdc
@@ -7,7 +7,7 @@ FlixelGDX aims to be an easily maintainable, beginner friendly and modernized ga
 - __***Never ever EVER allocate objects in a loop or method that gets called every frame.***__. This is the *most* important one and it's ***nonnegotiable***. We can and will not let the framework be the cause for garbage collection stutters for any game.
 - As a follow up to the rule just mentioned, reuse every object if it can be. Use pooling systems (both FlixelGDX's and libGDX's), indexed for loops, FlixelGDX and libGDX utilities (such as `FlixelString` from FlixelGDX or `ObjectMap` from libGDX) designed for performance, etc.
 - FlixelGDX is a multi-modular framework. The `flixelgdx-core` module is the heart of the entire system, which contains all of the main classes developers utilizing the framework will typically use. Avoid mixing backend logic with core logic. If something works differently on a different platform, use interfaces to abstract it away.
-- Keep your code simple and concise. It should be easily readable and changable without breaking other systems of the framework.
+- Keep your code simple and concise. It should be easily readable and changeable without breaking other systems of the framework.
 - Based on the given task, do not touch unrelated files unless it's absolutely necessary. Keep the goal focused on the specific context and goal provided.
 - This framework uses Java 17. Do not use old Java features, such as, for example, legacy switch statements.
-- When you are done with a provided task, you must explain in simple detail what you changed, your reasoning behind it, and how it incoporates with the system.
+- When you are done with a provided task, you must explain in simple detail what you changed, your reasoning behind it, and how it incorporates with the system.

--- a/.cursor/rules/documentation.mdc
+++ b/.cursor/rules/documentation.mdc
@@ -4,12 +4,12 @@ alwaysApply: true
 
 When writing documentation (specifically for source code Javadocs or comments), follow these guidelines:
 
-- Use proper grammar. Use proper puncationation on everything, including comments, Javadoc parameter/returns/throws descriptions., etc.
+- Use proper grammar. Use proper punctuation on everything, including comments, Javadoc parameter/returns/throws descriptions., etc.
 - Avoid using special symbols, such as en dashes, em dashes, special arrows, etc. It is not necessary. Avoiding these helps keep the documentation simple and concise. Use pure ASCII characters instead.
 - Always include every tag for Javadocs, such as @param, @returns, @throws, etc.
 - Use null annotations where necessary, such as @Nullable or @NotNull. This allows IDEs to highlight when something could be null ahead of time and allow the user to add safeguards before compiling their code.
 - When using Javadoc features like @link, make sure it actually works. If there's a broken link, or if it's not a supported feature, modify it accordingly. This allows the documentation to be easily navigated and readable by users and developers alike.
-- Keep the tone simple and inviting. The documenation should be able to teach the users (especially beginners) how to use the framework, not just a dry manual. When needed, include code examples showing how to use a class or method.
-- When writing code, always use the `.editorconfig` file for formatting. This keeps the formatting of the code consistient and makes it looks like as if it was written by a single person.
+- Keep the tone simple and inviting. The documentation should be able to teach the users (especially beginners) how to use the framework, not just a dry manual. When needed, include code examples showing how to use a class or method.
+- When writing code, always use the `.editorconfig` file for formatting. This keeps the formatting of the code consistent and makes it looks like as if it was written by a single person.
 - Add brief comments in places where the code either might be complex or hard to read when there's too much going on.
 - Avoid adding Javadocs to methods or functions that have literal names. For example, if it's a simple getter/setter or a method named `calculateTotal()`, don't add a Javadoc unless necessary.

--- a/.cursor/rules/framework-basics.mdc
+++ b/.cursor/rules/framework-basics.mdc
@@ -6,4 +6,4 @@ This project is a general purposed, Java based framework called FlixelGDX. It is
 
 The ultimate goal of this framework is to take the beloved features from HaxeFlixel and rewriting them for Java's massive ecosystem. It is meant to be as memory efficient as possible without breaking or sacrificing any powerful features that may be required in a game.
 
-Note that because this is a standalone framework, everything is tested in a *seperate test project*, either using the framework locally via `publishToMavenLocal` or JitPack from a GitHub branch.
+Note that because this is a standalone framework, everything is tested in a *separate test project*, either using the framework locally via `publishToMavenLocal` or JitPack from a GitHub branch.

--- a/.cursor/rules/teaching-for-beginners.mdc
+++ b/.cursor/rules/teaching-for-beginners.mdc
@@ -6,5 +6,5 @@ This framework isn't just meant for experts, it's designed and intended to be we
 
 - When providing a code solution, explain the "why" before the "how". For example, instead of just saying "You should move these fields into a subclass, located in another Gradle module", say something like "These fields are not very well organized because it can be confusing to navigate or not very easy to guess where things are, so you should move them in this location instead. It keeps the code clean and easy to look for."
 - Use analogies to explain complex systems. If a user doesn't explicitly provide one, ask them for a topic to compare a system to so they understand it.
-- End complex explinations with a brief question to verify the user understands the given explination. The goal is to ensure they actually understand the information they are given.
+- End complex explanations with a brief question to verify the user understands the given explanation. The goal is to ensure they actually understand the information they are given.
 - Be encouraging and professional, and avoid being condescending. Assume high intelligence but potentially low familiarity with specific Java/libGDX/FlixelGDX quirks.

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
@@ -1388,11 +1388,12 @@ public class FlixelCamera extends FlixelBasic {
     return 1;
   }
 
-  /** Target updates per second for follow lerp; matches {@link FlixelGame#getFramerate()} when in FlixelGDX. */
+  /** Target updates per second for follow lerp. Matches {@link FlixelGame#getFramerate()} when in FlixelGDX. */
   private static float resolveTargetFramerate() {
     FlixelGame game = Flixel.getGame();
     if (game != null) {
-      return game.getFramerate();
+      int framerate = game.getFramerate();
+      return (framerate > 0) ? framerate : 60; // Just in case the framerate is unlocked so that way following works!
     }
     if (Gdx.graphics != null) {
       int hz = Gdx.graphics.getDisplayMode().refreshRate;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
@@ -571,7 +571,7 @@ public class FlixelCamera extends FlixelBasic {
       }
     }
 
-    float lerpFactor = 1f - (float) Math.pow(1f - followLerp, elapsed * resolveTargetFramerate());
+    float lerpFactor = 1f - (float) Math.pow(1f - followLerp, elapsed * 60f);
     scroll.x = MathUtils.lerp(scroll.x, desiredX, lerpFactor);
     scroll.y = MathUtils.lerp(scroll.y, desiredY, lerpFactor);
   }
@@ -1388,22 +1388,6 @@ public class FlixelCamera extends FlixelBasic {
       return Math.max(1, Gdx.graphics.getHeight());
     }
     return 1;
-  }
-
-  /** Target updates per second for follow lerp. Matches {@link FlixelGame#getFramerate()} when in FlixelGDX. */
-  private static float resolveTargetFramerate() {
-    FlixelGame game = Flixel.getGame();
-    if (game != null) {
-      int framerate = game.getFramerate();
-      return (framerate > 0) ? framerate : 60; // Just in case the framerate is unlocked so that way following works!
-    }
-    if (Gdx.graphics != null) {
-      int hz = Gdx.graphics.getDisplayMode().refreshRate;
-      if (hz > 0) {
-        return hz;
-      }
-    }
-    return 60f;
   }
 
   /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
@@ -231,7 +231,7 @@ public abstract class FlixelTween implements Pool.Poolable {
    */
   public static FlixelTween tween(Object object, FlixelTweenSettings tweenSettings) {
     Objects.requireNonNull(tweenSettings, "tweenSettings");
-    Array<FlixelTweenSettings.FlixelTweenVarGoal> varGoals = tweenSettings.getGoals();
+    Array<FlixelTweenSettings.FlixelTweenVarGoal> varGoals = tweenSettings.getVarGoals();
     Array<FlixelTweenSettings.FlixelTweenPropertyGoal> propGoals = tweenSettings.getPropertyGoals();
     boolean hasVar = varGoals != null && varGoals.size > 0;
     boolean hasProp = propGoals != null && propGoals.size > 0;
@@ -359,12 +359,12 @@ public abstract class FlixelTween implements Pool.Poolable {
    * @param tweenSettings The settings that configure and determine how the tween should animate.
    * @return The newly created and started tween.
    */
-  public static FlixelTween colorRaw(
+  public static FlixelTween color(
       @Nullable FlixelSprite sprite,
       @Nullable Color from,
       @Nullable Color to,
       FlixelTweenSettings tweenSettings) {
-    return colorRaw(sprite, from, to, tweenSettings, null);
+    return color(sprite, from, to, tweenSettings, null);
   }
 
   /**
@@ -382,7 +382,7 @@ public abstract class FlixelTween implements Pool.Poolable {
    * @param onColor The callback to run when the tween is complete.
    * @return The newly created and started tween.
    */
-  public static FlixelTween colorRaw(
+  public static FlixelTween color(
       @Nullable FlixelSprite sprite,
       @Nullable Color from,
       @Nullable Color to,
@@ -392,6 +392,50 @@ public abstract class FlixelTween implements Pool.Poolable {
     tween.setTweenSettings(tweenSettings);
     tween.setColorEndpointsRaw(sprite, from, to, onColor);
     return globalManager.addTween(tween);
+  }
+
+  /**
+   * Creates a new color tween using mixture of libGDX's {@link Color} and FlixelGDX's {@link FlixelColor} values with
+   * the provided settings and adds it to the global tween manager.
+   *
+   * <p>It's advised you use this method rather than directly changing the color of a sprite, as
+   * {@link FlixelColorTween} will handle the color interpolation and apply it to the sprite smoothly, rather
+   * than causing a flash or jump in color.
+   *
+   * @param sprite The sprite to tween the color of.
+   * @param from The starting color.
+   * @param to The ending color.
+   * @param tweenSettings The settings that configure and determine how the tween should animate.
+   * @return The newly created and started tween.
+   */
+  public static FlixelTween color(
+    @Nullable FlixelSprite sprite,
+    @Nullable FlixelColor from,
+    @Nullable Color to,
+    FlixelTweenSettings tweenSettings) {
+    return color(sprite, from.getGdxColor(), to, tweenSettings, null);
+  }
+
+  /**
+   * Creates a new color tween using mixture of libGDX's {@link Color} and FlixelGDX's {@link FlixelColor} values with
+   * the provided settings and adds it to the global tween manager.
+   *
+   * <p>It's advised you use this method rather than directly changing the color of a sprite, as
+   * {@link FlixelColorTween} will handle the color interpolation and apply it to the sprite smoothly, rather
+   * than causing a flash or jump in color.
+   *
+   * @param sprite The sprite to tween the color of.
+   * @param from The starting color.
+   * @param to The ending color.
+   * @param tweenSettings The settings that configure and determine how the tween should animate.
+   * @return The newly created and started tween.
+   */
+  public static FlixelTween color(
+    @Nullable FlixelSprite sprite,
+    @Nullable Color from,
+    @Nullable FlixelColor to,
+    FlixelTweenSettings tweenSettings) {
+    return color(sprite, from, to.getGdxColor(), tweenSettings, null);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelTweenSettings.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelTweenSettings.java
@@ -149,7 +149,7 @@ public class FlixelTweenSettings {
     return onComplete;
   }
 
-  public FlixelTweenVarGoal getGoal(String field) {
+  public FlixelTweenVarGoal getVarGoal(String field) {
     for (FlixelTweenVarGoal goal : goals) {
       if (goal.field().equals(field)) {
         return goal;
@@ -158,7 +158,7 @@ public class FlixelTweenSettings {
     return null;
   }
 
-  public Array<FlixelTweenVarGoal> getGoals() {
+  public Array<FlixelTweenVarGoal> getVarGoals() {
     return goals;
   }
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelVarTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelVarTween.java
@@ -111,7 +111,7 @@ public class FlixelVarTween extends FlixelTween {
       return this;
     }
 
-    Array<FlixelTweenSettings.FlixelTweenVarGoal> goals = tweenSettings.getGoals();
+    Array<FlixelTweenSettings.FlixelTweenVarGoal> goals = tweenSettings.getVarGoals();
     if (goals == null || goals.isEmpty()) {
       return this;
     }
@@ -166,7 +166,7 @@ public class FlixelVarTween extends FlixelTween {
   @Override
   public void restart() {
     if (!internalRestart && tweenSettings != null && object != null && !goalPaths.isEmpty()) {
-      Array<FlixelTweenSettings.FlixelTweenVarGoal> goals = tweenSettings.getGoals();
+      Array<FlixelTweenSettings.FlixelTweenVarGoal> goals = tweenSettings.getVarGoals();
       if (goals != null && !goals.isEmpty()) {
         initialValues.clear();
         tweenSettings.forEachGoal((fieldName, value) -> {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/ui/FlixelBar.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/ui/FlixelBar.java
@@ -94,7 +94,6 @@ public class FlixelBar extends FlixelSprite {
   // Value smoothing: 1 = snap, lower = smoother.
   private float lerp = 1f;
   private float lastElapsed = 1f / 60f;
-  private float cachedTargetFramerate = 60f;
 
   // Empty/fill rendering configuration.
   private final Color emptyColor = new Color(0f, 0f, 0f, 0.5f);
@@ -172,18 +171,12 @@ public class FlixelBar extends FlixelSprite {
     ensureWhitePixel();
   }
 
-  /**
-   * @throws UnsupportedOperationException always.
-   */
   @Override
   public final FlixelSprite loadGraphic(Texture texture, int frameWidth, int frameHeight) {
     throw new UnsupportedOperationException(
       "FlixelBar does not use loadGraphic; use setEmptyColor, setFilledColor, setEmptyGraphic, setFilledGraphic, or setGradient.");
   }
 
-  /**
-   * @throws UnsupportedOperationException always.
-   */
   @Override
   public final FlixelSprite makeGraphic(int width, int height, Color color) {
     throw new UnsupportedOperationException(
@@ -617,7 +610,6 @@ public class FlixelBar extends FlixelSprite {
   public void update(float elapsed) {
     super.update(elapsed);
     lastElapsed = elapsed;
-    cachedTargetFramerate = resolveTargetFramerate();
 
     if (maxSupplier != null) {
       float newMax = maxSupplier.getAsFloat();
@@ -981,7 +973,7 @@ public class FlixelBar extends FlixelSprite {
   private float resolveFrameRateIndependentLerp(float lerp, float elapsed) {
     // Copied conceptually from FlixelCamera.updateFollow. Converts lerp into a per-frame factor.
     elapsed = Math.max(0f, elapsed);
-    return 1f - (float) Math.pow(1f - lerp, elapsed * cachedTargetFramerate);
+    return 1f - (float) Math.pow(1f - lerp, elapsed * 60f);
   }
 
   private static float resolveTargetFramerate() {


### PR DESCRIPTION
## Description

This pull request fixes a bug where unlocked framerate could potentially cause the following system for `FlixelCamera` to break and not follow a `FlixelObject`, since it would be zero!

It also fixes some issues with `FlixelBar` acting weird when the framerate was set to be very high.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
