### PR TITLE
Added heavy support for native image integration to allow games to be compiled to a native binary via GraalVM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,10 @@ Refer to `.cursor/rules/documentation.mdc` in the repo for full good versus bad 
 - If the current branch is set to either `master`, `develop` or something else, **create a new branch off of the latest changes from `develop`**.
 - When you're done with a task (and you haven't yet made one), **create a pull request**. Make sure it follows the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
   exactly with all of your changes.
+- Pull request titles should be read as **past tense**, in the format as if it was a new update to a game. Examples:
+    - "Added experimental controller/gamepad support for games to be playable on more platforms such as console"
+    - "Massively buffed the desktop/LWJGL3 backend with multiple new features, such as transparent window backgrounds, custom mouse icons, and more"
+    - "Reworked the logging API and its stack trace system to be much more accurate using a custom logging plugin"
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,8 +72,10 @@ Documentation should read like a **beginner-friendly handbook**, not an expert-o
 ### Mechanics
 
 - Use correct grammar and punctuation everywhere (comments, `@param`, `@return`, `@throws`, and so on).
-- Stick to **ASCII** in prose when practical; avoid decorative punctuation like en dash, fancy arrows or emojis. This allows the
-  docs to be read easily on every device and requires you to use clarity over brevity.
+- Stick to **ASCII** in prose when practical; avoid decorative punctuation like en dash, em dash, fancy arrows or emojis. This applies
+  to both source comments and Javadoc. Use a plain hyphen (-) only for compound adjectives; never use it as a sentence separator or
+  stand-in for an em dash. This rule also applies to inline comments in Groovy/Gradle files.
+  This allows the docs to be read easily on every device and requires you to use clarity over brevity.
 - Include the right Javadoc tags (`@param`, `@return`, `@throws`, …) wherever they apply.
 - Use nullability annotations (`@Nullable`, `@NotNull`) where they help tooling.
 - Keep `@link` references valid or fix broken links.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@
 
 ## Project context (FlixelGDX)
 
-FlixelGDX is a general purpose Java framework built on libGDX. It aims for strong performance and tooling so game development stays modernized, approachable, and accessible.
+FlixelGDX is a general-purposed Java framework built on libGDX. It aims for strong performance and tooling, so game development stays modernized, approachable, and accessible.
 
 The overarching goal is to bring HaxeFlixel-style features into Java's ecosystem while staying as memory-efficient as humanly possible without giving up features games need.
 
-This repository is the **standalone framework**. Runtime verification happens in a **separate test project**, consuming the framework via `publishToMavenLocal`, a composite build, or JitPack from a GitHub branch or commit.
+This repository is the **standalone framework**. Runtime verification happens in a **separate test project**, consuming the framework via `publishToMavenLocal`, a composite build, or JitPack from a GitHub branch/commit.
 
 ---
 
@@ -40,9 +40,169 @@ When explaining code or introducing patterns:
 
 ## Code quality (non-negotiables)
 
-### Performance and allocations
+### Performance, Memory, and allocations
 
-**Do not allocate objects inside loops or in methods invoked every frame.** That rule is strict. Prefer reuse, pooling (FlixelGDX and libGDX), indexed `for` loops, and performance-oriented helpers such as FlixelGDX's `FlixelString` or libGDX's `ObjectMap`.
+- **Do not allocate objects inside loops or in methods invoked every frame.** That rule is strict. Prefer reuse, pooling (FlixelGDX and libGDX), 
+indexed `for` loops, and performance-oriented helpers such as FlixelGDX's `FlixelString` or libGDX's `ObjectMap`.
+- **Always put fields in the correct order for each class**. This one is also an extremely important rule to follow, and it's
+  vital you **do not forget this**. This rule is specifically for ensuring objects are as lean and small as possible and to keep
+  alignment padding as tight as possible. Follow the order below:
+
+  1. `long`s and `double`s
+  2. `int`s, `float`s, and object references 
+  3. `short`s and `char`s
+  4. `boolean`s and `byte`s
+
+### Coding style
+
+**Always put fields, modifiers, types, and methods in the correct order**. This keeps the code readable and consistent.
+Follow the orders below:
+
+#### Modifiers
+
+1. `public`
+2. `protected`
+3. default
+4. `private`
+5. `static`
+6. `final`
+
+#### Fields, Methods/Functions and Types
+
+1. Fields (following the alignment padding rule!)
+2. Constructors, with smallest to largest parameters top to bottom
+3. Methods (if there are overloads, order them smallest to largest parameters top to bottom)
+4. Inner classes
+5. Inner interfaces
+6. Inner enums
+
+#### Example
+
+```java
+/*
+ * Copyright notice here...
+ */
+package me.stringdotjar.flixelgdx.example;
+
+/**
+ * Rich and detailed Javadoc here.
+ * 
+ * <p>Other details here.
+ */
+public class PerformanceObject {
+
+  // 1. FIELDS (Block 1: Statics - Ordered by Modifiers then Types)
+  
+  // Public Statics
+  public static final long GLOBAL_LIMIT = 5000L;
+  public static final int MAX_RETRIES = 5;
+  public static String systemNodeName = "PRIMARY_NODE";
+  public static char systemMode = 'V';
+  
+  // Protected Statics
+  protected static double internalWeight = 42.42;
+  
+  // Package-Private / Default Statics
+  static final double VERSION_STABILITY = 1.0;
+  static final float GRAVITY_CONSTANT = 9.81f;
+  
+  // Private Statics
+  private static Object sharedLock = new Object();
+  private static byte systemHeader = 0x1;
+  
+  
+  // 1. FIELDS (Block 2: Instance Fields - Ordered by memory alignment padding rules)
+
+  // Longs and doubles (8 bytes)
+  public final long createdAt;
+  private double sensorValue;
+  
+  // Ints, floats, and object references (4 bytes)
+  public int instanceId;
+  protected float velocity;
+  private String displayName;
+  private List<String> metadata;
+  
+  // Shorts and chars (2 bytes)
+  public short localFlags;
+  private char categoryCode;
+  
+  // Booleans and bytes (1 byte)
+  public boolean isActive;
+  private byte checksum;
+  
+  // ---
+  
+  // 2. CONSTRUCTORS (Smallest to largest, chaining downwards via this())
+  
+  // 0 parameters - passes default values to the 1-parameter constructor
+  public PerformanceObject() {
+    this(-1);
+  }
+  
+  // 1 parameter - passes defaults along to the 3-parameter constructor
+  public PerformanceObject(int instanceId) {
+    this(instanceId, "GENERIC_INSTANCE", 0.0f);
+  }
+  
+  // 3 parameters - passes defaults along to the final 4-parameter constructor
+  public PerformanceObject(int instanceId, String displayName, float velocity) {
+    this(instanceId, displayName, velocity, false);
+  }
+  
+  // 4 parameters - The "master" constructor that actually assigns the fields
+  public PerformanceObject(int instanceId, String displayName, float velocity, boolean isActive) {
+    this.createdAt = System.currentTimeMillis(); // Final field assigned here
+    this.instanceId = instanceId;
+    this.displayName = displayName;
+    this.velocity = velocity;
+    this.isActive = isActive;
+  }
+  
+  // ---
+  
+  // 3. METHODS (Overloads ordered smallest to largest, reusing logic)
+    
+  public static void sayHello() {
+    System.out.println("Hello, world!");
+  }
+
+  public void logMessage() {
+    logMessage("Default system heartbeat check.");
+  }
+
+  public void logMessage(String msg) {
+    logMessage(msg, 1);
+  }
+
+  public void logMessage(String msg, int level) {
+    System.out.println("[" + level + "] " + msg);
+  }
+
+  protected void processData() {
+    this.checksum = 0x00;
+  }
+  
+  // ---
+
+  // 4. TYPES (Class, Interface, Enum)
+
+  private static final class InternalConfig {
+    private long timeout;
+    private int bufferSize;
+  }
+
+  public interface StateListener {
+    void onTransition(boolean success);
+  }
+
+  public enum Priority {
+    LOW,
+    MEDIUM,
+    HIGH
+  }
+}
+```
 
 ### Architecture and scope
 
@@ -55,7 +215,7 @@ When explaining code or introducing patterns:
 - **Import** every type you use. Do **not** use star imports (`*`).
 - Do **not** use fully qualified class names inline when a normal import would read cleanly.
 - Empty or void-returning methods: opening brace on the same line per `.editorconfig` (example: `public void hook() {}`).
-- Prefer **short** field and method names. If shortening a method name hides meaning, use a concise name plus Javadoc instead of a long identifier.
+- Prefer **short** field and method names. If shortening a method name hides its meaning, use a concise name plus Javadoc instead of a long identifier.
 
 ### Finishing work
 
@@ -72,10 +232,12 @@ Documentation should read like a **beginner-friendly handbook**, not an expert-o
 ### Mechanics
 
 - Use correct grammar and punctuation everywhere (comments, `@param`, `@return`, `@throws`, and so on).
-- Stick to **ASCII** in prose when practical; avoid decorative punctuation like en dash, em dash, fancy arrows or emojis. This applies
+- Stick to **ASCII** in prose when practical; avoid decorative punctuation like en dash, em dash, fancy arrows, or emojis. This applies
   to both source comments and Javadoc. Use a plain hyphen (-) only for compound adjectives; never use it as a sentence separator or
   stand-in for an em dash. This rule also applies to inline comments in Groovy/Gradle files.
   This allows the docs to be read easily on every device and requires you to use clarity over brevity.
+- Use **consistent capitalization and grammar** in prose and code.
+- Every doc comment should always start with a single sentence, with detailed paragraphs following.
 - Include the right Javadoc tags (`@param`, `@return`, `@throws`, …) wherever they apply.
 - Use nullability annotations (`@Nullable`, `@NotNull`) where they help tooling.
 - Keep `@link` references valid or fix broken links.
@@ -83,7 +245,7 @@ Documentation should read like a **beginner-friendly handbook**, not an expert-o
 - Add comments where either complexity would otherwise be hard to follow, or where code requires import context.
 - Skip Javadoc on trivial, self-explanatory methods (plain getters/setters or something like `calculateTotal()` unless there is subtle behavior).
 - `.java` files should carry the project's standard copyright header (exceptions: `package-info.java`, `module-info.java`).
-- Prefer **American English** in docs.
+- Prefer **American English** in docs. (e.g., "behavior" instead of "behaviour")
 - After code changes that affect public behavior or APIs, **update relevant Markdown docs** in the repo.
 
 ### Comments versus Javadocs
@@ -102,10 +264,21 @@ Refer to `.cursor/rules/documentation.mdc` in the repo for full good versus bad 
 
 ## Working with Git and Pull Requests
 
-- Prefer **small, focused commits** as you finish logical slices of work so history stays readable.
-- Use **one branch and one pull request** unless the user explicitly asks for more (for example stacked features or dependent work).
+- Prefer **small, focused commits** as you finish logical slices of work so history stays readable. For example, if the task
+  involves a large refactor, **don't dump everything in one commit**; split each logical change into a separate commit.
+- Use **one branch and one pull request** unless the user explicitly asks for more (for example, stacked features or dependent work).
 - Follow `CONTRIBUTING.md`, `PULL_REQUEST_TEMPLATE.md`, and project PR or commit conventions.
 - If the user renames a pull request, **do not rename it back**; respect their title.
+- Your commit titles should be **short and descriptive**, and not contain **keywords in front (e.g. `fix`, `feat`, `refactor`, etc.)**. 
+  They should also be **present** tense. Examples:
+    - "Update README with more descriptive content"
+    - "Fix typos in documentation and refactor FlixelSprite"
+    - "Fix rendering bug in FlixelCamera"
+    - "Add missing Javadoc to FlixelCamera"
+- If the current branch is not up to date with the remote, always pull the latest changes before changing any code.
+- If the current branch is set to either `master`, `develop` or something else, **create a new branch off of the latest changes from `develop`**.
+- When you're done with a task (and you haven't yet made one), **create a pull request**. Make sure it follows the [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+  exactly with all of your changes.
 
 ---
 
@@ -120,7 +293,7 @@ If the task needs external reference beyond this repo:
    - `https://github.com/HaxeFlixel/flixel`
    - `https://github.com/libgdx/libgdx`
 
-2. If those are insufficient or off-topic for the question, broaden the search thoughtfully.
+2. If those are not enough or off-topic for the question, broaden the search thoughtfully.
 
 ---
 

--- a/flixelgdx-lwjgl3/build.gradle
+++ b/flixelgdx-lwjgl3/build.gradle
@@ -27,4 +27,8 @@ dependencies {
 
   implementation "org.jetbrains:annotations:26.1.0"
   implementation "org.fusesource.jansi:jansi:$jansiVersion"
+
+  // Provides the Feature interface and RuntimeJNIAccess used by FlixelGraalFeature.
+  // Compile-only: the class runs inside native-image at build time, not in user runtimes.
+  compileOnly "org.graalvm.sdk:nativeimage:24.2.0"
 }

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/alert/FlixelLwjgl3Alerter.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/alert/FlixelLwjgl3Alerter.java
@@ -33,11 +33,11 @@ public class FlixelLwjgl3Alerter implements FlixelAlerter {
 
   private void showAlert(String title, Object message, int type) {
     String msg = message != null ? message.toString() : "null";
-    // AWT is unavailable in GraalVM native image. The property is set to "runtime"
-    // when the binary runs as a compiled native executable. Attempting to access
-    // java.awt.EventQueue in that context calls Toolkit.<clinit>, which tries to
-    // load native AWT libraries and crashes with a JNI FatalError.
+    // AWT cannot be used in a GraalVM native image binary: Toolkit.<clinit> loads
+    // native AWT libraries via JNI_FatalError, which is non-recoverable. Fall back
+    // to stderr so the user still sees the alert text.
     if (System.getProperty("org.graalvm.nativeimage.imagecode") != null) {
+      System.err.println("[FlixelGDX Alert] " + title + ": " + msg);
       return;
     }
     if (EventQueue.isDispatchThread()) {

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
@@ -66,7 +66,8 @@ public class FlixelGraalFeature implements Feature {
 
   /**
    * Registers imgui-java 1.90.x JNI fields and callbacks.
-   * {@code nInitJni()} caches every field and method ID listed here at startup.
+   *
+   * <p>{@code nInitJni()} caches every field and method ID listed here at startup.
    * GraalVM returns null for anything unregistered, causing a NullPointerException
    * inside {@code GetFieldID} that surfaces as {@code ExceptionInInitializerError}.
    */
@@ -115,7 +116,8 @@ public class FlixelGraalFeature implements Feature {
 
   /**
    * Registers gdx-miniaudio JNI callbacks.
-   * gdx-miniaudio ships no GraalVM metadata; the native audio engine calls
+   *
+   * <p>gdx-miniaudio ships no GraalVM metadata; the native audio engine calls
    * {@code GetMethodID} for these three methods at startup.
    */
   private void registerMiniAudio() throws NoSuchMethodException {

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
@@ -8,6 +8,7 @@
 package me.stringdotjar.flixelgdx.backend.lwjgl3.graal;
 
 import games.rednblack.miniaudio.MiniAudio;
+
 import imgui.ImFontAtlas;
 import imgui.ImGuiViewport;
 import imgui.ImVec2;
@@ -27,6 +28,7 @@ import imgui.callback.ImStrConsumer;
 import imgui.callback.ImStrSupplier;
 import imgui.internal.ImRect;
 import imgui.type.ImString;
+
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeJNIAccess;
 import org.lwjgl.system.CallbackI;
@@ -62,10 +64,12 @@ public class FlixelGraalFeature implements Feature {
     }
   }
 
-  // imgui-java 1.90.x JNI registration.
-  // nInitJni() caches every field and method ID listed here at startup.
-  // GraalVM returns null for anything unregistered, causing a NullPointerException
-  // inside GetFieldID that surfaces as ExceptionInInitializerError.
+  /**
+   * Registers imgui-java 1.90.x JNI fields and callbacks.
+   * {@code nInitJni()} caches every field and method ID listed here at startup.
+   * GraalVM returns null for anything unregistered, causing a NullPointerException
+   * inside {@code GetFieldID} that surfaces as {@code ExceptionInInitializerError}.
+   */
   private void registerImGui() throws NoSuchFieldException, NoSuchMethodException {
     // Base native pointer inherited by every imgui wrapper object.
     RuntimeJNIAccess.register(ImGuiStruct.class.getDeclaredField("ptr"));
@@ -109,8 +113,11 @@ public class FlixelGraalFeature implements Feature {
     RuntimeJNIAccess.register(ImStrSupplier.class.getDeclaredMethod("get"));
   }
 
-  // gdx-miniaudio ships no GraalVM metadata. The native audio engine calls
-  // GetMethodID for these three callbacks at startup via JNI.
+  /**
+   * Registers gdx-miniaudio JNI callbacks.
+   * gdx-miniaudio ships no GraalVM metadata; the native audio engine calls
+   * {@code GetMethodID} for these three methods at startup.
+   */
   private void registerMiniAudio() throws NoSuchMethodException {
     RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_notification", int.class));
     RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_sound_end", long.class));

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
@@ -1,0 +1,119 @@
+/**********************************************************************************
+ * Copyright (c) 2025-2026 stringdotjar
+ *
+ * This file is part of the FlixelGDX framework, licensed under the MIT License.
+ * See the LICENSE file in the repository root for full license information.
+ **********************************************************************************/
+
+package me.stringdotjar.flixelgdx.backend.lwjgl3.graal;
+
+import games.rednblack.miniaudio.MiniAudio;
+import imgui.ImFontAtlas;
+import imgui.ImGuiViewport;
+import imgui.ImVec2;
+import imgui.ImVec4;
+import imgui.assertion.ImAssertCallback;
+import imgui.binding.ImGuiStruct;
+import imgui.callback.ImGuiInputTextCallback;
+import imgui.callback.ImListClipperCallback;
+import imgui.callback.ImPlatformFuncViewport;
+import imgui.callback.ImPlatformFuncViewportFloat;
+import imgui.callback.ImPlatformFuncViewportImVec2;
+import imgui.callback.ImPlatformFuncViewportString;
+import imgui.callback.ImPlatformFuncViewportSuppBoolean;
+import imgui.callback.ImPlatformFuncViewportSuppFloat;
+import imgui.callback.ImPlatformFuncViewportSuppImVec2;
+import imgui.callback.ImStrConsumer;
+import imgui.callback.ImStrSupplier;
+import imgui.internal.ImRect;
+import imgui.type.ImString;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeJNIAccess;
+import org.lwjgl.system.CallbackI;
+
+/**
+ * GraalVM native image Feature that registers all JNI entries for FlixelGDX's
+ * built-in native libraries: imgui-java and gdx-miniaudio.
+ *
+ * <p>Activated automatically when the framework JAR is on the native-image classpath,
+ * via {@code META-INF/native-image/me.stringdotjar.flixelgdx/native-image.properties}.
+ * Game projects do not need to configure anything.
+ *
+ * <p>If you add a third-party library that also uses JNI or reflection, run the
+ * tracing agent to capture configuration for those additional registrations. See
+ * your project README for the {@code generateNativeConfig} task instructions.
+ *
+ * <p><strong>Versioning note:</strong> This class registers against imgui-java 1.90.x
+ * and gdx-miniaudio 0.7. If the framework upgrades either dependency, the registration
+ * lists here must be re-validated with the tracing agent.
+ */
+public class FlixelGraalFeature implements Feature {
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        try {
+            registerImGui();
+            registerMiniAudio();
+        } catch (NoSuchFieldException | NoSuchMethodException e) {
+            // A missing entry means a library version change introduced or removed a field/method.
+            // The build will not fail here, but the resulting binary may crash at the call site.
+            System.err.println("[FlixelGDX] Warning: native image JNI registration failed: " + e);
+            System.err.println("[FlixelGDX] Re-run the tracing agent and update FlixelGraalFeature.");
+        }
+    }
+
+    // imgui-java 1.90.x JNI registration.
+    // nInitJni() caches every field and method ID listed here at startup.
+    // GraalVM returns null for anything unregistered, causing a NullPointerException
+    // inside GetFieldID that surfaces as ExceptionInInitializerError.
+    private void registerImGui() throws NoSuchFieldException, NoSuchMethodException {
+        // Base native pointer inherited by every imgui wrapper object.
+        RuntimeJNIAccess.register(ImGuiStruct.class.getDeclaredField("ptr"));
+
+        RuntimeJNIAccess.register(ImVec2.class.getDeclaredField("x"));
+        RuntimeJNIAccess.register(ImVec2.class.getDeclaredField("y"));
+
+        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("x"));
+        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("y"));
+        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("z"));
+        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("w"));
+
+        RuntimeJNIAccess.register(ImRect.class.getDeclaredField("min"));
+        RuntimeJNIAccess.register(ImRect.class.getDeclaredField("max"));
+
+        RuntimeJNIAccess.register(ImFontAtlas.class.getDeclaredMethod("createAlpha8Pixels", int.class));
+        RuntimeJNIAccess.register(ImFontAtlas.class.getDeclaredMethod("createRgba32Pixels", int.class));
+
+        RuntimeJNIAccess.register(ImString.class.getDeclaredMethod("resizeInternal", int.class));
+
+        Class<?> inputData = ImString.InputData.class;
+        RuntimeJNIAccess.register(inputData.getDeclaredField("isDirty"));
+        RuntimeJNIAccess.register(inputData.getDeclaredField("isResized"));
+        RuntimeJNIAccess.register(inputData.getDeclaredField("size"));
+
+        RuntimeJNIAccess.register(Boolean.class.getDeclaredMethod("getBoolean", String.class));
+        RuntimeJNIAccess.register(CallbackI.class.getDeclaredMethod("callback", long.class, long.class));
+
+        // Runtime callbacks invoked by the imgui native layer.
+        RuntimeJNIAccess.register(ImAssertCallback.class.getDeclaredMethod("imAssert", String.class, int.class, String.class));
+        RuntimeJNIAccess.register(ImGuiInputTextCallback.class.getDeclaredMethod("accept", long.class));
+        RuntimeJNIAccess.register(ImListClipperCallback.class.getDeclaredMethod("accept", int.class));
+        RuntimeJNIAccess.register(ImPlatformFuncViewport.class.getDeclaredMethod("accept", ImGuiViewport.class));
+        RuntimeJNIAccess.register(ImPlatformFuncViewportFloat.class.getDeclaredMethod("accept", ImGuiViewport.class, float.class));
+        RuntimeJNIAccess.register(ImPlatformFuncViewportImVec2.class.getDeclaredMethod("accept", ImGuiViewport.class, ImVec2.class));
+        RuntimeJNIAccess.register(ImPlatformFuncViewportString.class.getDeclaredMethod("accept", ImGuiViewport.class, String.class));
+        RuntimeJNIAccess.register(ImPlatformFuncViewportSuppBoolean.class.getDeclaredMethod("get", ImGuiViewport.class));
+        RuntimeJNIAccess.register(ImPlatformFuncViewportSuppFloat.class.getDeclaredMethod("get", ImGuiViewport.class));
+        RuntimeJNIAccess.register(ImPlatformFuncViewportSuppImVec2.class.getDeclaredMethod("get", ImGuiViewport.class, ImVec2.class));
+        RuntimeJNIAccess.register(ImStrConsumer.class.getDeclaredMethod("accept", String.class));
+        RuntimeJNIAccess.register(ImStrSupplier.class.getDeclaredMethod("get"));
+    }
+
+    // gdx-miniaudio ships no GraalVM metadata. The native audio engine calls
+    // GetMethodID for these three callbacks at startup via JNI.
+    private void registerMiniAudio() throws NoSuchMethodException {
+        RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_notification", int.class));
+        RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_sound_end", long.class));
+        RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_log", int.class, String.class));
+    }
+}

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
@@ -49,71 +49,71 @@ import org.lwjgl.system.CallbackI;
  */
 public class FlixelGraalFeature implements Feature {
 
-    @Override
-    public void beforeAnalysis(BeforeAnalysisAccess access) {
-        try {
-            registerImGui();
-            registerMiniAudio();
-        } catch (NoSuchFieldException | NoSuchMethodException e) {
-            // A missing entry means a library version change introduced or removed a field/method.
-            // The build will not fail here, but the resulting binary may crash at the call site.
-            System.err.println("[FlixelGDX] Warning: native image JNI registration failed: " + e);
-            System.err.println("[FlixelGDX] Re-run the tracing agent and update FlixelGraalFeature.");
-        }
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    try {
+      registerImGui();
+      registerMiniAudio();
+    } catch (NoSuchFieldException | NoSuchMethodException e) {
+      // A missing entry means a library version change introduced or removed a field/method.
+      // The build will not fail here, but the resulting binary may crash at the call site.
+      System.err.println("[FlixelGDX] Warning: native image JNI registration failed: " + e);
+      System.err.println("[FlixelGDX] Re-run the tracing agent and update FlixelGraalFeature.");
     }
+  }
 
-    // imgui-java 1.90.x JNI registration.
-    // nInitJni() caches every field and method ID listed here at startup.
-    // GraalVM returns null for anything unregistered, causing a NullPointerException
-    // inside GetFieldID that surfaces as ExceptionInInitializerError.
-    private void registerImGui() throws NoSuchFieldException, NoSuchMethodException {
-        // Base native pointer inherited by every imgui wrapper object.
-        RuntimeJNIAccess.register(ImGuiStruct.class.getDeclaredField("ptr"));
+  // imgui-java 1.90.x JNI registration.
+  // nInitJni() caches every field and method ID listed here at startup.
+  // GraalVM returns null for anything unregistered, causing a NullPointerException
+  // inside GetFieldID that surfaces as ExceptionInInitializerError.
+  private void registerImGui() throws NoSuchFieldException, NoSuchMethodException {
+    // Base native pointer inherited by every imgui wrapper object.
+    RuntimeJNIAccess.register(ImGuiStruct.class.getDeclaredField("ptr"));
 
-        RuntimeJNIAccess.register(ImVec2.class.getDeclaredField("x"));
-        RuntimeJNIAccess.register(ImVec2.class.getDeclaredField("y"));
+    RuntimeJNIAccess.register(ImVec2.class.getDeclaredField("x"));
+    RuntimeJNIAccess.register(ImVec2.class.getDeclaredField("y"));
 
-        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("x"));
-        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("y"));
-        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("z"));
-        RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("w"));
+    RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("x"));
+    RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("y"));
+    RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("z"));
+    RuntimeJNIAccess.register(ImVec4.class.getDeclaredField("w"));
 
-        RuntimeJNIAccess.register(ImRect.class.getDeclaredField("min"));
-        RuntimeJNIAccess.register(ImRect.class.getDeclaredField("max"));
+    RuntimeJNIAccess.register(ImRect.class.getDeclaredField("min"));
+    RuntimeJNIAccess.register(ImRect.class.getDeclaredField("max"));
 
-        RuntimeJNIAccess.register(ImFontAtlas.class.getDeclaredMethod("createAlpha8Pixels", int.class));
-        RuntimeJNIAccess.register(ImFontAtlas.class.getDeclaredMethod("createRgba32Pixels", int.class));
+    RuntimeJNIAccess.register(ImFontAtlas.class.getDeclaredMethod("createAlpha8Pixels", int.class));
+    RuntimeJNIAccess.register(ImFontAtlas.class.getDeclaredMethod("createRgba32Pixels", int.class));
 
-        RuntimeJNIAccess.register(ImString.class.getDeclaredMethod("resizeInternal", int.class));
+    RuntimeJNIAccess.register(ImString.class.getDeclaredMethod("resizeInternal", int.class));
 
-        Class<?> inputData = ImString.InputData.class;
-        RuntimeJNIAccess.register(inputData.getDeclaredField("isDirty"));
-        RuntimeJNIAccess.register(inputData.getDeclaredField("isResized"));
-        RuntimeJNIAccess.register(inputData.getDeclaredField("size"));
+    Class<?> inputData = ImString.InputData.class;
+    RuntimeJNIAccess.register(inputData.getDeclaredField("isDirty"));
+    RuntimeJNIAccess.register(inputData.getDeclaredField("isResized"));
+    RuntimeJNIAccess.register(inputData.getDeclaredField("size"));
 
-        RuntimeJNIAccess.register(Boolean.class.getDeclaredMethod("getBoolean", String.class));
-        RuntimeJNIAccess.register(CallbackI.class.getDeclaredMethod("callback", long.class, long.class));
+    RuntimeJNIAccess.register(Boolean.class.getDeclaredMethod("getBoolean", String.class));
+    RuntimeJNIAccess.register(CallbackI.class.getDeclaredMethod("callback", long.class, long.class));
 
-        // Runtime callbacks invoked by the imgui native layer.
-        RuntimeJNIAccess.register(ImAssertCallback.class.getDeclaredMethod("imAssert", String.class, int.class, String.class));
-        RuntimeJNIAccess.register(ImGuiInputTextCallback.class.getDeclaredMethod("accept", long.class));
-        RuntimeJNIAccess.register(ImListClipperCallback.class.getDeclaredMethod("accept", int.class));
-        RuntimeJNIAccess.register(ImPlatformFuncViewport.class.getDeclaredMethod("accept", ImGuiViewport.class));
-        RuntimeJNIAccess.register(ImPlatformFuncViewportFloat.class.getDeclaredMethod("accept", ImGuiViewport.class, float.class));
-        RuntimeJNIAccess.register(ImPlatformFuncViewportImVec2.class.getDeclaredMethod("accept", ImGuiViewport.class, ImVec2.class));
-        RuntimeJNIAccess.register(ImPlatformFuncViewportString.class.getDeclaredMethod("accept", ImGuiViewport.class, String.class));
-        RuntimeJNIAccess.register(ImPlatformFuncViewportSuppBoolean.class.getDeclaredMethod("get", ImGuiViewport.class));
-        RuntimeJNIAccess.register(ImPlatformFuncViewportSuppFloat.class.getDeclaredMethod("get", ImGuiViewport.class));
-        RuntimeJNIAccess.register(ImPlatformFuncViewportSuppImVec2.class.getDeclaredMethod("get", ImGuiViewport.class, ImVec2.class));
-        RuntimeJNIAccess.register(ImStrConsumer.class.getDeclaredMethod("accept", String.class));
-        RuntimeJNIAccess.register(ImStrSupplier.class.getDeclaredMethod("get"));
-    }
+    // Runtime callbacks invoked by the imgui native layer.
+    RuntimeJNIAccess.register(ImAssertCallback.class.getDeclaredMethod("imAssert", String.class, int.class, String.class));
+    RuntimeJNIAccess.register(ImGuiInputTextCallback.class.getDeclaredMethod("accept", long.class));
+    RuntimeJNIAccess.register(ImListClipperCallback.class.getDeclaredMethod("accept", int.class));
+    RuntimeJNIAccess.register(ImPlatformFuncViewport.class.getDeclaredMethod("accept", ImGuiViewport.class));
+    RuntimeJNIAccess.register(ImPlatformFuncViewportFloat.class.getDeclaredMethod("accept", ImGuiViewport.class, float.class));
+    RuntimeJNIAccess.register(ImPlatformFuncViewportImVec2.class.getDeclaredMethod("accept", ImGuiViewport.class, ImVec2.class));
+    RuntimeJNIAccess.register(ImPlatformFuncViewportString.class.getDeclaredMethod("accept", ImGuiViewport.class, String.class));
+    RuntimeJNIAccess.register(ImPlatformFuncViewportSuppBoolean.class.getDeclaredMethod("get", ImGuiViewport.class));
+    RuntimeJNIAccess.register(ImPlatformFuncViewportSuppFloat.class.getDeclaredMethod("get", ImGuiViewport.class));
+    RuntimeJNIAccess.register(ImPlatformFuncViewportSuppImVec2.class.getDeclaredMethod("get", ImGuiViewport.class, ImVec2.class));
+    RuntimeJNIAccess.register(ImStrConsumer.class.getDeclaredMethod("accept", String.class));
+    RuntimeJNIAccess.register(ImStrSupplier.class.getDeclaredMethod("get"));
+  }
 
-    // gdx-miniaudio ships no GraalVM metadata. The native audio engine calls
-    // GetMethodID for these three callbacks at startup via JNI.
-    private void registerMiniAudio() throws NoSuchMethodException {
-        RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_notification", int.class));
-        RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_sound_end", long.class));
-        RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_log", int.class, String.class));
-    }
+  // gdx-miniaudio ships no GraalVM metadata. The native audio engine calls
+  // GetMethodID for these three callbacks at startup via JNI.
+  private void registerMiniAudio() throws NoSuchMethodException {
+    RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_notification", int.class));
+    RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_sound_end", long.class));
+    RuntimeJNIAccess.register(MiniAudio.class.getDeclaredMethod("on_native_log", int.class, String.class));
+  }
 }

--- a/flixelgdx-lwjgl3/src/main/resources/META-INF/native-image/me.stringdotjar.flixelgdx/native-image.properties
+++ b/flixelgdx-lwjgl3/src/main/resources/META-INF/native-image/me.stringdotjar.flixelgdx/native-image.properties
@@ -1,0 +1,5 @@
+# GraalVM native image configuration for the FlixelGDX LWJGL3 backend.
+# These arguments are merged automatically when the framework JAR is on the native-image classpath.
+
+Args = --features=me.stringdotjar.flixelgdx.backend.lwjgl3.graal.FlixelGraalFeature \
+       --initialize-at-run-time=imgui.ImGui,imgui.ImFontAtlas,imgui.ImGuiPlatformIO


### PR DESCRIPTION
## Description

Adds `FlixelGraalFeature`, a GraalVM `Feature` implementation that automatically registers all JNI entries for FlixelGDX's built-in native libraries (imgui-java 1.90.x and gdx-miniaudio 0.7) during `nativeCompile`. The Feature activates via a `META-INF/native-image/native-image.properties` file bundled in the framework JAR, so game projects get correct JNI wiring with zero manual configuration.

Also improves `FlixelLwjgl3Alerter` to print alerts to stderr in native image mode instead of silently dropping them (AWT is not usable in a native binary at the C level).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Changes

- `FlixelGraalFeature.java` - Feature class; registers imgui-java fields, callbacks, and gdx-miniaudio methods via `RuntimeJNIAccess` in `beforeAnalysis()`. Throws checked exceptions so a version mismatch surfaces at build time rather than crashing the binary silently.
- `META-INF/native-image/native-image.properties` - Wires up the Feature and sets `--initialize-at-run-time` for the three imgui classes that load native libraries in their static initializers.
- `flixelgdx-lwjgl3/build.gradle` - Adds `compileOnly "org.graalvm.sdk:nativeimage:24.2.0"` for the Feature API (does not appear in user runtimes).
- `FlixelLwjgl3Alerter.java` - Replaced silent return in native image mode with a stderr print.
- `CLAUDE.md` - Extended the ASCII/punctuation rule to explicitly cover en dash, em dash, and Groovy/Gradle file comments.

## Screenshots / Evidence (if applicable)

Tested against the yes-siir test project via `publishToMavenLocal` + `nativeCompile`. The native binary starts without `ExceptionInInitializerError` and the imgui debug overlay opens correctly.