### PR TITLE
Fixed a fatal crash that would cause games running on TeaVM to freeze if a malformed path was passed down

### DIFF
--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelSpritemapJsonLoader.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelSpritemapJsonLoader.java
@@ -17,6 +17,7 @@ import com.badlogic.gdx.utils.JsonValue;
 import com.badlogic.gdx.utils.ObjectMap;
 
 import me.stringdotjar.flixelgdx.Flixel;
+import me.stringdotjar.flixelgdx.asset.FlixelAssetPaths;
 import me.stringdotjar.flixelgdx.graphics.FlixelFrame;
 import me.stringdotjar.flixelgdx.graphics.FlixelGraphic;
 
@@ -62,6 +63,7 @@ public final class FlixelSpritemapJsonLoader {
     if (path.isEmpty()) {
       throw new IllegalArgumentException("path cannot be empty.");
     }
+    path = FlixelAssetPaths.normalizeAssetPath(path);
     FileHandle f = Gdx.files.internal(path);
     if (f.exists() && !f.isDirectory()) {
       return f;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
@@ -29,6 +29,9 @@ import org.jetbrains.annotations.Nullable;
  * ambiguous if extensions collide or custom content is used—register mappings with
  * {@link #registerExtension(String, Function)} or use {@link #load(FlixelSource)} instead.
  *
+ * <p>The default implementation canonicalizes path-shaped keys (see {@link FlixelAssetPaths#normalizeAssetPath(String)})
+ * so duplicate slashes or mixed separators do not break lookups on backends that compare paths literally (such as web manifests).
+ *
  * <p><b>If you ever forget which method to use when it comes to handles, here's a quick reminder:</b>
  * <ul>
  *   <li><b>{@code peek...}</b>: “Is there already a handle for this key?” This should be read only; it may return {@code null}.

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetPaths.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetPaths.java
@@ -1,0 +1,87 @@
+/**********************************************************************************
+ * Copyright (c) 2025-2026 stringdotjar
+ *
+ * This file is part of the FlixelGDX framework, licensed under the MIT License.
+ * See the LICENSE file in the repository root for full license information.
+ **********************************************************************************/
+
+package me.stringdotjar.flixelgdx.asset;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Canonical path helpers for internal asset keys used with {@link FlixelAssetManager} and libGDX file APIs.
+ *
+ * <p>Accidentally duplicated slashes (for example {@code "ui//mainmenu/bg.png"}) or backslashes can confuse loaders,
+ * especially on HTML backends where manifest paths often match internal keys literally.
+ *
+ * <p>This helper collapses duplicate separators into one forward slash and maps {@code '\'} to {@code '/'}, matching the
+ * common layout used inside {@code assets/}. Call sites include {@link FlixelDefaultAssetManager}.
+ *
+ * <p><b>Note:</b> This is aimed at internal resource paths such as {@code "fonts/foo.ttf"}, not arbitrary URLs or UNC paths.
+ */
+public final class FlixelAssetPaths {
+
+  private FlixelAssetPaths() {}
+
+  /**
+   * Returns the same path with redundant slashes collapsed and backslashes converted to forward slashes.
+   *
+   * <p>If the input already looks canonical, the original reference may be returned to avoid allocating.
+   *
+   * @param path Internal asset path. Must not be {@code null}.
+   * @return Canonical internal-style path (never {@code null}; empty stays empty).
+   */
+  @NotNull
+  public static String normalizeAssetPath(@NotNull String path) {
+    Objects.requireNonNull(path, "path cannot be null.");
+    if (path.isEmpty()) {
+      return path;
+    }
+    if (!needsNormalization(path)) {
+      return path;
+    }
+
+    int n = path.length();
+    StringBuilder sb = new StringBuilder(n);
+    boolean prevSlash = false;
+    for (int i = 0; i < n; i++) {
+      char c = path.charAt(i);
+      if (c == '\\') {
+        c = '/';
+      }
+      if (c == '/') {
+        if (prevSlash) {
+          continue;
+        }
+        prevSlash = true;
+      } else {
+        prevSlash = false;
+      }
+      sb.append(c);
+    }
+    return sb.toString();
+  }
+
+  private static boolean needsNormalization(@NotNull String path) {
+    int n = path.length();
+    boolean prevSlash = false;
+    for (int i = 0; i < n; i++) {
+      char c = path.charAt(i);
+      if (c == '\\') {
+        return true;
+      }
+      if (c == '/') {
+        if (prevSlash) {
+          return true;
+        }
+        prevSlash = true;
+      } else {
+        prevSlash = false;
+      }
+    }
+    return false;
+  }
+}

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -147,7 +147,7 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
    * If a new {@link FlixelAsset} or {@link FlixelGraphic} handle is created for this key before the
    * pending entry is consumed, that handle is marked persistent. Call {@code load(path, true)} to
    * mark path-keyed assets that should survive {@link #clearNonPersist()}.
-   * 
+   *
    * @param assetKey The asset key.
    * @param handle The handle to apply the pending persist on.
    */
@@ -157,11 +157,26 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     }
   }
 
-  @Override
-  public void load(@NotNull String path) {
-    if (path == null || path.isEmpty()) {
+  /**
+   * Normalizes an incoming asset path (collapse redundant slashes, unify separators) and rejects empty keys.
+   *
+   * @param path Raw path from callers.
+   * @return Canonical internal-style path.
+   */
+  @NotNull
+  private static String requireNormalizedAssetPath(@NotNull String path) {
+    Objects.requireNonNull(path, "path cannot be null.");
+    path = FlixelAssetPaths.normalizeAssetPath(path);
+    if (path.isEmpty()) {
       throw new IllegalArgumentException("path cannot be null/empty.");
     }
+    return path;
+  }
+
+  /**
+   * Infers a {@link FlixelSource} from the extension registry and enqueues it. {@code path} must already be normalized.
+   */
+  private void loadByInferExtension(@NotNull String path) {
     String ext = fileExtensionFromPath(path);
     if (ext.isEmpty()) {
       throw new IllegalArgumentException(
@@ -184,43 +199,62 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   }
 
   @Override
+  public void load(@NotNull String path) {
+    loadByInferExtension(requireNormalizedAssetPath(path));
+  }
+
+  @Override
   public void load(@NotNull String path, boolean persist) {
+    path = requireNormalizedAssetPath(path);
     if (persist) {
       pendingPersistKeys.add(path);
     }
-    load(path);
+    loadByInferExtension(path);
   }
 
   @Override
   public void load(@NotNull FlixelSource<?> source, boolean persist) {
+    Objects.requireNonNull(source, "source cannot be null.");
+    String key = requireNormalizedAssetPath(source.getAssetKey());
     if (persist) {
-      pendingPersistKeys.add(source.getAssetKey());
+      pendingPersistKeys.add(key);
     }
-    load(source);
+    manager.load(key, source.getType());
   }
 
   @Override
   public <T> void load(@NotNull String fileName, @NotNull Class<T> type, boolean persist) {
+    Objects.requireNonNull(fileName, "fileName cannot be null.");
+    Objects.requireNonNull(type, "type cannot be null.");
+    fileName = requireNormalizedAssetPath(fileName);
     if (persist) {
       pendingPersistKeys.add(fileName);
     }
-    load(fileName, type);
+    manager.load(fileName, type);
   }
 
   @Override
   public <T> void load(@NotNull String fileName, @NotNull Class<T> type) {
-    manager.load(fileName, type);
+    Objects.requireNonNull(fileName, "fileName cannot be null.");
+    Objects.requireNonNull(type, "type cannot be null.");
+    manager.load(requireNormalizedAssetPath(fileName), type);
   }
 
   @Override
   public void load(@NotNull FlixelSource<?> source) {
     Objects.requireNonNull(source, "source cannot be null.");
-    load(source.getAssetKey(), source.getType());
+    manager.load(requireNormalizedAssetPath(source.getAssetKey()), source.getType());
   }
 
   @Override
   public void load(@NotNull AssetDescriptor<?> assetDescriptor) {
-    manager.load(assetDescriptor);
+    Objects.requireNonNull(assetDescriptor, "assetDescriptor cannot be null.");
+    String fn = FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(assetDescriptor.fileName, "assetDescriptor.fileName cannot be null."));
+    if (fn.equals(assetDescriptor.fileName)) {
+      manager.load(assetDescriptor);
+    } else {
+      manager.load(new AssetDescriptor<>(fn, assetDescriptor.type, assetDescriptor.params));
+    }
   }
 
   @Override
@@ -266,12 +300,13 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
 
   @Override
   public boolean isLoaded(@NotNull String fileName) {
-    return manager.isLoaded(fileName);
+    return manager.isLoaded(FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(fileName, "fileName cannot be null.")));
   }
 
   @Override
   public boolean isLoaded(@NotNull String fileName, @NotNull Class<?> type) {
-    return manager.isLoaded(fileName, type);
+    Objects.requireNonNull(type, "type cannot be null.");
+    return manager.isLoaded(FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(fileName, "fileName cannot be null.")), type);
   }
 
   @Override
@@ -285,7 +320,9 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @NotNull
   @Override
   public <T> T get(@NotNull String fileName, @NotNull Class<T> type) {
-    return manager.get(fileName, type);
+    Objects.requireNonNull(fileName, "fileName cannot be null.");
+    Objects.requireNonNull(type, "type cannot be null.");
+    return manager.get(FlixelAssetPaths.normalizeAssetPath(fileName), type);
   }
 
   @NotNull
@@ -309,6 +346,7 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @NotNull
   @Override
   public String resolveAudioPath(@NotNull String path) {
+    path = FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(path, "path cannot be null."));
     String cached = audioPathCache.get(path);
     if (cached != null) {
       return cached;
@@ -321,7 +359,8 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @NotNull
   @Override
   public String extractAssetPath(@NotNull String path) {
-    // On web/TeaVM, audio is loaded via Gdx.files.internal() which reads from
+    path = FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(path, "path cannot be null."));
+    // On web/TeaVM, audio is loaded via Gdx.files.internal(...) which reads from
     // the virtual filesystem populated by the preloader, which does not require filesystem extraction.
     // This is because browsers don't actually have a real filesystem, so we simply return the path as is.
     if (Gdx.app != null && Gdx.app.getType() == Application.ApplicationType.WebGL) {
@@ -353,7 +392,7 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
 
   @Override
   public void unload(@NotNull String fileName) {
-    manager.unload(fileName);
+    manager.unload(FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(fileName, "fileName cannot be null.")));
   }
 
   @Override
@@ -363,7 +402,7 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
 
   @Override
   public void finishLoadingAsset(@NotNull String fileName) {
-    manager.finishLoadingAsset(fileName);
+    manager.finishLoadingAsset(FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(fileName, "fileName cannot be null.")));
   }
 
   @NotNull
@@ -458,12 +497,13 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
    * {@link FlixelTypedAsset} if present, else {@link FlixelGraphic} for textures.
    */
   private int flixelRefCountForLoadedAsset(@NotNull String fileName, @NotNull Class<?> type) {
-    FlixelAsset<?> typed = peekTypedAsset(fileName, type);
+    String key = FlixelAssetPaths.normalizeAssetPath(fileName);
+    FlixelAsset<?> typed = peekTypedAsset(key, type);
     if (typed != null) {
       return typed.getRefCount();
     }
     if (type == Texture.class) {
-      FlixelGraphic g = peekWrapper(fileName, FlixelGraphic.class);
+      FlixelGraphic g = peekWrapper(key, FlixelGraphic.class);
       return g != null ? g.getRefCount() : 0;
     }
     return 0;
@@ -549,6 +589,11 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @Override
   @SuppressWarnings("unchecked")
   public <W> W ensureWrapper(@NotNull String key, @NotNull Class<W> wrapperType) {
+    Objects.requireNonNull(key, "key cannot be null.");
+    key = FlixelAssetPaths.normalizeAssetPath(key);
+    if (key.isEmpty()) {
+      throw new IllegalArgumentException("key cannot be null/empty.");
+    }
     FlixelWrapperFactory<?> f = wrapperFactories.get(wrapperType);
     if (f == null) {
       throw new IllegalArgumentException("No wrapper factory registered for: " + wrapperType.getName());
@@ -574,13 +619,19 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     if (f == null) {
       throw new IllegalArgumentException("No wrapper factory registered for: " + wrapperType.getName());
     }
-    return ((FlixelWrapperFactory<W>) f).peek(this, key);
+    return ((FlixelWrapperFactory<W>) f).peek(this, FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(key, "key cannot be null.")));
   }
 
   @NotNull
   @Override
   @SuppressWarnings("unchecked")
   public <T> FlixelAsset<T> ensureTypedAsset(@NotNull String assetKey, @NotNull Class<T> type) {
+    Objects.requireNonNull(assetKey, "assetKey cannot be null.");
+    Objects.requireNonNull(type, "type cannot be null.");
+    assetKey = FlixelAssetPaths.normalizeAssetPath(assetKey);
+    if (assetKey.isEmpty()) {
+      throw new IllegalArgumentException("assetKey cannot be null/empty.");
+    }
     AssetId id = new AssetId(assetKey, type);
     FlixelTypedAsset<?> existing = typedAssetCache.get(id);
     if (existing != null) {
@@ -603,7 +654,9 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   @Nullable
   @Override
   public FlixelAsset<?> peekTypedAsset(@NotNull String assetKey, @NotNull Class<?> type) {
-    return typedAssetCache.get(new AssetId(assetKey, type));
+    Objects.requireNonNull(assetKey, "assetKey cannot be null.");
+    Objects.requireNonNull(type, "type cannot be null.");
+    return typedAssetCache.get(new AssetId(FlixelAssetPaths.normalizeAssetPath(assetKey), type));
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelStringAssetSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelStringAssetSource.java
@@ -24,7 +24,7 @@ public final class FlixelStringAssetSource implements FlixelSource<String> {
     if (assetKey == null || assetKey.isEmpty()) {
       throw new IllegalArgumentException("assetKey cannot be null/empty.");
     }
-    this.assetKey = assetKey;
+    this.assetKey = FlixelAssetPaths.normalizeAssetPath(assetKey);
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
@@ -7,6 +7,10 @@
 
 package me.stringdotjar.flixelgdx.asset;
 
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Application.ApplicationType;
+import com.badlogic.gdx.assets.AssetManager;
+
 import java.util.Objects;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSource.java
@@ -9,6 +9,7 @@ package me.stringdotjar.flixelgdx.audio;
 
 import com.badlogic.gdx.files.FileHandle;
 import me.stringdotjar.flixelgdx.Flixel;
+import me.stringdotjar.flixelgdx.asset.FlixelAssetPaths;
 import me.stringdotjar.flixelgdx.asset.FlixelSource;
 import me.stringdotjar.flixelgdx.util.FlixelPathsUtil;
 import org.jetbrains.annotations.NotNull;
@@ -47,7 +48,7 @@ public final class FlixelSoundSource implements FlixelSource<FlixelSoundSource> 
     if (assetKey == null || assetKey.isEmpty()) {
       throw new IllegalArgumentException("assetKey cannot be null/empty");
     }
-    this.assetKey = assetKey;
+    this.assetKey = external ? assetKey : FlixelAssetPaths.normalizeAssetPath(assetKey);
     this.external = external;
   }
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelShakeable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelShakeable.java
@@ -8,6 +8,7 @@
 package me.stringdotjar.flixelgdx.functional;
 
 import com.badlogic.gdx.Gdx;
+import me.stringdotjar.flixelgdx.tween.settings.FlixelShakeUnit;
 
 /**
  * Something {@link me.stringdotjar.flixelgdx.tween.type.FlixelShakeTween} can jitter and restore without caring whether
@@ -45,7 +46,7 @@ public interface FlixelShakeable {
   void setShake(float x, float y);
 
   /**
-   * Width used to scale {@link me.stringdotjar.flixelgdx.tween.type.FlixelShakeTween.ShakeUnit#FRACTION} on the X axis.
+   * Width used to scale {@link FlixelShakeUnit#FRACTION} on the X axis.
    * Values {@code 0} or less mean the tween treats intensity like plain pixels on that axis.
    *
    * @return Reference width for fractional shake, or non-positive to fall back.
@@ -55,7 +56,7 @@ public interface FlixelShakeable {
   }
 
   /**
-   * Height used to scale {@link me.stringdotjar.flixelgdx.tween.type.FlixelShakeTween.ShakeUnit#FRACTION} on the Y axis.
+   * Height used to scale {@link FlixelShakeUnit#FRACTION} on the Y axis.
    * Values {@code 0} or less mean the tween treats intensity like plain pixels on that axis.
    *
    * @return Reference height for fractional shake, or non-positive to fall back.

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicSource.java
@@ -11,6 +11,7 @@ import com.badlogic.gdx.graphics.Texture;
 
 import me.stringdotjar.flixelgdx.Flixel;
 import me.stringdotjar.flixelgdx.asset.FlixelAssetManager;
+import me.stringdotjar.flixelgdx.asset.FlixelAssetPaths;
 import me.stringdotjar.flixelgdx.asset.FlixelWrapperSource;
 
 import org.jetbrains.annotations.NotNull;
@@ -33,7 +34,7 @@ public final class FlixelGraphicSource implements FlixelWrapperSource<Texture, F
     if (assetKey == null || assetKey.isEmpty()) {
       throw new IllegalArgumentException("Asset key cannot be null/empty.");
     }
-    this.assetKey = assetKey;
+    this.assetKey = FlixelAssetPaths.normalizeAssetPath(assetKey);
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
@@ -22,6 +22,7 @@ import me.stringdotjar.flixelgdx.functional.FlixelShakeable;
 import me.stringdotjar.flixelgdx.functional.FlixelVisible;
 import me.stringdotjar.flixelgdx.tween.builders.FlixelAbstractTweenBuilder;
 import me.stringdotjar.flixelgdx.tween.builders.FlixelPropertyTweenBuilder;
+import me.stringdotjar.flixelgdx.tween.settings.FlixelShakeUnit;
 import me.stringdotjar.flixelgdx.tween.settings.FlixelTweenSettings;
 import me.stringdotjar.flixelgdx.tween.settings.FlixelTweenType;
 import me.stringdotjar.flixelgdx.tween.type.FlixelAngleTween;
@@ -441,13 +442,13 @@ public abstract class FlixelTween implements Pool.Poolable {
   }
 
   /**
-   * Creates a shake tween using defaults {@link FlixelShakeTween.ShakeUnit#FRACTION} and
+   * Creates a shake tween using defaults {@link FlixelShakeUnit#FRACTION} and
    * {@code fadeOut == false} (full strength each frame until the tween ends). Pooled instances
    * are reset to those defaults before configuration.
    *
    * @param shakeable The shake channel to jitter (sprite offset, object position, window, etc.).
    * @param axes Axes that receive position jitter.
-   * @param intensity With {@link FlixelShakeTween.ShakeUnit#FRACTION}, use a small value (for example 0.05f).
+   * @param intensity With {@link FlixelShakeUnit#FRACTION}, use a small value (for example 0.05f).
    * @param tweenSettings Duration, ease, and callbacks.
    * @return The new tween, already added to the global manager.
    */
@@ -456,17 +457,17 @@ public abstract class FlixelTween implements Pool.Poolable {
       FlixelAxes axes,
       float intensity,
       FlixelTweenSettings tweenSettings) {
-    return shake(shakeable, axes, intensity, tweenSettings, FlixelShakeTween.ShakeUnit.FRACTION, false);
+    return shake(shakeable, axes, intensity, tweenSettings, FlixelShakeUnit.FRACTION, false);
   }
 
   /**
-   * Creates a shake tween with explicit {@link FlixelShakeTween.ShakeUnit} and fade-out taper.
+   * Creates a shake tween with explicit {@link FlixelShakeUnit} and fade-out taper.
    *
    * @param shakeable The shake channel to jitter.
    * @param axes Axes that receive position jitter.
    * @param intensity Interpretation depends on {@code shakeUnit}.
    * @param tweenSettings Duration, ease, and callbacks.
-   * @param shakeUnit {@link FlixelShakeTween.ShakeUnit#FRACTION} or {@link FlixelShakeTween.ShakeUnit#PIXELS}.
+   * @param shakeUnit {@link FlixelShakeUnit#FRACTION} or {@link FlixelShakeUnit#PIXELS}.
    * @param fadeOut If true, amplitude is scaled by {@code (1 - scale)} toward the end of the tween.
    * @return The new tween, already added to the global manager.
    */
@@ -475,7 +476,7 @@ public abstract class FlixelTween implements Pool.Poolable {
       FlixelAxes axes,
       float intensity,
       FlixelTweenSettings tweenSettings,
-      FlixelShakeTween.ShakeUnit shakeUnit,
+      FlixelShakeUnit shakeUnit,
       boolean fadeOut) {
     FlixelShakeTween tween = globalManager.obtainTween(FlixelShakeTween.class, () -> new FlixelShakeTween(tweenSettings));
     tween.setTweenSettings(tweenSettings);

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/builders/FlixelShakeTweenBuilder.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/builders/FlixelShakeTweenBuilder.java
@@ -10,13 +10,13 @@ package me.stringdotjar.flixelgdx.tween.builders;
 import me.stringdotjar.flixelgdx.functional.FlixelShakeable;
 import me.stringdotjar.flixelgdx.tween.settings.FlixelTweenSettings;
 import me.stringdotjar.flixelgdx.tween.type.FlixelShakeTween;
-import me.stringdotjar.flixelgdx.tween.type.FlixelShakeTween.ShakeUnit;
+import me.stringdotjar.flixelgdx.tween.settings.FlixelShakeUnit;
 import me.stringdotjar.flixelgdx.util.FlixelAxes;
 
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Fluent builder for {@link FlixelShakeTween}. Defaults are {@link ShakeUnit#FRACTION} with intensity
+ * Fluent builder for {@link FlixelShakeTween}. Defaults are {@link FlixelShakeUnit#FRACTION} with intensity
  * {@code 0.05f}, no fade-out taper.
  */
 public final class FlixelShakeTweenBuilder extends FlixelAbstractTweenBuilder<FlixelShakeTween, FlixelShakeTweenBuilder> {
@@ -24,7 +24,7 @@ public final class FlixelShakeTweenBuilder extends FlixelAbstractTweenBuilder<Fl
   private @Nullable FlixelShakeable target;
   private FlixelAxes axes = FlixelAxes.XY;
   private float intensity = 0.05f;
-  private ShakeUnit shakeUnit = ShakeUnit.FRACTION;
+  private FlixelShakeUnit shakeUnit = FlixelShakeUnit.FRACTION;
   private boolean fadeOut = false;
 
   @Override
@@ -43,8 +43,8 @@ public final class FlixelShakeTweenBuilder extends FlixelAbstractTweenBuilder<Fl
   }
 
   /**
-   * Maximum shake amount. Meaning depends on the {@link #setShakeUnit(ShakeUnit)} setting.
-   * Default {@code 0.05f} is appropriate for {@link ShakeUnit#FRACTION} when the target is a
+   * Maximum shake amount. Meaning depends on the {@link #setShakeUnit(FlixelShakeUnit)} setting.
+   * Default {@code 0.05f} is appropriate for {@link FlixelShakeUnit#FRACTION} when the target is a
    * {@link me.stringdotjar.flixelgdx.FlixelObject} or {@link me.stringdotjar.flixelgdx.FlixelSprite}.
    */
   public FlixelShakeTweenBuilder setIntensity(float intensity) {
@@ -53,11 +53,11 @@ public final class FlixelShakeTweenBuilder extends FlixelAbstractTweenBuilder<Fl
   }
 
   /**
-   * {@link ShakeUnit#FRACTION} by default (see {@link me.stringdotjar.flixelgdx.functional.FlixelShakeable#getShakeWidth()}).
-   * Use {@link ShakeUnit#PIXELS} for absolute pixel half-range.
+   * {@link FlixelShakeUnit#FRACTION} by default (see {@link me.stringdotjar.flixelgdx.functional.FlixelShakeable#getShakeWidth()}).
+   * Use {@link FlixelShakeUnit#PIXELS} for absolute pixel half-range.
    */
-  public FlixelShakeTweenBuilder setShakeUnit(ShakeUnit shakeUnit) {
-    this.shakeUnit = shakeUnit != null ? shakeUnit : ShakeUnit.FRACTION;
+  public FlixelShakeTweenBuilder setShakeUnit(FlixelShakeUnit shakeUnit) {
+    this.shakeUnit = shakeUnit != null ? shakeUnit : FlixelShakeUnit.FRACTION;
     return self();
   }
 

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelShakeUnit.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelShakeUnit.java
@@ -1,0 +1,34 @@
+package me.stringdotjar.flixelgdx.tween.settings;
+
+import me.stringdotjar.flixelgdx.functional.FlixelShakeable;
+import me.stringdotjar.flixelgdx.tween.type.FlixelShakeTween;
+import me.stringdotjar.flixelgdx.util.FlixelAxes;
+
+/**
+ * How {@link FlixelShakeTween#intensity} maps to maximum offset per axis.
+ *
+ * <p>{@link #FRACTION} scales horizontal range by {@link FlixelShakeable#getShakeWidth()} and vertical range by
+ * {@link FlixelShakeable#getShakeHeight()} when those return values greater than zero (per axis enabled by
+ * {@link FlixelAxes}). Typical values are small, for example {@code 0.05f}.
+ *
+ * <p>{@link #PIXELS} sets the half-range in pixels on each active axis (random offset in {@code [-intensity, +intensity]}).
+ */
+public enum FlixelShakeUnit {
+
+  /**
+   * Scale intensity by {@link FlixelShakeable#getShakeWidth()} (X) and
+   * {@link FlixelShakeable#getShakeHeight()} (Y) when positive. This is the default value.
+   *
+   * <p>Use this if you're familiar with HaxeFlixel and want to use the same behavior.
+   */
+  FRACTION,
+
+  /**
+   * Treat intensity as pixel magnitude on each shaken axis.
+   *
+   * <p>Use this if you want to directly set the half-range in pixels on each active
+   * axis (random offset in {@code [-intensity, +intensity]}) and you're used to how
+   * Unity or Godot shakes objects.
+   */
+  PIXELS
+}

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelShakeTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelShakeTween.java
@@ -13,6 +13,7 @@ import com.badlogic.gdx.math.MathUtils;
 
 import me.stringdotjar.flixelgdx.functional.FlixelShakeable;
 import me.stringdotjar.flixelgdx.tween.FlixelTween;
+import me.stringdotjar.flixelgdx.tween.settings.FlixelShakeUnit;
 import me.stringdotjar.flixelgdx.tween.settings.FlixelTweenSettings;
 import me.stringdotjar.flixelgdx.util.FlixelAxes;
 
@@ -25,8 +26,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Intensity can be interpreted as a fraction of {@link FlixelShakeable#getShakeWidth()} /
  * {@link FlixelShakeable#getShakeHeight()} (HaxeFlixel-style when those return positive sizes), or as plain
- * pixels (Unity or Godot style). When {@link ShakeUnit#FRACTION} is used and a size hook returns {@code 0} or less on an
- * axis, that axis falls back to treating intensity like {@link ShakeUnit#PIXELS}. Use {@link #setShakeUnit(ShakeUnit)} and
+ * pixels (Unity or Godot style). When {@link FlixelShakeUnit#FRACTION} is used and a size hook returns {@code 0} or less on an
+ * axis, that axis falls back to treating intensity like {@link FlixelShakeUnit#PIXELS}. Use {@link #setShakeUnit(FlixelShakeUnit)} and
  * {@link #setFadeOut(boolean)} to configure behavior after {@link #setShake(FlixelShakeable, FlixelAxes, float)} or alongside
  * it.
  */
@@ -34,7 +35,7 @@ public class FlixelShakeTween extends FlixelTween {
 
   protected @Nullable FlixelShakeable target;
   protected FlixelAxes axes = FlixelAxes.XY;
-  protected ShakeUnit shakeUnit = ShakeUnit.FRACTION;
+  protected FlixelShakeUnit shakeUnit = FlixelShakeUnit.FRACTION;
   protected float intensity = 0.05f;
   protected boolean fadeOut = false;
   protected float savedX;
@@ -46,15 +47,15 @@ public class FlixelShakeTween extends FlixelTween {
 
   /**
    * Sets target, axes, and intensity. Does not change {@link #shakeUnit} or {@link #fadeOut}; those
-   * stay at defaults from {@link #reset()} ({@link ShakeUnit#FRACTION}, fade out false) until you set
-   * them with {@link #setShakeUnit(ShakeUnit)} or {@link #setFadeOut(boolean)}. Call order is free:
+   * stay at defaults from {@link #reset()} ({@link FlixelShakeUnit#FRACTION}, fade out false) until you set
+   * them with {@link #setShakeUnit(FlixelShakeUnit)} or {@link #setFadeOut(boolean)}. Call order is free:
    * you may chain before or after this method.
    *
    * @param target The object whose shake channel is jittered.
    * @param axes Which axes receive random offset.
-   * @param intensity With {@link ShakeUnit#FRACTION} and positive {@link FlixelShakeable#getShakeWidth()} /
+   * @param intensity With {@link FlixelShakeUnit#FRACTION} and positive {@link FlixelShakeable#getShakeWidth()} /
    *   {@link FlixelShakeable#getShakeHeight()}, use a small value (for example 0.05f). With
-   *   {@link ShakeUnit#PIXELS}, use half-range in pixels.
+   *   {@link FlixelShakeUnit#PIXELS}, use half-range in pixels.
    * @return this tween for chaining.
    */
   public FlixelShakeTween setShake(@Nullable FlixelShakeable target, FlixelAxes axes, float intensity) {
@@ -65,12 +66,12 @@ public class FlixelShakeTween extends FlixelTween {
   }
 
   /**
-   * Sets how {@link #intensity} is interpreted. Default is {@link ShakeUnit#FRACTION}.
+   * Sets how {@link #intensity} is interpreted. Default is {@link FlixelShakeUnit#FRACTION}.
    *
    * @return this tween for chaining.
    */
-  public FlixelShakeTween setShakeUnit(ShakeUnit shakeUnit) {
-    this.shakeUnit = shakeUnit != null ? shakeUnit : ShakeUnit.FRACTION;
+  public FlixelShakeTween setShakeUnit(FlixelShakeUnit shakeUnit) {
+    this.shakeUnit = shakeUnit != null ? shakeUnit : FlixelShakeUnit.FRACTION;
     return this;
   }
 
@@ -85,7 +86,7 @@ public class FlixelShakeTween extends FlixelTween {
     return this;
   }
 
-  public ShakeUnit getShakeUnit() {
+  public FlixelShakeUnit getShakeUnit() {
     return shakeUnit;
   }
 
@@ -121,7 +122,7 @@ public class FlixelShakeTween extends FlixelTween {
     if (axes == FlixelAxes.Y) {
       return 0f;
     }
-    if (shakeUnit == ShakeUnit.PIXELS) {
+    if (shakeUnit == FlixelShakeUnit.PIXELS) {
       return Math.max(0f, intensity);
     }
     if (target == null) {
@@ -139,7 +140,7 @@ public class FlixelShakeTween extends FlixelTween {
     if (axes == FlixelAxes.X) {
       return 0f;
     }
-    if (shakeUnit == ShakeUnit.PIXELS) {
+    if (shakeUnit == FlixelShakeUnit.PIXELS) {
       return Math.max(0f, intensity);
     }
     if (target == null) {
@@ -158,7 +159,7 @@ public class FlixelShakeTween extends FlixelTween {
     super.reset();
     target = null;
     axes = FlixelAxes.XY;
-    shakeUnit = ShakeUnit.FRACTION;
+    shakeUnit = FlixelShakeUnit.FRACTION;
     intensity = 0.05f;
     fadeOut = false;
     savedX = 0f;
@@ -188,32 +189,4 @@ public class FlixelShakeTween extends FlixelTween {
     return Objects.equals(object, target) && "shake".equals(field);
   }
 
-  /**
-   * How {@link FlixelShakeTween#intensity} maps to maximum offset per axis.
-   *
-   * <p>{@link #FRACTION} scales horizontal range by {@link FlixelShakeable#getShakeWidth()} and vertical range by
-   * {@link FlixelShakeable#getShakeHeight()} when those return values greater than zero (per axis enabled by
-   * {@link FlixelAxes}). Typical values are small, for example {@code 0.05f}.
-   *
-   * <p>{@link #PIXELS} sets the half-range in pixels on each active axis (random offset in {@code [-intensity, +intensity]}).
-   */
-  public enum ShakeUnit {
-
-    /**
-     * Scale intensity by {@link FlixelShakeable#getShakeWidth()} (X) and
-     * {@link FlixelShakeable#getShakeHeight()} (Y) when positive. This is the default value.
-     *
-     * <p>Use this if you're familiar with HaxeFlixel and want to use the same behavior.
-     */
-    FRACTION,
-
-    /**
-     * Treat intensity as pixel magnitude on each shaken axis.
-     *
-     * <p>Use this if you want to directly set the half-range in pixels on each active
-     * axis (random offset in {@code [-intensity, +intensity]}) and you're used to how
-     * Unity or Godot shakes objects.
-     */
-    PIXELS
-  }
 }


### PR DESCRIPTION
## Description

This pull request fixes a fatal crash, which would cause any FlixelGDX game compiled to a web game to freeze when a malformed path was passed down when loading an asset.

This fixes the problem by automatically checking to see if the path is valid; if it's not, then it formats it to be valid.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [ ] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
