### PR TITLE
Sound objects on the flixelgdx-teavm backend no longer throw an exception and are now silent no-ops

### DIFF
--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/audio/FlixelGdxSound.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/audio/FlixelGdxSound.java
@@ -68,7 +68,7 @@ final class FlixelGdxSound implements FlixelSoundBackend {
 
   @Override
   public void setPitch(float pitch) {
-    throw new UnsupportedOperationException("Pitch is not supported on TeaVM");
+    // No-op.
   }
 
   @Override
@@ -88,7 +88,7 @@ final class FlixelGdxSound implements FlixelSoundBackend {
 
   @Override
   public float getLength() {
-    throw new UnsupportedOperationException("Duration is not supported on TeaVM");
+    return 0;
   }
 
   @Override
@@ -103,7 +103,7 @@ final class FlixelGdxSound implements FlixelSoundBackend {
 
   @Override
   public void setPosition(float x, float y, float z) {
-    throw new UnsupportedOperationException("Spatial audio is not supported on TeaVM");
+    // No-op.
   }
 
   @Override


### PR DESCRIPTION
## Description

This pull request makes a simple change that removes the thrown exceptions for sound on TeaVM and, instead of throwing an exception when attempting to use a method that wasn't supported, now are just silent no-ops.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
