### PR TITLE
Upgraded the debugger with more quality-of-life features and stats, including flush calls, total assets loaded, etc.

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -1686,10 +1686,8 @@ public final class Flixel {
     public static final FlixelSignal<Void> windowUnfocused = new FlixelSignal<>();
     public static final FlixelSignal<Void> windowMinimized = new FlixelSignal<>();
 
-    private Signals() {
-    }
+    private Signals() {}
   }
 
-  private Flixel() {
-  }
+  private Flixel() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
@@ -125,8 +125,7 @@ public abstract class FlixelBasic implements IFlixelBasic {
    * @param elapsed Seconds elapsed since the last frame.
    */
   @Override
-  public void update(float elapsed) {
-  }
+  public void update(float elapsed) {}
 
   /**
    * Override this function to control how the object is drawn. Doing so is rarely necessary
@@ -135,8 +134,7 @@ public abstract class FlixelBasic implements IFlixelBasic {
    * @param batch The batch used for rendering.
    */
   @Override
-  public void draw(Batch batch) {
-  }
+  public void draw(Batch batch) {}
 
   /**
    * Whether this object should render in the current {@link FlixelGame} camera pass.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
@@ -1144,7 +1144,6 @@ public class FlixelObject extends FlixelBasic implements FlixelDebugDrawable, Fl
     public static final int CEILING = UP;
     public static final int WALL = LEFT | RIGHT;
 
-    private DirectionFlags() {
-    }
+    private DirectionFlags() {}
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
@@ -104,8 +104,7 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
   }
 
   @Override
-  public void render(float delta) {
-  }
+  public void render(float delta) {}
 
   /**
    * Called when the state is first created. This is where you want to assign your
@@ -113,8 +112,7 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
    *
    * <p>Make sure to override this, NOT the constructor!
    */
-  public void create() {
-  }
+  public void create() {}
 
   /**
    * Updates the logic of {@code this} state.
@@ -208,8 +206,7 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
   }
 
   @Override
-  public void resize(int width, int height) {
-  }
+  public void resize(int width, int height) {}
 
   /**
    * Called by the framework when the application is paused by the OS (for example Android backgrounding) or when the
@@ -256,8 +253,7 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
    *
    * <p>Parent states run this hook before substates during {@link #pause()}.
    */
-  protected void onFocusLost() {
-  }
+  protected void onFocusLost() {}
 
   /**
    * Hook for when {@code this} state should treat the game as active again after {@link #onFocusLost()}: window
@@ -265,12 +261,10 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
    *
    * <p>Substates run this hook before their parent states during {@link #resume()}.
    */
-  protected void onFocus() {
-  }
+  protected void onFocus() {}
 
   @Override
-  public void hide() {
-  }
+  public void hide() {}
 
   @Override
   public void destroy() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationSources.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationSources.java
@@ -35,8 +35,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class FlixelAnimationSources {
 
-  private FlixelAnimationSources() {
-  }
+  private FlixelAnimationSources() {}
 
   /**
    * Adds an animation using named regions from an atlas (order preserved).

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
@@ -62,8 +62,7 @@ import java.util.Objects;
  */
 public final class FlixelSpritemapJsonLoader {
 
-  private FlixelSpritemapJsonLoader() {
-  }
+  private FlixelSpritemapJsonLoader() {}
 
   /**
    * Resolves an asset path the same way the rest of FlixelGDX does: first {@code Gdx.files.internal},

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
@@ -161,6 +161,19 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
   float getProgress();
 
   /**
+   * Returns the number of assets currently loaded in the underlying {@link AssetManager}. Reads a
+   * single integer field and does not allocate.
+   *
+   * <p>Useful for tracking memory leaks: a steadily climbing count across state switches often
+   * means assets are being loaded without a matching unload or {@link #clearNonPersist()} call.
+   *
+   * @return Number of loaded assets, or {@code 0} if not available.
+   */
+  default int getLoadedAssetCount() {
+    return 0;
+  }
+
+  /**
    * @param fileName Asset file name/key.
    * @return Whether any type of asset with that name is loaded (libGDX {@link AssetManager#isLoaded(String)}).
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetPaths.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetPaths.java
@@ -40,8 +40,7 @@ import java.util.Objects;
  */
 public final class FlixelAssetPaths {
 
-  private FlixelAssetPaths() {
-  }
+  private FlixelAssetPaths() {}
 
   /**
    * Returns the same path with redundant slashes collapsed and backslashes converted to forward slashes.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -315,6 +315,11 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   }
 
   @Override
+  public int getLoadedAssetCount() {
+    return manager.getLoadedAssets();
+  }
+
+  @Override
   public boolean isLoaded(@NotNull String fileName) {
     return manager
         .isLoaded(FlixelAssetPaths.normalizeAssetPath(Objects.requireNonNull(fileName, "fileName cannot be null.")));

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/host/FlixelNoopHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/host/FlixelNoopHostIntegration.java
@@ -42,8 +42,7 @@ public enum FlixelNoopHostIntegration implements FlixelHostIntegration {
   }
 
   @Override
-  public void requestAttention() {
-  }
+  public void requestAttention() {}
 
   @Override
   public boolean supportsDesktopNotification() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/window/FlixelNoopWindow.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/window/FlixelNoopWindow.java
@@ -32,8 +32,7 @@ public enum FlixelNoopWindow implements FlixelWindow {
   INSTANCE;
 
   @Override
-  public void setOpacity(float opacity) {
-  }
+  public void setOpacity(float opacity) {}
 
   @Override
   public boolean supportsWindowOpacity() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/window/FlixelWindow.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/window/FlixelWindow.java
@@ -131,8 +131,7 @@ public interface FlixelWindow extends FlixelShakeable {
    *
    * @param opacity Opacity in {@code [0, 1]}; non-finite values are ignored.
    */
-  default void setOpacity(float opacity) {
-  }
+  default void setOpacity(float opacity) {}
 
   /**
    * @return {@code true} if {@link #setOpacity(float)} can affect the window on this session.
@@ -144,8 +143,7 @@ public interface FlixelWindow extends FlixelShakeable {
    *
    * @param decorated {@code false} for a borderless window.
    */
-  default void setDecorated(boolean decorated) {
-  }
+  default void setDecorated(boolean decorated) {}
 
   /**
    * @return {@code true} if {@link #setDecorated(boolean)} is supported on this session.
@@ -177,16 +175,14 @@ public interface FlixelWindow extends FlixelShakeable {
    *
    * @param x Target X in screen coordinates.
    */
-  default void setX(int x) {
-  }
+  default void setX(int x) {}
 
   /**
    * Sets the window's Y position in screen coordinates, when supported.
    *
    * @param y Target Y in screen coordinates.
    */
-  default void setY(int y) {
-  }
+  default void setY(int y) {}
 
   /**
    * Moves the window so its client area origin is placed at the given screen coordinates, when supported.
@@ -194,24 +190,21 @@ public interface FlixelWindow extends FlixelShakeable {
    * @param x Target X in screen coordinates.
    * @param y Target Y in screen coordinates.
    */
-  default void setPosition(int x, int y) {
-  }
+  default void setPosition(int x, int y) {}
 
   /**
    * Moves the window horizontally by a delta in screen pixels.
    *
    * @param deltaX Pixels to add to the current X position (negative values move left).
    */
-  default void changeX(int deltaX) {
-  }
+  default void changeX(int deltaX) {}
 
   /**
    * Moves the window vertically by a delta in screen pixels.
    *
    * @param deltaY Pixels to add to the current Y position (negative values move up on backends that use upper-left origin).
    */
-  default void changeY(int deltaY) {
-  }
+  default void changeY(int deltaY) {}
 
   /**
    * Asks the OS to focus this game window (desktop only where GLFW allows it).
@@ -219,8 +212,7 @@ public interface FlixelWindow extends FlixelShakeable {
    * <p><b>CAUTION:</b> Pulling focus away from another application is disruptive. It's advised you warn players ahead of
    * time on your store page, in a first-run dialog, or in an in-game settings label before calling this from normal gameplay.
    */
-  default void bringToForeground() {
-  }
+  default void bringToForeground() {}
 
   /**
    * @return {@code true} if {@link #bringToForeground()} can run on this session.
@@ -237,8 +229,7 @@ public interface FlixelWindow extends FlixelShakeable {
    *
    * @param floating {@code true} to keep the window above normal stacking, {@code false} for default stacking.
    */
-  default void setFloating(boolean floating) {
-  }
+  default void setFloating(boolean floating) {}
 
   /**
    * @return {@code true} if {@link #setFloating(boolean)} may take effect on this session.
@@ -256,8 +247,7 @@ public interface FlixelWindow extends FlixelShakeable {
    *
    * @param absorb {@code true} to cancel the default close handling from the windowing system.
    */
-  default void setAbsorbCloseRequests(boolean absorb) {
-  }
+  default void setAbsorbCloseRequests(boolean absorb) {}
 
   /**
    * @return {@code true} if {@link #setAbsorbCloseRequests(boolean)} is wired for this session.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.debug;
 
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ObjectMap;
 
@@ -93,6 +94,13 @@ public class FlixelDebugManager {
 
   private final ObjectMap<String, RegisteredCommand> commands = new ObjectMap<>();
   private final Array<String> commandHistory = new Array<>(MAX_HISTORY_ENTRIES);
+
+  /**
+   * Extra {@link SpriteBatch} instances registered by game code via {@link #trackBatch(SpriteBatch)}.
+   * The framework's own batch is counted separately in {@link FlixelDebugOverlay}, so only user-supplied
+   * batches live here.
+   */
+  private final Array<SpriteBatch> trackedBatches = new Array<>(false, 4);
 
   /** The sprite currently selected by the LMB picker, or {@code null}. */
   @Nullable
@@ -207,6 +215,47 @@ public class FlixelDebugManager {
       draggedSprite = null;
     }
     return draggedSprite;
+  }
+
+  /**
+   * Registers a {@link SpriteBatch} whose {@code renderCalls} will be included in the debugger's
+   * total render-call count shown in the Stats panel. The framework's own batch is already counted
+   * automatically; call this for any additional batches your game creates.
+   *
+   * <p>Registering a batch that is already tracked is a no-op. The batch must remain valid (not
+   * disposed) for as long as it is registered. Call {@link #untrackBatch(SpriteBatch)} before
+   * disposing a tracked batch.
+   *
+   * <p>Example:
+   * <pre>{@code
+   * SpriteBatch uiBatch = new SpriteBatch();
+   * Flixel.debug.trackBatch(uiBatch);
+   * }</pre>
+   *
+   * @param batch The batch to track. Must not be {@code null}.
+   */
+  public void trackBatch(@NotNull SpriteBatch batch) {
+    if (batch == null || trackedBatches.contains(batch, true)) {
+      return;
+    }
+    trackedBatches.add(batch);
+  }
+
+  /**
+   * Removes a batch that was previously registered via {@link #trackBatch(SpriteBatch)}.
+   * Passing a batch that was never registered is a no-op.
+   *
+   * @param batch The batch to stop tracking.
+   */
+  public void untrackBatch(@NotNull SpriteBatch batch) {
+    if (batch != null) {
+      trackedBatches.removeValue(batch, true);
+    }
+  }
+
+  /** Returns the live array of user-registered batches. Package-private; consumed by the debug overlay. */
+  Array<SpriteBatch> getTrackedBatches() {
+    return trackedBatches;
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -27,6 +27,7 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.graphics.GL20;
 import com.badlogic.gdx.graphics.g2d.Batch;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.glutils.ShapeRenderer;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
@@ -130,6 +131,13 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   protected float cachedHeapMegabytes;
   protected float cachedNativeMegabytes;
   protected int cachedObjectCount;
+
+  /**
+   * Total render-call count snapshotted at the start of each {@link #draw()} call, after the
+   * game's {@link SpriteBatch} has been ended for the frame. Sums the framework's own batch and
+   * any batches registered via {@link FlixelDebugManager#trackBatch(SpriteBatch)}.
+   */
+  protected int cachedRenderCalls;
 
   private float perfSampleTimer = 0f;
 
@@ -751,7 +759,34 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (!visible) {
       return;
     }
+    snapshotRenderCalls();
     drawUI();
+  }
+
+  /**
+   * Sums {@code renderCalls} from the framework's own batch and all user-registered batches.
+   * Called from {@link #draw()} after the game's batch has been ended for the frame, so the
+   * count reflects the full just-completed frame rather than a partial in-progress one.
+   */
+  private void snapshotRenderCalls() {
+    int total = 0;
+    if (Flixel.game != null) {
+      SpriteBatch frameworkBatch = Flixel.game.getBatch();
+      if (frameworkBatch != null) {
+        total += frameworkBatch.renderCalls;
+      }
+    }
+    FlixelDebugManager mgr = Flixel.debug;
+    if (mgr != null) {
+      Array<SpriteBatch> extra = mgr.getTrackedBatches();
+      for (int i = 0, n = extra.size; i < n; i++) {
+        SpriteBatch b = extra.get(i);
+        if (b != null) {
+          total += b.renderCalls;
+        }
+      }
+    }
+    cachedRenderCalls = total;
   }
 
   /** Hook invoked from {@link #draw()} when the overlay is visible. Each platform backend implements this. */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -407,8 +407,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   }
 
   /** Hook for subclass UI state updates that should happen every frame while the overlay is visible. */
-  protected void onUpdateUI(float elapsed) {
-  }
+  protected void onUpdateUI(float elapsed) {}
 
   private void handleToggleKeys() {
     // Use the raw* variants so the toggle keys still work even while a Dear ImGui text field
@@ -452,15 +451,13 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    * in renderer subclasses that need to keep a parallel cache (for example a {@code String[]} for
    * Dear ImGui calls that only accept {@link String}).
    */
-  protected void onWatchEntriesRefreshed() {
-  }
+  protected void onWatchEntriesRefreshed() {}
 
   /**
    * Hook fired after {@link #cachedConsoleBlocks} has been rebuilt. Override in renderer subclasses
    * that need to keep a parallel cache (for example a {@code String[]} for Dear ImGui).
    */
-  protected void onConsoleBlocksRebuilt() {
-  }
+  protected void onConsoleBlocksRebuilt() {}
 
   /**
    * Hook fired right after a new {@link FlixelLogEntry} has been pushed into {@link #logBuffer}.
@@ -470,8 +467,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    *
    * @param line The pooled buffer that was just populated.
    */
-  protected void onLogEntryAppended(BufferedLogLine line) {
-  }
+  protected void onLogEntryAppended(BufferedLogLine line) {}
 
   /**
    * Override to tell the framework's input layer that another UI layer (typically the imgui
@@ -840,8 +836,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    * @param width New window width in pixels.
    * @param height New window height in pixels.
    */
-  public void resize(int width, int height) {
-  }
+  public void resize(int width, int height) {}
 
   private void reclaimConsoleBlocksToPool() {
     for (int i = 0; i < cachedConsoleBlocks.size; i++) {
@@ -951,8 +946,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     public static final int DEFAULT_DEBUG_CAMERA_CYCLE_LEFT = FlixelKey.LEFT;
     public static final int DEFAULT_DEBUG_CAMERA_CYCLE_RIGHT = FlixelKey.RIGHT;
 
-    private Keybinds() {
-    }
+    private Keybinds() {}
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -131,6 +131,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   protected float cachedHeapMegabytes;
   protected float cachedNativeMegabytes;
   protected int cachedObjectCount;
+  protected int cachedAssetCount;
 
   /**
    * Total render-call count snapshotted at the start of each {@link #draw()} call, after the
@@ -152,6 +153,13 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
 
   /** FPS as reported by libGDX per sample. */
   protected final float[] perfFps = new float[PERF_HISTORY_SIZE];
+
+  /**
+   * Render-call count per sample. Sampled in {@link #pushPerfSample(float)} after the
+   * previous frame's batch has been ended but before the next frame's {@code begin()} resets the
+   * counter, so it always reflects a complete frame even when the overlay is hidden.
+   */
+  protected final float[] perfRenderCalls = new float[PERF_HISTORY_SIZE];
 
   /** Index of the next sample to write (rolls over once the ring is full). */
   protected int perfHead = 0;
@@ -310,6 +318,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
       cachedHeapMegabytes = Flixel.getJavaHeapUsedMegabytes();
       cachedNativeMegabytes = Flixel.getNativeHeapUsedMegabytes();
       cachedObjectCount = FlixelDebugUtil.countActiveMembers();
+      cachedAssetCount = Flixel.assets != null ? Flixel.assets.getLoadedAssetCount() : 0;
     }
 
     if (watchRefreshTimer >= WATCH_REFRESH_INTERVAL) {
@@ -333,10 +342,38 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     perfHeapMb[idx] = Flixel.getJavaHeapUsedMegabytes();
     perfNativeMb[idx] = Flixel.getNativeHeapUsedMegabytes();
     perfFps[idx] = Gdx.graphics.getFramesPerSecond();
+    perfRenderCalls[idx] = sampleRenderCallsNow();
     perfHead = (idx + 1) % PERF_HISTORY_SIZE;
     if (perfCount < PERF_HISTORY_SIZE) {
       perfCount++;
     }
+  }
+
+  /**
+   * Reads the current total render-call count from the framework batch and any user-registered
+   * batches. Safe to call from {@link #pushPerfSample(float)} in {@link #update(float)} because
+   * the game loop ends the previous frame's batch before calling {@code update}, so the counter
+   * reflects the just-completed frame and has not yet been reset by the next {@code begin()}.
+   */
+  private int sampleRenderCallsNow() {
+    int total = 0;
+    if (Flixel.game != null) {
+      SpriteBatch frameworkBatch = Flixel.game.getBatch();
+      if (frameworkBatch != null) {
+        total += frameworkBatch.renderCalls;
+      }
+    }
+    FlixelDebugManager mgr = Flixel.debug;
+    if (mgr != null) {
+      Array<SpriteBatch> extra = mgr.getTrackedBatches();
+      for (int i = 0, n = extra.size; i < n; i++) {
+        SpriteBatch b = extra.get(i);
+        if (b != null) {
+          total += b.renderCalls;
+        }
+      }
+    }
+    return total;
   }
 
   /** Returns the index immediately after the latest sample (where the next write will go). */
@@ -363,6 +400,10 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
 
   public final float[] getPerfFps() {
     return perfFps;
+  }
+
+  public final float[] getPerfRenderCalls() {
+    return perfRenderCalls;
   }
 
   /** Hook for subclass UI state updates that should happen every frame while the overlay is visible. */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/FlixelInputManager.java
@@ -42,6 +42,5 @@ public interface FlixelInputManager {
   void endFrame();
 
   /** Clears internal state. Default implementation does nothing. */
-  default void reset() {
-  }
+  default void reset() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
@@ -53,8 +53,7 @@ public final class FlixelActionSets {
 
   private static final Array<FlixelActionSet> registered = new Array<>(8);
 
-  private FlixelActionSets() {
-  }
+  private FlixelActionSets() {}
 
   static void register(@NotNull FlixelActionSet set) {
     for (int i = 0, n = registered.size; i < n; i++) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelSteamActionReaders.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelSteamActionReaders.java
@@ -50,6 +50,5 @@ public final class FlixelSteamActionReaders {
     }
   };
 
-  private FlixelSteamActionReaders() {
-  }
+  private FlixelSteamActionReaders() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadDetector.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadDetector.java
@@ -39,8 +39,7 @@ import java.util.Locale;
  */
 public final class FlixelGamepadDetector {
 
-  private FlixelGamepadDetector() {
-  }
+  private FlixelGamepadDetector() {}
 
   /**
    * Detects the best {@link FlixelGamepadModel} for the given controller name.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInput.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInput.java
@@ -51,8 +51,7 @@ import java.util.Locale;
  */
 public final class FlixelGamepadInput {
 
-  private FlixelGamepadInput() {
-  }
+  private FlixelGamepadInput() {}
 
   public static final int NONE = -2;
   public static final int ANY = -1;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadManager.java
@@ -120,8 +120,7 @@ public final class FlixelGamepadManager implements FlixelInputManager, Controlle
 
   private boolean listenerAttached;
 
-  public FlixelGamepadManager() {
-  }
+  public FlixelGamepadManager() {}
 
   /**
    * Registers a {@link ControllerListener} with gdx-controllers. Safe to call more than once.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKey.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKey.java
@@ -31,8 +31,7 @@ import com.badlogic.gdx.Input;
  */
 public final class FlixelKey {
 
-  private FlixelKey() {
-  }
+  private FlixelKey() {}
 
   public static final int NONE = -2; // In HaxeFlixel, this is -1, but we use -2 to avoid confusion with ANY.
   public static final int ANY = -1;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -126,8 +126,7 @@ public class FlixelKeyInputManager implements FlixelInputProcessorManager {
     }
   };
 
-  public FlixelKeyInputManager() {
-  }
+  public FlixelKeyInputManager() {}
 
   /**
    * Returns the input processor that tracks key state. Add this first to an

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
@@ -139,8 +139,7 @@ public class FlixelMouseManager implements FlixelInputProcessorManager {
     }
   };
 
-  public FlixelMouseManager() {
-  }
+  public FlixelMouseManager() {}
 
   /**
    * Replaces the active {@link FlixelMouseIconManager}, for example with an LWJGL3 or web backend.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
@@ -34,12 +34,10 @@ public enum FlixelNoopMouseIconManager implements FlixelMouseIconManager {
   INSTANCE;
 
   @Override
-  public void setNativeCursor(@NotNull FlixelNativeMouseCursor cursor) {
-  }
+  public void setNativeCursor(@NotNull FlixelNativeMouseCursor cursor) {}
 
   @Override
-  public void clearNativeCursor() {
-  }
+  public void clearNativeCursor() {}
 
   @Override
   public boolean supportsNativeCursor() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLoggingBytecodeHooks.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLoggingBytecodeHooks.java
@@ -35,8 +35,7 @@ import org.flixelgdx.Flixel;
  */
 public final class FlixelLoggingBytecodeHooks {
 
-  private FlixelLoggingBytecodeHooks() {
-  }
+  private FlixelLoggingBytecodeHooks() {}
 
   public static void bcInfo0(Object message, String sourceFile, int line, String declaringClass,
       String declaringMethod) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRegistry.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRegistry.java
@@ -100,8 +100,7 @@ public final class FlixelFontRegistry {
    */
   private static final ObjectMap<String, BitmapFont> freeTypeBitmapFonts = new ObjectMap<>();
 
-  private FlixelFontRegistry() {
-  }
+  private FlixelFontRegistry() {}
 
   /**
    * Registers a TrueType font under the given identifier. If an entry with the same

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelEase.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelEase.java
@@ -37,8 +37,7 @@ public final class FlixelEase {
   private static final float ELASTIC_AMPLITUDE = 1;
   private static final float ELASTIC_PERIOD = 0.4f;
 
-  private FlixelEase() {
-  }
+  private FlixelEase() {}
 
   public static float linear(float t) {
     return t;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -171,8 +171,7 @@ public abstract class FlixelTween implements Pool.Poolable {
   protected boolean internalRestart = false;
 
   /** Default constructor for pooling purposes. */
-  protected FlixelTween() {
-  }
+  protected FlixelTween() {}
 
   /**
    * Constructs a new tween with the provided settings.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelAsciiCodes.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelAsciiCodes.java
@@ -42,6 +42,5 @@ public final class FlixelAsciiCodes {
   public static final String CYAN = "\u001B[36m";
   public static final String WHITE = "\u001B[37m";
 
-  private FlixelAsciiCodes() {
-  }
+  private FlixelAsciiCodes() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
@@ -45,8 +45,7 @@ import java.util.function.Consumer;
  */
 public final class FlixelDebugUtil {
 
-  private FlixelDebugUtil() {
-  }
+  private FlixelDebugUtil() {}
 
   /**
    * Recursively counts all active members in the current state's object tree. A member is

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelGitUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelGitUtil.java
@@ -100,6 +100,5 @@ public final class FlixelGitUtil {
     }
   }
 
-  private FlixelGitUtil() {
-  }
+  private FlixelGitUtil() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelMathUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelMathUtil.java
@@ -40,6 +40,5 @@ public final class FlixelMathUtil {
     return Math.round(value * scale) / scale;
   }
 
-  private FlixelMathUtil() {
-  }
+  private FlixelMathUtil() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelPathsUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelPathsUtil.java
@@ -77,6 +77,5 @@ public final class FlixelPathsUtil {
     return Flixel.ensureAssets().resolveAudioPath(path);
   }
 
-  private FlixelPathsUtil() {
-  }
+  private FlixelPathsUtil() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelRuntimeUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelRuntimeUtil.java
@@ -293,6 +293,5 @@ public final class FlixelRuntimeUtil {
     UNKNOWN
   }
 
-  private FlixelRuntimeUtil() {
-  }
+  private FlixelRuntimeUtil() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
@@ -60,8 +60,7 @@ import java.util.Objects;
  */
 public final class FlixelSpriteUtil {
 
-  private FlixelSpriteUtil() {
-  }
+  private FlixelSpriteUtil() {}
 
   private static final Vector2 TMP_V2 = new Vector2();
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
@@ -88,6 +88,5 @@ public final class FlixelStringUtil {
     out.append((char) ('0' + frac));
   }
 
-  private FlixelStringUtil() {
-  }
+  private FlixelStringUtil() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/signal/FlixelSignalData.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/signal/FlixelSignalData.java
@@ -45,8 +45,7 @@ public final class FlixelSignalData {
   public static final class UpdateSignalData {
     private float elapsed;
 
-    public UpdateSignalData() {
-    }
+    public UpdateSignalData() {}
 
     public UpdateSignalData(float elapsed) {
       this.elapsed = elapsed;
@@ -64,6 +63,5 @@ public final class FlixelSignalData {
   public record StateSwitchSignalData(FlixelState state) {
   }
 
-  private FlixelSignalData() {
-  }
+  private FlixelSignalData() {}
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
@@ -103,8 +103,7 @@ public class FlixelTimerManager extends FlixelBasic {
   }
 
   @Override
-  public final void draw(Batch batch) {
-  }
+  public final void draw(Batch batch) {}
 
   @Override
   public void destroy() {

--- a/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
+++ b/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
@@ -138,8 +138,7 @@ public final class FlixelLoggerBytecodeWeaver {
   private record Replacement(String newName, String newDescriptor) {
   }
 
-  private FlixelLoggerBytecodeWeaver() {
-  }
+  private FlixelLoggerBytecodeWeaver() {}
 
   /**
    * @return {@code true} if at least one invocation was rewritten.

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -484,6 +484,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
    *
    * <pre>{@code
    * public class MyOverlay extends FlixelImGuiDebugOverlay {
+   *
    *   protected void onDrawImGui() {
    *     // New standalone window.
    *     if (ImGui.begin("My Panel")) {
@@ -510,8 +511,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
    * }
    * }</pre>
    */
-  protected void onDrawImGui() {
-  }
+  protected void onDrawImGui() {}
 
   private static long resolveGlfwWindowHandle() {
     if (!(Gdx.graphics instanceof Lwjgl3Graphics graphics)) {

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -136,6 +136,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private float perfScaleMaxFrameMs = 1f;
   private float perfScaleMaxHeapMb = 1f;
   private float perfScaleMaxNativeMb = 1f;
+  private float perfScaleMaxRenderCalls = 1f;
 
   private final ImGuiImplGlfw imGuiGlfw = new ImGuiImplGlfw();
   private final ImGuiImplGl3 imGuiGl3 = new ImGuiImplGl3();
@@ -867,6 +868,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     drawStatRow("Heap (MB)", cachedHeapMegabytes);
     drawStatRow("Native (MB)", cachedNativeMegabytes);
     drawStatRow("Active members", cachedObjectCount);
+    drawStatRow("Assets loaded", cachedAssetCount);
     drawStatRow("Render calls", cachedRenderCalls);
 
     ImGui.separator();
@@ -888,6 +890,10 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       text(COLOR_VALUE, "0 (none)");
     } else {
       text(COLOR_VALUE, (inspect + 1) + " / " + camCount);
+      FlixelCamera cam = cams.get(inspect);
+      drawStatRow("  Scroll X", cam.scrollX);
+      drawStatRow("  Scroll Y", cam.scrollY);
+      drawStatRow("  Zoom", cam.getZoom());
     }
     ImGui.end();
   }
@@ -943,6 +949,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     perfScaleMaxFrameMs = Math.max(ringMax(getPerfFrameMs(), count) * 1.15f, perfScaleMaxFrameMs * 0.997f);
     perfScaleMaxHeapMb = Math.max(ringMax(getPerfHeapMb(), count) * 1.15f, perfScaleMaxHeapMb * 0.997f);
     perfScaleMaxNativeMb = Math.max(ringMax(getPerfNativeMb(), count) * 1.15f, perfScaleMaxNativeMb * 0.997f);
+    perfScaleMaxRenderCalls = Math.max(ringMax(getPerfRenderCalls(), count) * 1.15f, perfScaleMaxRenderCalls * 0.997f);
 
     float graphWidth = ImGui.getContentRegionAvailX();
     float graphHeight = 60f;
@@ -975,6 +982,14 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       ImGui.plotLines("##native", getPerfNativeMb(), count, offset, "", 0f, perfScaleMaxNativeMb, graphWidth,
           graphHeight);
     }
+
+    // Render calls plot.
+    text(COLOR_KEY, "Render calls");
+    ImGui.sameLine();
+    text(COLOR_VALUE, Integer.toString(Math.round(latestSample(getPerfRenderCalls()))));
+    ImGui.plotLines("##rendercalls", getPerfRenderCalls(), count, offset, "", 0f, perfScaleMaxRenderCalls, graphWidth,
+        graphHeight);
+
     ImGui.end();
   }
 

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -867,6 +867,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     drawStatRow("Heap (MB)", cachedHeapMegabytes);
     drawStatRow("Native (MB)", cachedNativeMegabytes);
     drawStatRow("Active members", cachedObjectCount);
+    drawStatRow("Render calls", cachedRenderCalls);
 
     ImGui.separator();
     boolean paused = Flixel.isPaused();

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -389,7 +389,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     drawConsoleWindow();
     drawCommandWindow();
     drawTextureWindow();
-    onDrawExtraWindows();
+    onDrawImGui();
 
     // The forced-layout pass only lasts one frame; subsequent frames use FirstUseEver so the
     // user's manual window moves stick.
@@ -471,71 +471,46 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   }
 
   /**
-   * Hook for subclasses that want to add extra Dear ImGui windows to the overlay.
+   * Hook for subclasses that want to add custom Dear ImGui content to the overlay.
    *
    * <p>Called once per frame from {@link #drawUI()} after all built-in panels have been submitted
-   * ({@code drawStatsWindow()}, {@code drawPerformanceWindow()}, and so on) but before
-   * {@code ImGui.render()} is called. At the call site the Dear ImGui frame is open and a
-   * full-screen passthrough dockspace is active, so you can call any combination of
-   * {@code ImGui.begin()} / {@code ImGui.end()} blocks here and they will be docked or floated
-   * exactly like the built-in windows.
+   * but before {@code ImGui.render()} is called. The Dear ImGui frame is fully open, so any
+   * standard Dear ImGui call is valid here.
    *
-   * <p>Example usage:
+   * <p>Because Dear ImGui is an immediate-mode API, a second {@code ImGui.begin()} call with the
+   * same window title as an existing panel appends content to that panel rather than creating a
+   * new one. This means a single override can both add new windows and inject content into any
+   * built-in window without needing a separate hook for each one:
+   *
    * <pre>{@code
    * public class MyOverlay extends FlixelImGuiDebugOverlay {
-   *   protected void onDrawExtraWindows() {
-   *     if (ImGui.begin("My Custom Panel")) {
-   *       ImGui.textUnformatted("Hello from a custom panel!");
+   *   protected void onDrawImGui() {
+   *     // New standalone window.
+   *     if (ImGui.begin("My Panel")) {
+   *       ImGui.textUnformatted("Custom content here.");
    *     }
    *     ImGui.end();
-   *   }
-   * }
-   * }</pre>
-   */
-  protected void onDrawExtraWindows() {
-  }
-
-  /**
-   * Hook for subclasses that want to add extra entries to the main menu bar.
    *
-   * <p>Called from {@code drawMainMenuBar()} after the built-in "Debug" and "Game" menus have been
-   * added and before {@code ImGui.endMainMenuBar()} is called. The menu bar is open and
-   * ready to accept additional {@code ImGui.beginMenu()} / {@code ImGui.endMenu()} blocks.
+   *     // Append extra rows to the built-in Stats panel.
+   *     if (ImGui.begin("Stats")) {
+   *       ImGui.separator();
+   *       ImGui.textUnformatted("My stat: " + myValue);
+   *     }
+   *     ImGui.end();
    *
-   * <p>Example usage:
-   * <pre>{@code
-   * public class MyOverlay extends FlixelImGuiDebugOverlay {
-   *   protected void onDrawMainMenuBarExtras() {
-   *     if (ImGui.beginMenu("My Tools")) {
-   *       if (ImGui.menuItem("Spawn enemy")) { spawnEnemy(); }
-   *       ImGui.endMenu();
+   *     // Add a menu to the main menu bar.
+   *     if (ImGui.beginMainMenuBar()) {
+   *       if (ImGui.beginMenu("My Tools")) {
+   *         if (ImGui.menuItem("Spawn enemy")) { spawnEnemy(); }
+   *         ImGui.endMenu();
+   *       }
+   *       ImGui.endMainMenuBar();
    *     }
    *   }
    * }
    * }</pre>
    */
-  protected void onDrawMainMenuBarExtras() {
-  }
-
-  /**
-   * Hook for subclasses that want to append extra rows to the Stats panel.
-   *
-   * <p>Called from {@code drawStatsWindow()} after all built-in stat rows (FPS, heap, cameras,
-   * and so on) have been drawn and before {@code ImGui.end()} closes the window. You can call
-   * {@code ImGui.separator()}, {@code ImGui.textUnformatted()}, or any other Dear ImGui calls
-   * to append more content to the window.
-   *
-   * <p>Example usage:
-   * <pre>{@code
-   * public class MyOverlay extends FlixelImGuiDebugOverlay {
-   *   protected void onDrawStatsExtras() {
-   *     ImGui.separator();
-   *     ImGui.textUnformatted("My custom stat: " + myValue);
-   *   }
-   * }
-   * }</pre>
-   */
-  protected void onDrawStatsExtras() {
+  protected void onDrawImGui() {
   }
 
   private static long resolveGlfwWindowHandle() {
@@ -921,7 +896,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       }
       ImGui.endMenu();
     }
-    onDrawMainMenuBarExtras();
     ImGui.endMainMenuBar();
   }
 
@@ -965,7 +939,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       drawStatRow("  Scroll Y", cam.scrollY);
       drawStatRow("  Zoom", cam.getZoom());
     }
-    onDrawStatsExtras();
     ImGui.end();
   }
 

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -389,6 +389,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     drawConsoleWindow();
     drawCommandWindow();
     drawTextureWindow();
+    onDrawExtraWindows();
 
     // The forced-layout pass only lasts one frame; subsequent frames use FirstUseEver so the
     // user's manual window moves stick.
@@ -467,6 +468,74 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     if (logAutoScroll.get()) {
       scrollLogToBottom = true;
     }
+  }
+
+  /**
+   * Hook for subclasses that want to add extra Dear ImGui windows to the overlay.
+   *
+   * <p>Called once per frame from {@link #drawUI()} after all built-in panels have been submitted
+   * ({@code drawStatsWindow()}, {@code drawPerformanceWindow()}, and so on) but before
+   * {@code ImGui.render()} is called. At the call site the Dear ImGui frame is open and a
+   * full-screen passthrough dockspace is active, so you can call any combination of
+   * {@code ImGui.begin()} / {@code ImGui.end()} blocks here and they will be docked or floated
+   * exactly like the built-in windows.
+   *
+   * <p>Example usage:
+   * <pre>{@code
+   * public class MyOverlay extends FlixelImGuiDebugOverlay {
+   *   protected void onDrawExtraWindows() {
+   *     if (ImGui.begin("My Custom Panel")) {
+   *       ImGui.textUnformatted("Hello from a custom panel!");
+   *     }
+   *     ImGui.end();
+   *   }
+   * }
+   * }</pre>
+   */
+  protected void onDrawExtraWindows() {
+  }
+
+  /**
+   * Hook for subclasses that want to add extra entries to the main menu bar.
+   *
+   * <p>Called from {@code drawMainMenuBar()} after the built-in "Debug" and "Game" menus have been
+   * added and before {@code ImGui.endMainMenuBar()} is called. The menu bar is open and
+   * ready to accept additional {@code ImGui.beginMenu()} / {@code ImGui.endMenu()} blocks.
+   *
+   * <p>Example usage:
+   * <pre>{@code
+   * public class MyOverlay extends FlixelImGuiDebugOverlay {
+   *   protected void onDrawMainMenuBarExtras() {
+   *     if (ImGui.beginMenu("My Tools")) {
+   *       if (ImGui.menuItem("Spawn enemy")) { spawnEnemy(); }
+   *       ImGui.endMenu();
+   *     }
+   *   }
+   * }
+   * }</pre>
+   */
+  protected void onDrawMainMenuBarExtras() {
+  }
+
+  /**
+   * Hook for subclasses that want to append extra rows to the Stats panel.
+   *
+   * <p>Called from {@code drawStatsWindow()} after all built-in stat rows (FPS, heap, cameras,
+   * and so on) have been drawn and before {@code ImGui.end()} closes the window. You can call
+   * {@code ImGui.separator()}, {@code ImGui.textUnformatted()}, or any other Dear ImGui calls
+   * to append more content to the window.
+   *
+   * <p>Example usage:
+   * <pre>{@code
+   * public class MyOverlay extends FlixelImGuiDebugOverlay {
+   *   protected void onDrawStatsExtras() {
+   *     ImGui.separator();
+   *     ImGui.textUnformatted("My custom stat: " + myValue);
+   *   }
+   * }
+   * }</pre>
+   */
+  protected void onDrawStatsExtras() {
   }
 
   private static long resolveGlfwWindowHandle() {
@@ -852,6 +921,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       }
       ImGui.endMenu();
     }
+    onDrawMainMenuBarExtras();
     ImGui.endMainMenuBar();
   }
 
@@ -895,6 +965,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       drawStatRow("  Scroll Y", cam.scrollY);
       drawStatRow("  Zoom", cam.getZoom());
     }
+    onDrawStatsExtras();
     ImGui.end();
   }
 

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/logging/FlixelTeaVMLogConsole.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/logging/FlixelTeaVMLogConsole.java
@@ -38,8 +38,7 @@ import org.teavm.jso.JSBody;
  */
 public final class FlixelTeaVMLogConsole {
 
-  private FlixelTeaVMLogConsole() {
-  }
+  private FlixelTeaVMLogConsole() {}
 
   /**
    * Forwards one structured log to JavaScript. Matches {@code FlixelLogConsoleSink#emit} for use

--- a/gradle/spotless/eclipse-formatter.xml
+++ b/gradle/spotless/eclipse-formatter.xml
@@ -331,6 +331,7 @@
   <setting id="org.eclipse.jdt.core.formatter.keep_code_on_same_line_as_closing_brace_for_empty_type_declaration" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+  <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_if_empty"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_simple_class_on_one_line" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>


### PR DESCRIPTION
## Description

Adds render-call count tracking to the FlixelGDX in-game debugger.

`renderCalls` on a `SpriteBatch` counts how many times the batch flushed its geometry to the GPU per frame (i.e., actual GPU draw calls, not the number of `draw()` invocations). High flush counts are one of the most common causes of performance drops in libGDX games, so surfacing this in the Stats panel makes it immediately visible when a code change is hurting batching.

The framework's own global batch is counted automatically. Game code can also register additional batches via the new `Flixel.debug.trackBatch(myBatch)` API so their render calls are included in the total.

The snapshot is taken at the start of `FlixelDebugOverlay.draw()`, after the game's batch has been ended for the frame, so the count always reflects the just-completed frame accurately.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - the change adds a new row ("Render calls") to the Stats debug window alongside FPS, Heap, Native, and Active members.