### PR TITLE
The follow() method for FlixelCamera no longer throws a NPE when the follow style is set to null

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -357,29 +357,30 @@ After the project is generated, add FlixelGDX and wire it in:
      ```java
      package com.example.flixeltest;
 
-    import com.example.flixeltest.MyTestState;
-    import com.example.flixeltest.FlixelTestGame;
-    import me.stringdotjar.flixelgdx.backend.lwjgl3.FlixelLwjgl3Launcher;
+     import com.example.flixeltest.MyTestState;
+     import com.example.flixeltest.FlixelTestGame;
+     import me.stringdotjar.flixelgdx.backend.lwjgl3.FlixelLwjgl3Launcher;
 
-    /** Launches the desktop (LWJGL3) application. */
-    public class Lwjgl3Launcher {
+     /** Launches the desktop (LWJGL3) application. */
+     public class Lwjgl3Launcher {
+ 
+       public static void main(String[] args) {
+         if (StartupHelper.startNewJvmIfRequired()) return; // This handles macOS support and helps on Windows.
+ 
+         // Create your game and pass the initial screen.
+         FlixelTestGame game = new FlixelTestGame(
+           "Flixel Test", 
+           800, 
+           600, 
+           new MyTestState()
+         );
+ 
+         // Launch the game using the FlixelGDX LWJGL3 launcher.
+         FlixelLwjgl3Launcher.launch(game);
+       }
+     }
+     ```
 
-      public static void main(String[] args) {
-        if (StartupHelper.startNewJvmIfRequired()) return; // This handles macOS support and helps on Windows.
-
-        // Create your game and pass the initial screen.
-        FlixelTestGame game = new FlixelTestGame(
-          "Flixel Test", 
-          800, 
-          600, 
-          new MyTestState()
-        );
-
-        // Launch the game using the FlixelGDX LWJGL3 launcher.
-        FlixelLwjgl3Launcher.launch(game);
-      }
-    }
-    ```
 7. **Refresh Gradle** in your IDE (e.g. “Reload All Gradle Projects” or Gradle sync). Resolve any import errors so that `FlixelGame`, `FlixelState`, and `Flixel` are found from `flixelgdx-core`, and `FlixelLwjgl3Launcher` from `flixelgdx-lwjgl3`.
 8. **Run the desktop launcher.**
   Run the **lwjgl3** run configuration with the main class set to your launcher (e.g. `FlixelTestLauncher`). You should see your state. If you added Android/iOS/HTML, run the corresponding launcher or Gradle task for that platform to test there as well.

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
@@ -452,7 +452,7 @@ public class FlixelCamera extends FlixelBasic {
    */
   public void follow(FlixelObject target, FollowStyle style, float lerp) {
     this.target = target;
-    this.style = style;
+    this.style = style != null ? style : FollowStyle.LOCKON;
     this.followLerp = lerp;
     updateDeadzoneForStyle();
   }
@@ -577,6 +577,10 @@ public class FlixelCamera extends FlixelBasic {
   }
 
   private void updateDeadzoneForStyle() {
+    if (style == null) {
+      return;
+    }
+
     float vw = getViewWidth();
     float vh = getViewHeight();
     float w, h;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/GdxHeadlessExtension.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/GdxHeadlessExtension.java
@@ -16,7 +16,7 @@ import com.badlogic.gdx.backends.headless.HeadlessApplication;
 import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
 
 /**
- * Starts a minimal libGDX headless application so {@link Gdx#app} and related statics are valid for tests.
+ * Starts a minimal libGDX headless application so {@link com.badlogic.gdx.Gdx#app} and related statics are valid for tests.
  */
 public final class GdxHeadlessExtension implements BeforeAllCallback, AfterAllCallback {
 


### PR DESCRIPTION
## Description

Closes #141 

This PR fixes a bug that crashed a FlixelGDX game when the `FollowStyle` for a `FlixelCamera` was set to null.

It also makes a slight typo fix in the `README` file that made a specific code block look malformed due to the indention.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
