### PR TITLE
Removed the built-in Scene2D stage of FlixelGame to reduce bloat and increase performance

### DIFF
--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
@@ -11,7 +11,6 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.Application.ApplicationType;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Array;
 
 import me.stringdotjar.flixelgdx.asset.FlixelAssetManager;
@@ -889,10 +888,6 @@ public final class Flixel {
 
   public static FlixelGame getGame() {
     return game;
-  }
-
-  public static Stage getStage() {
-    return game.stage;
   }
 
   public static FlixelState getState() {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelGame.java
@@ -19,7 +19,6 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ScreenUtils;
 
@@ -129,9 +128,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
   /** Is the game's window currently minimized? */
   private boolean isMinimized = false;
-
-  /** The main stage used for rendering all screens and sprites on screen. */
-  protected Stage stage;
 
   /** The main sprite batch used for rendering all sprites on screen. */
   protected SpriteBatch batch;
@@ -305,7 +301,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     batch = new SpriteBatch();
     cameras = new Array<>(FlixelCamera[]::new);
     cameras.add(new FlixelCamera((int) viewSize.x, (int) viewSize.y));
-    stage = new Stage(getCamera().getViewport(), batch);
 
     Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
     pixmap.setColor(Color.WHITE);
@@ -391,7 +386,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     FlixelActionSets.updateAll(elapsed);
 
     if (!gamePaused) {
-      stage.act(elapsed);
       FlixelTween.updateTweens(elapsed);
       FlixelTimer.getGlobalManager().update(elapsed * Flixel.getTimeScale());
 
@@ -472,8 +466,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
         Flixel.setDrawCamera(null);
       }
     }
-
-    stage.draw();
 
     FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
     if (debugOverlay != null) {
@@ -741,10 +733,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     if (Flixel.getState() != null) {
       Flixel.getState().destroy();
     }
-    if (stage != null) {
-      stage.dispose();
-      stage = null;
-    }
     if (batch != null) {
       batch.dispose();
       batch = null;
@@ -825,7 +813,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     if (cameras.isEmpty()) {
       cameras.add(new FlixelCamera((int) windowSize.x, (int) windowSize.y));
       cameras.first().apply();
-      stage.setViewport(cameras.first().getViewport());
     }
     return cameras.first();
   }
@@ -838,7 +825,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     camera.update((int) windowSize.x, (int) windowSize.y, camera.centerCameraOnResize);
     cameras = new Array<>(FlixelCamera[]::new);
     cameras.add(camera);
-    stage.setViewport(camera.getViewport());
     if (desktopTransparencyActive) {
       applyDesktopTransparencyBackdropOnly();
     }
@@ -874,10 +860,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
   public boolean isFocused() {
     return isFocused;
-  }
-
-  public Stage getStage() {
-    return stage;
   }
 
   public Array<FlixelCamera> getCameras() {


### PR DESCRIPTION
## Description

This pull request removes the Scene2D stage from the `FlixelGame` class. Because stages have their own `SpriteBatch`, it added extra draw calls to the GPU, and by removing this, it gives about another 100-200 FPS for games.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [ ] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [ ] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
