### PR TITLE
Replaced the vague license header with the full MIT copyright notice on every source file

### DIFF
--- a/flixelgdx-android/src/main/java/me/stringdotjar/flixelgdx/backend/android/FlixelAndroidLauncher.java
+++ b/flixelgdx-android/src/main/java/me/stringdotjar/flixelgdx/backend/android/FlixelAndroidLauncher.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.android;
 
 import com.badlogic.gdx.backends.android.AndroidApplication;

--- a/flixelgdx-android/src/main/java/me/stringdotjar/flixelgdx/backend/android/alert/FlixelAndroidAlerter.java
+++ b/flixelgdx-android/src/main/java/me/stringdotjar/flixelgdx/backend/android/alert/FlixelAndroidAlerter.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.android.alert;
 
 import android.app.Activity;

--- a/flixelgdx-common/src/main/java/me/stringdotjar/flixelgdx/backend/common/audio/FlixelMiniAudioSound.java
+++ b/flixelgdx-common/src/main/java/me/stringdotjar/flixelgdx/backend/common/audio/FlixelMiniAudioSound.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.common.audio;
 
 import games.rednblack.miniaudio.MASound;

--- a/flixelgdx-common/src/main/java/me/stringdotjar/flixelgdx/backend/common/audio/FlixelMiniAudioSoundHandler.java
+++ b/flixelgdx-common/src/main/java/me/stringdotjar/flixelgdx/backend/common/audio/FlixelMiniAudioSoundHandler.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.common.audio;
 
 import games.rednblack.miniaudio.MAGroup;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/Flixel.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelBasic.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelBasic.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import com.badlogic.gdx.graphics.g2d.Batch;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelCamera.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelGame.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import com.badlogic.gdx.Application;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelObject.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelObject.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import me.stringdotjar.flixelgdx.debug.FlixelDebugDrawable;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSprite.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import com.badlogic.gdx.files.FileHandle;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelState.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelState.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import com.badlogic.gdx.Screen;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSubState.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/FlixelSubState.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateRig.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateRig.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import com.badlogic.gdx.graphics.g2d.TextureRegion;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateRigLoader.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateRigLoader.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import com.badlogic.gdx.graphics.Texture;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimateSprite.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationController.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import com.badlogic.gdx.files.FileHandle;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationFrameSignalData.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationFrameSignalData.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import me.stringdotjar.flixelgdx.graphics.FlixelFrame;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationSources.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationSources.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import com.badlogic.gdx.graphics.g2d.Animation;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationStateMachine.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationStateMachine.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import com.badlogic.gdx.utils.ObjectMap;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelSpritemapJsonLoader.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/animation/FlixelSpritemapJsonLoader.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAsset.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAsset.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import com.badlogic.gdx.assets.AssetDescriptor;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetPaths.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelAssetPaths.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import com.badlogic.gdx.Application;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelPooledWrapper.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelPooledWrapper.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelSource.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelStringAssetLoader.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelStringAssetLoader.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import com.badlogic.gdx.assets.AssetDescriptor;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelStringAssetSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelStringAssetSource.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelTypedAsset.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperFactory.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/asset/FlixelWrapperSource.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.asset;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelAudioManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.audio;
 
 import me.stringdotjar.flixelgdx.Flixel;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSound.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.audio;
 
 import me.stringdotjar.flixelgdx.Flixel;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundBackend.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundBackend.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.audio;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSource.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.audio;
 
 import com.badlogic.gdx.files.FileHandle;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSourceLoader.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/audio/FlixelSoundSourceLoader.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.audio;
 
 import com.badlogic.gdx.assets.AssetDescriptor;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/alert/FlixelAlerter.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/alert/FlixelAlerter.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.alert;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/host/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/host/FlixelHostIntegration.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.host;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/host/FlixelNoopHostIntegration.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/host/FlixelNoopHostIntegration.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.host;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/runtime/FlixelRuntimeMode.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/runtime/FlixelRuntimeMode.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.runtime;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/window/FlixelNoopWindow.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/window/FlixelNoopWindow.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.window;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/window/FlixelWindow.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/backend/window/FlixelWindow.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.window;
 
 import me.stringdotjar.flixelgdx.Flixel;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugCommandArgs.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugCommandArgs.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.debug;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugDrawable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugDrawable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.debug;
 
 import me.stringdotjar.flixelgdx.FlixelCamera;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.debug;
 
 import com.badlogic.gdx.utils.Array;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugOverlay.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.debug;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugWatchManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelDebugWatchManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.debug;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelHeadlessDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/debug/FlixelHeadlessDebugOverlay.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.debug;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelAngleable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelAngleable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelColorable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelColorable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelDestroyable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelDestroyable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelDrawable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelDrawable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 import com.badlogic.gdx.graphics.g2d.Batch;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelKillable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelKillable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelPositional.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelPositional.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelShakeable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelShakeable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelUpdatable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelUpdatable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelVisible.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/FlixelVisible.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/IFlixelBasic.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/IFlixelBasic.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional;
 
 import com.badlogic.gdx.utils.Disposable;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/ByteSupplier.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/ByteSupplier.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional.supplier;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/CharSupplier.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/CharSupplier.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional.supplier;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/FloatSupplier.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/FloatSupplier.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional.supplier;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/ShortSupplier.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/functional/supplier/ShortSupplier.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.functional.supplier;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelFrame.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelFrame.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.graphics;
 
 import com.badlogic.gdx.graphics.Texture;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphic.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphic.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.graphics;
 
 import com.badlogic.gdx.graphics.Texture;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicSource.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicSource.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.graphics;
 
 import com.badlogic.gdx.graphics.Texture;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.graphics;
 
 import com.badlogic.gdx.assets.AssetManager;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelBasicGroup.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelBasicGroup.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.group;
 
 import com.badlogic.gdx.graphics.g2d.Batch;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelBasicGroupable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelBasicGroupable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.group;
 
 import com.badlogic.gdx.utils.SnapshotArray;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelGroup.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelGroup.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.group;
 
 import com.badlogic.gdx.utils.ArraySupplier;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelGroupable.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelGroupable.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.group;
 
 import com.badlogic.gdx.utils.SnapshotArray;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/group/FlixelSpriteGroup.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.group;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/FlixelInputManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/FlixelInputManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/FlixelInputProcessorManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/FlixelInputProcessorManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input;
 
 import com.badlogic.gdx.InputProcessor;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelAction.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelAction.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionAnalog.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import com.badlogic.gdx.math.Vector2;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionDigital.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionSet.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionSet.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import com.badlogic.gdx.utils.Array;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionSets.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelActionSets.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import com.badlogic.gdx.utils.Array;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelAnalogAxisBinding.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelAnalogAxisBinding.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import me.stringdotjar.flixelgdx.input.gamepad.FlixelGamepadInput;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelInputBinding.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelInputBinding.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import com.badlogic.gdx.Input;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelInputBindingKind.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelInputBindingKind.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelSteamActionReader.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelSteamActionReader.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelSteamActionReaders.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/action/FlixelSteamActionReaders.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadDetector.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadDetector.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.gamepad;
 
 import java.util.Locale;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadDevice.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadDevice.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.gamepad;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadInput.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadInput.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.gamepad;
 
 import com.badlogic.gdx.Input;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.gamepad;
 
 import com.badlogic.gdx.controllers.Controller;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadModel.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadModel.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.gamepad;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKey.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKey.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.keyboard;
 
 import com.badlogic.gdx.Input;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.keyboard;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseButton.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseButton.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.mouse;
 
 import com.badlogic.gdx.Input;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseIconManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.mouse;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.mouse;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelNativeMouseCursor.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelNativeMouseCursor.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.mouse;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.mouse;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelDebugConsoleEntry.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelDebugConsoleEntry.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 import java.util.Collections;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogConsoleSink.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogConsoleSink.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogEntry.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogEntry.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogFileHandler.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogFileHandler.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogLevel.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogLevel.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogMode.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogMode.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogger.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLogger.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 import me.stringdotjar.flixelgdx.Flixel;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLoggingBytecodeHooks.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelLoggingBytecodeHooks.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 import me.stringdotjar.flixelgdx.Flixel;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelStackFrame.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelStackFrame.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelStackTraceProvider.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/logging/FlixelStackTraceProvider.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.logging;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/text/FlixelFontRegistry.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/text/FlixelFontRegistry.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.text;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/text/FlixelText.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.text;
 
 import com.badlogic.gdx.files.FileHandle;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelEase.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelEase.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween;
 
 /** Class where all easer functions are stored, mostly used for tweening. */

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTween.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTweenManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/FlixelTweenManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween;
 
 import java.util.HashMap;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelShakeUnit.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelShakeUnit.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.settings;
 
 import me.stringdotjar.flixelgdx.functional.FlixelShakeable;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelTweenSettings.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelTweenSettings.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.settings;
 
 import com.badlogic.gdx.utils.Array;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelTweenType.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/settings/FlixelTweenType.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.settings;
 
 /** Enum containing all different tween types that can determine the behavior of a tween. */

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelAngleTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelAngleTween.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelColorTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelColorTween.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelFlickerTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelFlickerTween.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelGoalTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelGoalTween.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelNumTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelNumTween.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type;
 
 import me.stringdotjar.flixelgdx.tween.FlixelTween;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelShakeTween.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/FlixelShakeTween.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelCircularMotion.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelCircularMotion.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type.motion;
 
 import com.badlogic.gdx.math.MathUtils;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelCubicMotion.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelCubicMotion.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type.motion;
 
 import com.badlogic.gdx.math.MathUtils;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelLinearMotion.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelLinearMotion.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type.motion;
 
 import com.badlogic.gdx.math.MathUtils;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelLinearPath.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelLinearPath.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type.motion;
 
 import com.badlogic.gdx.math.MathUtils;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelMotion.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelMotion.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type.motion;
 
 import java.util.Objects;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelQuadMotion.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelQuadMotion.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type.motion;
 
 import com.badlogic.gdx.math.MathUtils;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelQuadPath.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/tween/type/motion/FlixelQuadPath.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween.type.motion;
 
 import com.badlogic.gdx.math.MathUtils;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/ui/FlixelBar.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/ui/FlixelBar.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.ui;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelAsciiCodes.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelAsciiCodes.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelAxes.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelAxes.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelColor.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelColor.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelDebugUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelDebugUtil.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import com.badlogic.gdx.utils.SnapshotArray;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelGitUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelGitUtil.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import java.io.BufferedReader;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelMathUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelMathUtil.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelPathsUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelPathsUtil.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelRuntimeUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelRuntimeUtil.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import org.jetbrains.annotations.Nullable;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelSpriteUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelSpriteUtil.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelString.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelString.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import com.badlogic.gdx.utils.CharArray;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelStringUtil.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/FlixelStringUtil.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import com.badlogic.gdx.utils.CharArray;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/save/FlixelSave.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/save/FlixelSave.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.save;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/save/FlixelSaveStatus.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/save/FlixelSaveStatus.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.save;
 
 /**

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/signal/FlixelSignal.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/signal/FlixelSignal.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.signal;
 
 import com.badlogic.gdx.utils.SnapshotArray;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/signal/FlixelSignalData.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/signal/FlixelSignalData.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.signal;
 
 import me.stringdotjar.flixelgdx.Flixel;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimer.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimer.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.timer;
 
 import com.badlogic.gdx.utils.Pool;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimerListener.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimerListener.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.timer;
 
 import org.jetbrains.annotations.NotNull;

--- a/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimerManager.java
+++ b/flixelgdx-core/src/main/java/me/stringdotjar/flixelgdx/util/timer/FlixelTimerManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.timer;
 
 import com.badlogic.gdx.graphics.g2d.Batch;

--- a/flixelgdx-ios/src/main/java/me/stringdotjar/flixelgdx/backend/ios/FlixelIOSLauncher.java
+++ b/flixelgdx-ios/src/main/java/me/stringdotjar/flixelgdx/backend/ios/FlixelIOSLauncher.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.ios;
 
 import com.badlogic.gdx.backends.iosrobovm.IOSApplication;

--- a/flixelgdx-ios/src/main/java/me/stringdotjar/flixelgdx/backend/ios/alert/FlixelIOSAlerter.java
+++ b/flixelgdx-ios/src/main/java/me/stringdotjar/flixelgdx/backend/ios/alert/FlixelIOSAlerter.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.ios.alert;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-jvm/src/main/java/me/stringdotjar/flixelgdx/backend/jvm/logging/FlixelDefaultStackTraceProvider.java
+++ b/flixelgdx-jvm/src/main/java/me/stringdotjar/flixelgdx/backend/jvm/logging/FlixelDefaultStackTraceProvider.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.jvm.logging;
 
 import me.stringdotjar.flixelgdx.logging.FlixelStackFrame;

--- a/flixelgdx-jvm/src/main/java/me/stringdotjar/flixelgdx/backend/jvm/logging/FlixelJvmLogFileHandler.java
+++ b/flixelgdx-jvm/src/main/java/me/stringdotjar/flixelgdx/backend/jvm/logging/FlixelJvmLogFileHandler.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.jvm.logging;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-jvm/src/main/java/me/stringdotjar/flixelgdx/backend/jvm/runtime/FlixelJvmRuntimeProbe.java
+++ b/flixelgdx-jvm/src/main/java/me/stringdotjar/flixelgdx/backend/jvm/runtime/FlixelJvmRuntimeProbe.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.jvm.runtime;
 
 import java.net.URI;

--- a/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
+++ b/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.gradle.logging;
 
 import org.objectweb.asm.ClassReader;

--- a/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggingExtension.java
+++ b/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggingExtension.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.gradle.logging;
 
 import org.gradle.api.model.ObjectFactory;

--- a/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggingPlugin.java
+++ b/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggingPlugin.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.gradle.logging;
 
 import org.gradle.api.Plugin;

--- a/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelTransformLoggingTask.java
+++ b/flixelgdx-logging-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelTransformLoggingTask.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.gradle.logging;
 
 import org.gradle.api.DefaultTask;

--- a/flixelgdx-logging-plugin/src/test/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaverTest.java
+++ b/flixelgdx-logging-plugin/src/test/java/me/stringdotjar/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaverTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.gradle.logging;
 
 import org.junit.jupiter.api.Test;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3ApplicationConfiguration.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3ApplicationConfiguration.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3ApplicationConfiguration;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3ChainingWindowListener.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3ChainingWindowListener.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3;
 
 import java.awt.EventQueue;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3;
 
 import java.util.Arrays;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3NotifyWindowListener.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3NotifyWindowListener.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3;
 
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Window;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3Window.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/FlixelLwjgl3Window.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/alert/FlixelLwjgl3Alerter.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/alert/FlixelLwjgl3Alerter.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3.alert;
 
 import java.awt.EventQueue;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3.debug;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/graal/FlixelGraalFeature.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3.graal;
 
 import games.rednblack.miniaudio.MiniAudio;

--- a/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/input/FlixelLwjgl3MouseIconManager.java
+++ b/flixelgdx-lwjgl3/src/main/java/me/stringdotjar/flixelgdx/backend/lwjgl3/input/FlixelLwjgl3MouseIconManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.lwjgl3.input;
 
 import java.util.Locale;

--- a/flixelgdx-teavm-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/teavm/FlixelTeaVMExtension.java
+++ b/flixelgdx-teavm-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/teavm/FlixelTeaVMExtension.java
@@ -1,10 +1,26 @@
-/*********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- *********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.gradle.teavm;
 
 import org.gradle.api.file.DirectoryProperty;

--- a/flixelgdx-teavm-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/teavm/FlixelTeaVMPlugin.java
+++ b/flixelgdx-teavm-plugin/src/main/java/me/stringdotjar/flixelgdx/gradle/teavm/FlixelTeaVMPlugin.java
@@ -1,10 +1,26 @@
-/*********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- *********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.gradle.teavm;
 
 import com.sun.net.httpserver.HttpExchange;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm;
 
 import com.github.xpenatan.gdx.teavm.backends.web.WebApplication;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/FlixelTeaVMMouseIconManager.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/FlixelTeaVMMouseIconManager.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm;
 
 import me.stringdotjar.flixelgdx.input.mouse.FlixelMouseIconManager;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/alert/FlixelTeaVMAlerter.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/alert/FlixelTeaVMAlerter.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm.alert;
 
 import org.teavm.jso.JSBody;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/audio/FlixelDefaultSoundHandler.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/audio/FlixelDefaultSoundHandler.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm.audio;
 
 import me.stringdotjar.flixelgdx.audio.FlixelSoundBackend;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/audio/FlixelGdxSound.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/audio/FlixelGdxSound.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm.audio;
 
 import com.badlogic.gdx.Gdx;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/debug/FlixelTeaVMDebugOverlay.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/debug/FlixelTeaVMDebugOverlay.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm.debug;
 
 import me.stringdotjar.flixelgdx.debug.FlixelDebugOverlay;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/logging/FlixelTeaVMLogConsole.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/logging/FlixelTeaVMLogConsole.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm.logging;
 
 import me.stringdotjar.flixelgdx.logging.FlixelLogLevel;

--- a/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/logging/TeaVMStackTraceProvider.java
+++ b/flixelgdx-teavm/src/main/java/me/stringdotjar/flixelgdx/backend/teavm/logging/TeaVMStackTraceProvider.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.backend.teavm.logging;
 
 import me.stringdotjar.flixelgdx.logging.FlixelStackFrame;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/GdxHeadlessExtension.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/GdxHeadlessExtension.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationTypesTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/animation/FlixelAnimationTypesTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.animation;
 
 import org.junit.jupiter.api.Test;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.action;
 
 import com.badlogic.gdx.Input;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadDetectorTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/input/gamepad/FlixelGamepadDetectorTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.gamepad;
 
 import org.junit.jupiter.api.Assertions;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseManagerTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/input/mouse/FlixelMouseManagerTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.input.mouse;
 
 import com.badlogic.gdx.Input;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/signal/FlixelSignalTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/signal/FlixelSignalTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.signal;
 
 import me.stringdotjar.flixelgdx.GdxHeadlessExtension;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/tween/FlixelEaseTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/tween/FlixelEaseTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween;
 
 import org.junit.jupiter.api.Test;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/tween/FlixelNumTweenManagerTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/tween/FlixelNumTweenManagerTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.tween;
 
 import me.stringdotjar.flixelgdx.GdxHeadlessExtension;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/FlixelColorTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/FlixelColorTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import me.stringdotjar.flixelgdx.GdxHeadlessExtension;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/FlixelMathUtilTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/FlixelMathUtilTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import org.junit.jupiter.api.Test;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/FlixelSpriteUtilTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/FlixelSpriteUtilTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util;
 
 import com.badlogic.gdx.graphics.Color;

--- a/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/save/FlixelSaveTest.java
+++ b/flixelgdx-test/src/test/java/me/stringdotjar/flixelgdx/util/save/FlixelSaveTest.java
@@ -1,10 +1,26 @@
-/**********************************************************************************
- * Copyright (c) 2025-2026 stringdotjar
+/*
+ * MIT License
  *
- * This file is part of the FlixelGDX framework, licensed under the MIT License.
- * See the LICENSE file in the repository root for full license information.
- **********************************************************************************/
-
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package me.stringdotjar.flixelgdx.util.save;
 
 import com.badlogic.gdx.utils.ObjectMap;


### PR DESCRIPTION
## Description

The previous license header was a short, vague four-line comment that only pointed readers to the `LICENSE` file. This replaces it across every Java source file with the complete MIT License notice as a multi-line block comment, so the full terms are visible directly at the top of each file.

The header was applied with a Python script (not by hand-editing each file). The script:

- Strips any existing leading block-comment header and prepends the full notice.
- Places the comment directly above the source with no blank line between the comment and the `package` line.
- Excludes `package-info.java` and `module-info.java`, and skips `build/` output.

187 source files were updated. Changes are comment-only; `./gradlew compileJava` succeeds with no new warnings.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - comment-only change.