### PR TITLE
Enhance getFullExceptionMessage to display the cause

### DIFF
--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKey.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKey.java
@@ -193,7 +193,7 @@ public final class FlixelKey {
    * {@link Input.Keys#toString(int)}) to a key code.
    *
    * @param keyname Key name from {@link FlixelKey#toString(int)}.
-   * @return The key code, or {@link NONE} if not found.
+   * @return The key code, or {@link #NONE} if not found.
    */
   public static int fromString(String keyname) {
     if (keyname == null || keyname.equalsIgnoreCase("NONE")) {

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelRuntimeUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelRuntimeUtil.java
@@ -192,6 +192,16 @@ public final class FlixelRuntimeUtil {
     for (StackTraceElement element : exception.getStackTrace()) {
       messageBuilder.append("\tat ").append(element.toString()).append("\n");
     }
+    Throwable cause = exception.getCause();
+    int depth = 0;
+    while (cause != null && depth < 8) {
+      messageBuilder.append("Caused by: ").append(cause).append("\n");
+      for (StackTraceElement element : cause.getStackTrace()) {
+        messageBuilder.append("\tat ").append(element.toString()).append("\n");
+      }
+      cause = cause.getCause();
+      depth++;
+    }
     return messageBuilder.toString();
   }
 

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/alert/FlixelLwjgl3Alerter.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/alert/FlixelLwjgl3Alerter.java
@@ -33,6 +33,13 @@ public class FlixelLwjgl3Alerter implements FlixelAlerter {
 
   private void showAlert(String title, Object message, int type) {
     String msg = message != null ? message.toString() : "null";
+    // AWT is unavailable in GraalVM native image. The property is set to "runtime"
+    // when the binary runs as a compiled native executable. Attempting to access
+    // java.awt.EventQueue in that context calls Toolkit.<clinit>, which tries to
+    // load native AWT libraries and crashes with a JNI FatalError.
+    if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
+      return;
+    }
     if (EventQueue.isDispatchThread()) {
       JOptionPane.showMessageDialog(null, msg, title, type);
     } else {


### PR DESCRIPTION
## Description

This pull request updates the `FlixelRuntimeUtil.getFullExceptionMessage(Throwable)` function to also display the cause from the `Throwable` object to be more descriptive and make debugging easier.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
