### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+## Cursor Cloud specific instructions
+
+FlixelGDX is a Java 17 game framework library (not a standalone application). There is no runnable app in this repo; it is tested via unit tests and by consuming the published artifacts from a separate project.
+
+### Key commands
+
+All commands are run from the repository root using the Gradle wrapper (`./gradlew`).
+
+| Task | Command |
+|------|---------|
+| Compile all modules | `./gradlew classes` |
+| Run unit tests | `./gradlew :flixelgdx-test:test` |
+| Publish to Maven Local | `./gradlew publishToMavenLocal` |
+| Generate Javadocs | `./gradlew javadocAll` |
+
+See `COMPILING.md` for full build/test documentation and `CONTRIBUTING.md` for coding standards and PR workflow.
+
+### Environment notes
+
+- The VM has JDK 21 installed. Gradle 9.x runs on JDK 17+, and the Gradle toolchain (foojay-resolver) auto-downloads JDK 17 for compilation. No manual JDK 17 install is needed.
+- The Gradle daemon is disabled by default (`org.gradle.daemon=false` in `gradle.properties`) to save memory.
+- Default logging level is `quiet`; use `--info` for verbose output during debugging.
+- The Android module is excluded by default. Pass `-PincludeAndroid=true` or add `includeAndroid=true` to `local.properties` if you need it.
+- Tests use the libGDX headless backend and do not require a display or GPU.
+- PRs should target the `develop` branch per `CONTRIBUTING.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working on this repository. The file documents key build/test commands, environment notes (JDK toolchain auto-download, Gradle daemon settings, headless test backend), and references to existing documentation.

## Type of Change

- [x] Documentation update

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).

## Evidence

Build and test evidence:

[build_evidence.log](https://cursor.com/agents/bc-85a31daf-29b2-4847-a637-e8eb79e71253/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_evidence.log)

[test_results.log](https://cursor.com/agents/bc-85a31daf-29b2-4847-a637-e8eb79e71253/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85a31daf-29b2-4847-a637-e8eb79e71253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85a31daf-29b2-4847-a637-e8eb79e71253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

