### PR TITLE
FlixelAnimateSprite graphics no longer shift away from its hitbox origin when a `FlixelCamera` zooms in or out

### DIFF
--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
@@ -837,10 +837,6 @@ public final class Flixel {
     return state;
   }
 
-  public static FlixelSound getMusic() {
-    return sound.getMusic();
-  }
-
   public static Vector2 getWindowSize() {
     return game.windowSize;
   }

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateSprite.java
@@ -45,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
  * player sees.
  *
  * <h2>Example</h2>
- * <pre>
+ * <pre>{@code
  * FlixelAnimateSprite fas = new FlixelAnimateSprite();
  * fas.loadSpritemapAndAnimation(
  *     "path/to/atlas/spritemap1.png",
@@ -57,6 +57,7 @@ import org.jetbrains.annotations.Nullable;
  * fas.screenCenter();
  * fas.animation.playAnimation("Animation Name");
  * add(fas);
+ * }
  * </pre>
  *
  * <h2>Merging multiple atlases</h2>

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateSprite.java
@@ -440,8 +440,8 @@ public class FlixelAnimateSprite extends FlixelSprite {
 
     // World position with scroll factor (matches FlixelSprite.draw() / FlixelObject.getDrawX()).
     FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.getCamera();
-    float wx = getX() - cam.scroll.x * getScrollX() - getOffsetX();
-    float wy = getY() - cam.scroll.y * getScrollY() - getOffsetY();
+    float wx = cam.worldToViewX(getX(), scrollX);
+    float wy = cam.worldToViewY(getY(), scrollY);
 
     // Match FlixelSprite's flip-into-scale convention: a negative scale on either axis mirrors the
     // sprite around its origin, and the facing flag piles on top of the user-set flipX.
@@ -475,7 +475,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
     // +origin_world, then translates to the world position. Identity branches are skipped so the
     // no-rotation/no-scale fast path stays cheap.
     baseAffine.idt();
-    baseAffine.translate(wx, wy);
+    baseAffine.translate(wx - getOffsetX(), wy - getOffsetY());
     if (hasOrigin) {
       baseAffine.translate(ox, oy);
     }

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
@@ -35,7 +35,9 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
   private Object musicGroup;
 
   private float masterVolume = 1f;
-  private FlixelSound music;
+
+  @Nullable
+  public FlixelSound music;
 
   /**
    * Constructs a new audio manager using the given backend factory.
@@ -110,16 +112,6 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
   @NotNull
   public Object getSoundsGroup() {
     return sfxGroup;
-  }
-
-  /**
-   * Returns the currently playing music, or {@code null} if none.
-   *
-   * @return The current music sound, or {@code null}.
-   */
-  @Nullable
-  public FlixelSound getMusic() {
-    return music;
   }
 
   /**
@@ -350,7 +342,7 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
   }
 
   @Override
-  public void dispose() {
+  public final void dispose() {
     destroy();
   }
 }


### PR DESCRIPTION
## Description

Closes #140 

This pull request fixes a small bug with `FlixelAnimateSprite` that caused its graphic to shift away from its hitboxes' origin when a `FlixelCamera` was zoomed in or out.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [ ] My code follows the code style of this project (if any code was added or changed).
- [ ] I have performed a self-review of my own code (if any code was added or changed).
- [ ] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
