### PR TITLE
Added an onBeforeInitialize callback to all platform launchers to allow injecting custom services

### DIFF
--- a/flixelgdx-android/src/main/java/org/flixelgdx/backend/android/FlixelAndroidLauncher.java
+++ b/flixelgdx-android/src/main/java/org/flixelgdx/backend/android/FlixelAndroidLauncher.java
@@ -65,12 +65,47 @@ public class FlixelAndroidLauncher {
    * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
    */
   public static void launch(FlixelGame game, AndroidApplication activity, FlixelRuntimeMode runtimeMode) {
+    launch(game, activity, runtimeMode, null);
+  }
+
+  /**
+   * Launches the Android version of the game with an optional pre-initialization callback.
+   *
+   * <p>{@code onBeforeInitialize} fires after all default FlixelGDX backend services (alerter,
+   * audio, etc.) have been registered but before {@link Flixel#initialize} is called. Use it to
+   * override any of those defaults without needing to duplicate the rest of the launcher wiring:
+   *
+   * <pre>{@code
+   * public class MyAndroidLauncher extends AndroidApplication {
+   *   protected void onCreate(Bundle savedInstanceState) {
+   *     super.onCreate(savedInstanceState);
+   *     FlixelAndroidLauncher.launch(
+   *         new MyGame("My Game", 800, 600, new InitialState()),
+   *         this,
+   *         FlixelRuntimeMode.RELEASE,
+   *         () -> Flixel.setAlerter(myCustomAlerter)
+   *     );
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param game The game instance to launch (e.g. {@code new MyGame(...)}).
+   * @param activity The Android application activity (must extend {@link AndroidApplication}).
+   * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
+   * @param onBeforeInitialize Optional callback invoked just before {@link Flixel#initialize}.
+   *     Pass {@code null} to skip.
+   */
+  public static void launch(FlixelGame game, AndroidApplication activity, FlixelRuntimeMode runtimeMode,
+      Runnable onBeforeInitialize) {
     Flixel.setAlerter(new FlixelAndroidAlerter(activity));
     Flixel.setStackTraceProvider(new FlixelDefaultStackTraceProvider());
     Flixel.setLogFileHandler(new FlixelJvmLogFileHandler());
     Flixel.setSoundBackendFactory(new FlixelMiniAudioSoundHandler());
     Flixel.setRuntimeMode(runtimeMode);
     Flixel.setDebugMode(runtimeMode == FlixelRuntimeMode.DEBUG);
+    if (onBeforeInitialize != null) {
+      onBeforeInitialize.run();
+    }
     Flixel.initialize(game);
 
     AndroidApplicationConfiguration configuration = new AndroidApplicationConfiguration();

--- a/flixelgdx-ios/src/main/java/org/flixelgdx/backend/ios/FlixelIOSLauncher.java
+++ b/flixelgdx-ios/src/main/java/org/flixelgdx/backend/ios/FlixelIOSLauncher.java
@@ -82,12 +82,45 @@ public class FlixelIOSLauncher {
    * @return The configured {@link IOSApplication} to return from {@code createApplication()}.
    */
   public static IOSApplication launch(FlixelGame game, FlixelRuntimeMode runtimeMode) {
+    return launch(game, runtimeMode, null);
+  }
+
+  /**
+   * Launches the iOS version of the game with an optional pre-initialization callback.
+   *
+   * <p>{@code onBeforeInitialize} fires after all default FlixelGDX backend services (alerter,
+   * audio, etc.) have been registered but before {@link Flixel#initialize} is called. Use it to
+   * override any of those defaults without needing to duplicate the rest of the launcher wiring:
+   *
+   * <pre>{@code
+   * public class MyIOSLauncher extends IOSApplication.Delegate {
+   *   protected IOSApplication createApplication() {
+   *     return FlixelIOSLauncher.launch(
+   *         new MyGame("My Game", 800, 600, new InitialState()),
+   *         FlixelRuntimeMode.DEBUG,
+   *         () -> Flixel.setAlerter(myCustomAlerter)
+   *     );
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param game The game instance to launch (e.g. {@code new MyGame(...)}).
+   * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
+   * @param onBeforeInitialize Optional callback invoked just before {@link Flixel#initialize}.
+   *     Pass {@code null} to skip.
+   * @return The configured {@link IOSApplication} to return from {@code createApplication()}.
+   */
+  public static IOSApplication launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
+      Runnable onBeforeInitialize) {
     Flixel.setAlerter(new FlixelIOSAlerter());
     Flixel.setStackTraceProvider(new FlixelDefaultStackTraceProvider());
     Flixel.setLogFileHandler(new FlixelJvmLogFileHandler());
     Flixel.setSoundBackendFactory(new FlixelMiniAudioSoundHandler());
     Flixel.setRuntimeMode(runtimeMode);
     Flixel.setDebugMode(runtimeMode == FlixelRuntimeMode.DEBUG);
+    if (onBeforeInitialize != null) {
+      onBeforeInitialize.run();
+    }
     Flixel.initialize(game);
 
     IOSApplicationConfiguration configuration = new IOSApplicationConfiguration();

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
@@ -52,97 +52,73 @@ public class FlixelLwjgl3Launcher {
   private static volatile boolean linuxAwtCompatibilityPrepared;
 
   /**
-   * Ensures Flixel window notifications, optional user {@link com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowListener},
-   * and close-absorption wrapping are installed. Only {@link FlixelLwjgl3ApplicationConfiguration} is supported so the
-   * user listener can be captured without reflection, which allows AOT compilers like GraalVM to not scream at you.
-   */
-  public static void attachFlixelWindowListener(FlixelLwjgl3ApplicationConfiguration configuration) {
-    configuration.attachFlixelWindowListenerChain();
-  }
-
-  /**
-   * Linux AWT uses GTK for dialogs. Prefer GTK3 before any AWT class loads to reduce broken embeddings
-   * (orphan windows, wrong icons) on Cinnamon and other GTK3 desktops.
-   */
-  private static void prepareLinuxAwtCompatibility() {
-    if (linuxAwtCompatibilityPrepared) {
-      return;
-    }
-    linuxAwtCompatibilityPrepared = true;
-    if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux")) {
-      System.setProperty("jdk.gtk.version", "3");
-    }
-  }
-
-  /**
    * Launches the LWJGL3 version of the Flixel game in {@link FlixelRuntimeMode#RELEASE RELEASE}
-   * mode and with a default configuration object. This should be called from the main method of the
-   * libGDX LWJGL3 launcher class, and the game instance should be created in the same general area.
+   * mode with a default configuration. This should be called from the main method of the libGDX
+   * LWJGL3 launcher class.
    *
    * @param game The game instance to launch.
    */
   public static void launch(FlixelGame game) {
-    launch(game, FlixelRuntimeMode.RELEASE, "");
+    launch(game, FlixelRuntimeMode.RELEASE, (Runnable) null);
   }
 
   /**
    * Launches the LWJGL3 version of the Flixel game in {@link FlixelRuntimeMode#RELEASE RELEASE}
-   * mode and with pre-made configuration object. This should be called from the main method of the
-   * libGDX LWJGL3 launcher class, and the game instance should be created in the same general area.
+   * mode with a default configuration and the given window icons.
    *
    * @param game The game instance to launch.
    * @param icons Window icon paths. Make sure your icons actually exist and are valid!
    */
   public static void launch(FlixelGame game, String... icons) {
-    launch(game, FlixelRuntimeMode.RELEASE, icons);
+    launch(game, FlixelRuntimeMode.RELEASE, buildDefaultConfig(game, icons), null);
   }
 
   /**
-   * Launches the LWJGL3 version of the Flixel game with the given runtime mode and a pre-made configuration object.
-   * This should be called from the main method of the libGDX LWJGL3 launcher class, and the game instance
-   * should be created in the same general area.
+   * Launches the LWJGL3 version of the Flixel game with the given runtime mode and a default
+   * configuration built from the game's own settings.
    *
    * @param game The game instance to launch.
    * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
    * @param icons Window icon paths. Make sure your icons actually exist and are valid!
    */
   public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode, String... icons) {
-    Objects.requireNonNull(game, "The game object provided cannot be null!");
-    FlixelLwjgl3ApplicationConfiguration configuration = new FlixelLwjgl3ApplicationConfiguration();
-    configuration.setTitle(game.getTitle());
-    configuration.useVsync(game.isVsync());
-    configuration.setForegroundFPS(game.getFramerate());
-    if (game.isFullscreen()) {
-      configuration.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
-    } else {
-      configuration.setWindowedMode(game.getViewWidth(), game.getViewHeight());
-    }
-    // Ensure the icons are not null, empty, or whitespace only.
-    configuration.setWindowIcon(Arrays.stream(icons)
-        .filter(Objects::nonNull)
-        .map(String::trim)
-        .filter(s -> !s.isEmpty())
-        .toArray(String[]::new));
-    if (game.isTransparentFramebufferRequested()) {
-      configuration.setTransparentFramebuffer(true);
-    }
-    attachFlixelWindowListener(configuration);
-
-    launch(game, runtimeMode, configuration);
+    launch(game, runtimeMode, buildDefaultConfig(game, icons), null);
   }
 
   /**
-   * Launches the LWJGL3 version of the Flixel game in {@link FlixelRuntimeMode#RELEASE RELEASE}
-   * mode using the given configuration. This should be called from the main method of the libGDX LWJGL3 launcher class.
+   * Launches the LWJGL3 version of the Flixel game with the given runtime mode, a default
+   * configuration, and an optional pre-initialization callback.
    *
-   * <p>This method is useful if you have an existing libGDX project with an already made configuration object and
-   * you want to integrate FlixelGDX into it.
+   * <p>Use this when you want to inject custom services (e.g. a custom debug overlay) without
+   * supplying a full configuration object. The configuration is built from the game's own settings
+   * exactly as {@link #buildDefaultConfig(FlixelGame, String[])} would produce it.
+   *
+   * <pre>{@code
+   * FlixelLwjgl3Launcher.launch(game, FlixelRuntimeMode.DEBUG, () -> {
+   *   Flixel.setDebugOverlay(MyCustomOverlay::new);
+   * });
+   * }</pre>
    *
    * @param game The game instance to launch.
    * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
-   * @param configuration The {@link FlixelLwjgl3ApplicationConfiguration} to use. Use this type (not a raw
-   * {@link Lwjgl3ApplicationConfiguration}) so a custom {@link com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowListener}
-   * can be preserved without reflection.
+   * @param onBeforeInitialize Optional callback invoked just before {@link Flixel#initialize}.
+   *     Pass {@code null} to skip.
+   */
+  public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
+      @Nullable Runnable onBeforeInitialize) {
+    launch(game, runtimeMode, buildDefaultConfig(game), onBeforeInitialize);
+  }
+
+  /**
+   * Launches the LWJGL3 version of the Flixel game using the given configuration. Useful when you
+   * have an existing libGDX project with an already-made configuration object.
+   *
+   * @param game The game instance to launch.
+   * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
+   * @param configuration The {@link FlixelLwjgl3ApplicationConfiguration} to use. Use this type
+   *     (not a raw {@link Lwjgl3ApplicationConfiguration}) so a custom
+   *     {@link com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowListener} can be preserved without
+   *     reflection.
    */
   public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
       FlixelLwjgl3ApplicationConfiguration configuration) {
@@ -150,17 +126,20 @@ public class FlixelLwjgl3Launcher {
   }
 
   /**
-   * Launches the LWJGL3 version of the Flixel game with an optional pre-initialization callback.
+   * Launches the LWJGL3 version of the Flixel game with full control over both the window
+   * configuration and the pre-initialization callback.
    *
-   * <p>This is the most flexible overload. {@code onBeforeInitialize} fires after all default
-   * FlixelGDX backend services (alerter, audio, debug overlay, etc.) have been registered but
-   * before {@link Flixel#initialize} is called. Use it to override any of those defaults without
-   * needing to duplicate the rest of the launcher wiring:
+   * <p>{@code onBeforeInitialize} fires after all default FlixelGDX backend services (alerter,
+   * audio, debug overlay, etc.) have been registered but before {@link Flixel#initialize} is
+   * called. Use it to override any of those defaults without duplicating the rest of the launcher
+   * wiring. Call {@link #buildDefaultConfig(FlixelGame, String[])} to get the same starting
+   * configuration the other overloads would use, then customize it before passing it in:
    *
    * <pre>{@code
+   * FlixelLwjgl3ApplicationConfiguration config = FlixelLwjgl3Launcher.buildDefaultConfig(game);
+   * config.setWindowedMode(1920, 1080);
    * FlixelLwjgl3Launcher.launch(game, FlixelRuntimeMode.DEBUG, config, () -> {
-   *     Flixel.setDebugOverlay(MyCustomOverlay::new);
-   *     Flixel.setAlerter(myCustomAlerter);
+   *   Flixel.setDebugOverlay(MyCustomOverlay::new);
    * });
    * }</pre>
    *
@@ -203,6 +182,68 @@ public class FlixelLwjgl3Launcher {
 
     if (AnsiConsole.isInstalled()) {
       AnsiConsole.systemUninstall();
+    }
+  }
+
+  /**
+   * Builds the default {@link FlixelLwjgl3ApplicationConfiguration} for a game the same way the
+   * simple {@code launch} overloads would. Use this when you need to customize the configuration
+   * before passing it to {@link #launch(FlixelGame, FlixelRuntimeMode, FlixelLwjgl3ApplicationConfiguration, Runnable)}.
+   *
+   * <pre>{@code
+   * FlixelLwjgl3ApplicationConfiguration config = FlixelLwjgl3Launcher.buildDefaultConfig(game);
+   * config.setWindowedMode(1920, 1080);
+   * FlixelLwjgl3Launcher.launch(game, FlixelRuntimeMode.RELEASE, config);
+   * }</pre>
+   *
+   * @param game The game instance the configuration is built for.
+   * @param icons Window icon paths (may be empty or omitted). Invalid paths are silently skipped.
+   * @return A new {@link FlixelLwjgl3ApplicationConfiguration} ready to pass to {@code launch}.
+   */
+  public static FlixelLwjgl3ApplicationConfiguration buildDefaultConfig(FlixelGame game,
+      String... icons) {
+    Objects.requireNonNull(game, "The game object provided cannot be null!");
+    FlixelLwjgl3ApplicationConfiguration configuration = new FlixelLwjgl3ApplicationConfiguration();
+    configuration.setTitle(game.getTitle());
+    configuration.useVsync(game.isVsync());
+    configuration.setForegroundFPS(game.getFramerate());
+    if (game.isFullscreen()) {
+      configuration.setFullscreenMode(Lwjgl3ApplicationConfiguration.getDisplayMode());
+    } else {
+      configuration.setWindowedMode(game.getViewWidth(), game.getViewHeight());
+    }
+    configuration.setWindowIcon(Arrays.stream(icons)
+        .filter(Objects::nonNull)
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .toArray(String[]::new));
+    if (game.isTransparentFramebufferRequested()) {
+      configuration.setTransparentFramebuffer(true);
+    }
+    attachFlixelWindowListener(configuration);
+    return configuration;
+  }
+
+  /**
+   * Ensures Flixel window notifications, optional user {@link com.badlogic.gdx.backends.lwjgl3.Lwjgl3WindowListener},
+   * and close-absorption wrapping are installed. Only {@link FlixelLwjgl3ApplicationConfiguration} is supported so the
+   * user listener can be captured without reflection, which allows AOT compilers like GraalVM to not scream at you.
+   */
+  public static void attachFlixelWindowListener(FlixelLwjgl3ApplicationConfiguration configuration) {
+    configuration.attachFlixelWindowListenerChain();
+  }
+
+  /**
+   * Linux AWT uses GTK for dialogs. Prefer GTK3 before any AWT class loads to reduce broken embeddings
+   * (orphan windows, wrong icons) on Cinnamon and other GTK3 desktops.
+   */
+  private static void prepareLinuxAwtCompatibility() {
+    if (linuxAwtCompatibilityPrepared) {
+      return;
+    }
+    linuxAwtCompatibilityPrepared = true;
+    if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux")) {
+      System.setProperty("jdk.gtk.version", "3");
     }
   }
 }

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3Launcher.java
@@ -38,6 +38,7 @@ import org.flixelgdx.backend.lwjgl3.input.FlixelLwjgl3MouseIconManager;
 import org.flixelgdx.backend.runtime.FlixelRuntimeMode;
 import org.flixelgdx.util.FlixelRuntimeUtil;
 import org.fusesource.jansi.AnsiConsole;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -145,6 +146,32 @@ public class FlixelLwjgl3Launcher {
    */
   public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
       FlixelLwjgl3ApplicationConfiguration configuration) {
+    launch(game, runtimeMode, configuration, null);
+  }
+
+  /**
+   * Launches the LWJGL3 version of the Flixel game with an optional pre-initialization callback.
+   *
+   * <p>This is the most flexible overload. {@code onBeforeInitialize} fires after all default
+   * FlixelGDX backend services (alerter, audio, debug overlay, etc.) have been registered but
+   * before {@link Flixel#initialize} is called. Use it to override any of those defaults without
+   * needing to duplicate the rest of the launcher wiring:
+   *
+   * <pre>{@code
+   * FlixelLwjgl3Launcher.launch(game, FlixelRuntimeMode.DEBUG, config, () -> {
+   *     Flixel.setDebugOverlay(MyCustomOverlay::new);
+   *     Flixel.setAlerter(myCustomAlerter);
+   * });
+   * }</pre>
+   *
+   * @param game The game instance to launch.
+   * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
+   * @param configuration The {@link FlixelLwjgl3ApplicationConfiguration} to use.
+   * @param onBeforeInitialize Optional callback invoked just before {@link Flixel#initialize}.
+   *     Pass {@code null} to skip.
+   */
+  public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
+      FlixelLwjgl3ApplicationConfiguration configuration, @Nullable Runnable onBeforeInitialize) {
     prepareLinuxAwtCompatibility();
     if (game.isTransparentFramebufferRequested()) {
       configuration.setTransparentFramebuffer(true);
@@ -165,6 +192,9 @@ public class FlixelLwjgl3Launcher {
     Flixel.setDebugMode(runtimeMode == FlixelRuntimeMode.DEBUG);
     if (runtimeMode == FlixelRuntimeMode.DEBUG) {
       Flixel.setDebugOverlay(FlixelImGuiDebugOverlay::new);
+    }
+    if (onBeforeInitialize != null) {
+      onBeforeInitialize.run();
     }
     Flixel.initialize(game);
     Flixel.mouse.setMouseIconManager(new FlixelLwjgl3MouseIconManager());

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -124,6 +124,32 @@ public class FlixelTeaVMLauncher {
    */
   public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
       @Nullable Consumer<WebApplicationConfiguration> configCustomizer) {
+    launch(game, runtimeMode, configCustomizer, null);
+  }
+
+  /**
+   * Launches the web version of the game with an optional pre-initialization callback.
+   *
+   * <p>{@code onBeforeInitialize} fires after all default FlixelGDX backend services (alerter,
+   * audio, debug overlay, etc.) have been registered but before {@link Flixel#initialize} is
+   * called. Use it to override any of those defaults without needing to duplicate the rest of
+   * the launcher wiring:
+   *
+   * <pre>{@code
+   * FlixelTeaVMLauncher.launch(game, FlixelRuntimeMode.DEBUG, null, () -> {
+   *     Flixel.setDebugOverlay(MyCustomOverlay::new);
+   * });
+   * }</pre>
+   *
+   * @param game The game instance to launch.
+   * @param runtimeMode The {@link FlixelRuntimeMode} for this session.
+   * @param configCustomizer Optional consumer that can modify the web configuration before the application starts.
+   * @param onBeforeInitialize Optional callback invoked just before {@link Flixel#initialize}.
+   *     Pass {@code null} to skip.
+   */
+  public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
+      @Nullable Consumer<WebApplicationConfiguration> configCustomizer,
+      @Nullable Runnable onBeforeInitialize) {
     Flixel.setAlerter(new FlixelTeaVMAlerter());
     Flixel.setStackTraceProvider(new TeaVMStackTraceProvider());
     Flixel.setLogConsoleSink(FlixelTeaVMLogConsole::emit);
@@ -132,6 +158,9 @@ public class FlixelTeaVMLauncher {
     Flixel.setDebugMode(runtimeMode == FlixelRuntimeMode.DEBUG);
     if (runtimeMode == FlixelRuntimeMode.DEBUG) {
       Flixel.setDebugOverlay(FlixelTeaVMDebugOverlay::new);
+    }
+    if (onBeforeInitialize != null) {
+      onBeforeInitialize.run();
     }
     Flixel.initialize(game);
 

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -108,7 +108,30 @@ public class FlixelTeaVMLauncher {
    * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
    */
   public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode) {
-    launch(game, runtimeMode, null);
+    launch(game, runtimeMode, null, null);
+  }
+
+  /**
+   * Launches the web version of the game with the given runtime mode, default configuration, and
+   * an optional pre-initialization callback.
+   *
+   * <p>Use this when you want to inject custom services without supplying a configuration
+   * customizer:
+   *
+   * <pre>{@code
+   * FlixelTeaVMLauncher.launch(game, FlixelRuntimeMode.DEBUG, () -> {
+   *   Flixel.setDebugOverlay(MyCustomOverlay::new);
+   * });
+   * }</pre>
+   *
+   * @param game The game instance to launch.
+   * @param runtimeMode The {@link FlixelRuntimeMode} for this session (TEST, DEBUG, or RELEASE).
+   * @param onBeforeInitialize Optional callback invoked just before {@link Flixel#initialize}.
+   *     Pass {@code null} to skip.
+   */
+  public static void launch(FlixelGame game, FlixelRuntimeMode runtimeMode,
+      @Nullable Runnable onBeforeInitialize) {
+    launch(game, runtimeMode, null, onBeforeInitialize);
   }
 
   /**

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -97,7 +97,7 @@ public class FlixelTeaVMLauncher {
    * @param game The game instance to launch (e.g. {@code new MyGame(...)}).
    */
   public static void launch(FlixelGame game) {
-    launch(game, FlixelRuntimeMode.RELEASE, null);
+    launch(game, FlixelRuntimeMode.RELEASE, (Runnable) null);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Added a new `launch()` overload to all four platform launchers (`FlixelLwjgl3Launcher`, `FlixelTeaVMLauncher`, `FlixelIOSLauncher`, `FlixelAndroidLauncher`) accepting an optional `onBeforeInitialize` callback
- The callback fires after all default backend services are registered but before `Flixel.initialize()`, letting users override any `Flixel.set*()` call (custom debug overlay, alerter, etc.) without copying the entire launcher
- Existing overloads delegate to the new one with `null`, so no existing call sites are affected
- `@Nullable` used on LWJGL3 and TeaVM (which already have the annotations dep); iOS and Android use plain `Runnable` since that dep is not available in those modules

## Test plan

- [x] Verify existing `launch()` call sites still compile and behave identically
- [x] Confirm a custom debug overlay can be injected via the callback: `FlixelLwjgl3Launcher.launch(game, FlixelRuntimeMode.DEBUG, config, () -> Flixel.setDebugOverlay(MyOverlay::new))`
- [x] Run unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)