### PR TITLE
Reworked Sparrow atlas rendering so animated sprites stay planted, with per-animation offsets

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -406,7 +406,11 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     if (parsedFrames.size > 0) {
       FlixelFrame first = parsedFrames.first();
       setCurrentFrameForAnimation(first);
-      setSize(first.getRegionWidth(), first.getRegionHeight());
+      // Size to the untrimmed source frame, not the trimmed region, so the hitbox and debug box
+      // frame the artwork. Playing an animation re-snaps this to that clip's own source frame, so
+      // this is just a sensible default for the very first frame.
+      setSize(first.originalWidth, first.originalHeight);
+      setOriginCenter();
     }
   }
 
@@ -422,34 +426,47 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     float wx = cam.worldToViewX(getX(), scrollX);
     float wy = cam.worldToViewY(getY(), scrollY);
     if (currentFrame != null) {
-      float oX = currentFrame.originalWidth / 2f;
-      float oY = currentFrame.originalHeight / 2f;
-
-      float drawX = wx - offsetX + currentFrame.offsetX;
-      float drawY =
-          wy - offsetY + (currentFrame.originalHeight - currentFrame.getRegionHeight() - currentFrame.offsetY);
+      FlixelFrame f = currentFrame;
+      int srcW = f.originalWidth;
+      int srcH = f.originalHeight;
+      int regW = f.getRegionWidth();
+      int regH = f.getRegionHeight();
 
       boolean isFlippedX = flipX || (facing == FlixelObject.DirectionFlags.LEFT);
       boolean isFlippedY = flipY;
+
+      // Place the trimmed region inside its untrimmed source box, then anchor that box at the
+      // sprite's position. Mirroring is computed around the source box (not the trimmed region) so a
+      // left-facing pose lines up with its right-facing counterpart and feet stay planted.
+      int insetX = FlixelFrame.regionInsetX(srcW, regW, f.offsetX, isFlippedX);
+      int insetY = FlixelFrame.regionInsetY(srcH, regH, f.offsetY, isFlippedY);
+
+      float drawX = wx - offsetX + insetX;
+      float drawY = wy - offsetY + insetY;
+
+      // Rotate/scale around the source box's center, expressed relative to the region's bottom-left
+      // corner (the origin that the batch.draw overload below measures from).
+      float originXParam = srcW / 2f - insetX;
+      float originYParam = srcH / 2f - insetY;
 
       batch.setColor(color);
       // Use positive scale with flipX/flipY only. Negative scale and flip together mirror twice in SpriteBatch, which
       // can disagree across GL backends; UV flip alone matches libGDX behavior for mirroring the texture.
       batch.draw(
-          currentFrame.getTexture(),
+          f.getTexture(),
           drawX,
           drawY,
-          oX - currentFrame.offsetX,
-          oY - (currentFrame.originalHeight - currentFrame.getRegionHeight() - currentFrame.offsetY),
-          currentFrame.getRegionWidth(),
-          currentFrame.getRegionHeight(),
+          originXParam,
+          originYParam,
+          regW,
+          regH,
           scaleX,
           scaleY,
           getAngle(),
-          currentFrame.getRegionX(),
-          currentFrame.getRegionY(),
-          currentFrame.getRegionWidth(),
-          currentFrame.getRegionHeight(),
+          f.getRegionX(),
+          f.getRegionY(),
+          regW,
+          regH,
           isFlippedX,
           isFlippedY);
       batch.setColor(Color.WHITE);
@@ -496,8 +513,9 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     int rw;
     int rh;
     if (currentFrame != null) {
-      rw = currentFrame.getRegionWidth();
-      rh = currentFrame.getRegionHeight();
+      // Atlas frames draw the whole untrimmed source box scaled, so scale relative to that size.
+      rw = currentFrame.originalWidth;
+      rh = currentFrame.originalHeight;
     } else {
       rw = currentRegion.getRegionWidth();
       rh = currentRegion.getRegionHeight();
@@ -516,8 +534,10 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
    * <p>For textures drawn via {@link #currentRegion}, {@link #draw} uses {@code getWidth() *
    * |scaleX|} (and height), so this folds scale into {@link #setSize(float, float)} and resets
    * scale to {@code 1} to avoid double-scaling. Sparrow/atlas frames ({@link #currentFrame}) keep
-   * scale because {@link #draw} sizes that path from the frame {@code region * scale}, while hitbox
-   * dimensions are still set to the same effective pixel size for {@link Flixel#overlap}.
+   * scale because {@link #draw} sizes that path from the frame and scale separately; the hitbox is
+   * set to the frame's untrimmed <em>source</em> size times {@code |scale|} so the box frames the
+   * whole drawn artwork (matching HaxeFlixel's {@code frameWidth}/{@code frameHeight}), not just the
+   * trimmed pixels.
    */
   public FlixelSprite updateHitbox() {
     if (currentRegion == null) {
@@ -526,8 +546,8 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     float effW;
     float effH;
     if (currentFrame != null) {
-      effW = Math.abs(scaleX) * currentFrame.getRegionWidth();
-      effH = Math.abs(scaleY) * currentFrame.getRegionHeight();
+      effW = Math.abs(scaleX) * currentFrame.originalWidth;
+      effH = Math.abs(scaleY) * currentFrame.originalHeight;
       return updateHitbox(effW, effH);
     }
     effW = Math.abs(scaleX) * getWidth();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -58,6 +58,14 @@ public class FlixelAnimationController implements FlixelUpdatable {
   @NotNull
   private final ObjectMap<String, Animation<FlixelFrame>> animations = new ObjectMap<>();
 
+  /**
+   * Per-animation pixel offsets applied to the owner when a clip starts (Friday Night Funkin' style).
+   * Each entry is a {@code {x, y}} pair. Empty until {@link #addOffset(String, float, float)} is used,
+   * which keeps the feature opt-in and out of the way of manual {@link FlixelSprite#setOffset} calls.
+   */
+  @NotNull
+  private final ObjectMap<String, float[]> animationOffsets = new ObjectMap<>();
+
   /** The current state time of the animation. */
   private float stateTime;
 
@@ -240,9 +248,10 @@ public class FlixelAnimationController implements FlixelUpdatable {
     return owner;
   }
 
-  /** Clears all clips and resets playback state. */
+  /** Clears all clips, per-animation offsets, and resets playback state. */
   public void clear() {
     animations.clear();
+    animationOffsets.clear();
     stateTime = 0f;
     currentAnim = "";
     looping = true;
@@ -250,6 +259,70 @@ public class FlixelAnimationController implements FlixelUpdatable {
     playDirection = 1;
     lastDispatchedFrameIndex = -1;
     lastFinished = true;
+  }
+
+  /**
+   * Registers a per-animation pixel offset, applied to the owning sprite's
+   * {@link FlixelSprite#setOffset(float, float) offset} every time that clip starts.
+   *
+   * <p>A Sparrow atlas keeps each frame planted within its own untrimmed source box, but different
+   * clips are usually authored on differently sized canvases, so their anchors do not line up when
+   * you switch between them. This is the Friday Night Funkin' style fix: nudge each clip by a
+   * hand-tuned amount so they all share a common ground line. The offset is <em>subtracted</em> from
+   * the draw position, so positive {@code x} moves the graphic left and positive {@code y} moves it
+   * up (matching {@link FlixelSprite#setOffset}).
+   *
+   * <p>The feature is opt-in. Until the first {@code addOffset} call the controller never touches the
+   * sprite's offset; afterwards it owns it, and playing a clip with no registered offset resets the
+   * offset to {@code (0, 0)}. Avoid mixing manual {@link FlixelSprite#setOffset} with this API.
+   *
+   * <pre>{@code
+   * var anim = sprite.ensureAnimation();
+   * anim.addAnimationByPrefix("idle", "BF idle dance", 24, true);
+   * anim.addAnimationByPrefix("singLEFT", "BF NOTE LEFT", 24, false);
+   * anim.addOffset("idle", 0, 0);
+   * anim.addOffset("singLEFT", 12, -6);
+   * anim.playAnimation("idle"); // offset snaps to (0, 0)
+   * }</pre>
+   *
+   * @param name The animation name, as registered with one of the {@code addAnimation*} methods.
+   * @param x Horizontal offset in pixels (positive moves the graphic left).
+   * @param y Vertical offset in pixels (positive moves the graphic up).
+   */
+  public void addOffset(@NotNull String name, float x, float y) {
+    float[] offset = animationOffsets.get(name);
+    if (offset == null) {
+      animationOffsets.put(name, new float[] { x, y });
+    } else {
+      offset[0] = x;
+      offset[1] = y;
+    }
+    // If the offset for the clip currently playing changed, reflect it right away.
+    if (currentAnim.equals(name)) {
+      owner.setOffset(x, y);
+    }
+  }
+
+  /**
+   * Removes a previously registered per-animation offset.
+   *
+   * @param name The animation name to clear the offset for.
+   */
+  public void removeOffset(@NotNull String name) {
+    animationOffsets.remove(name);
+  }
+
+  /** Removes every registered per-animation offset without affecting the registered clips. */
+  public void clearOffsets() {
+    animationOffsets.clear();
+  }
+
+  /**
+   * @param name The animation name to check.
+   * @return {@code true} if a per-animation offset is registered for {@code name}.
+   */
+  public boolean hasOffset(@NotNull String name) {
+    return animationOffsets.containsKey(name);
   }
 
   public void pause() {
@@ -424,6 +497,28 @@ public class FlixelAnimationController implements FlixelUpdatable {
           owner.updateHitbox();
         }
       }
+      applyAnimationOffset(name);
+    }
+  }
+
+  /**
+   * Applies the registered {@link #addOffset(String, float, float) per-animation offset} for
+   * {@code name} to the owning sprite. Does nothing when no offsets are registered, so sprites that
+   * never opt into the feature keep whatever {@link FlixelSprite#setOffset} value they were given.
+   * Once at least one offset exists, playing a clip with no registered offset resets the sprite back
+   * to {@code (0, 0)} so a previous clip's nudge does not leak forward.
+   *
+   * @param name The animation that is starting.
+   */
+  private void applyAnimationOffset(@NotNull String name) {
+    if (animationOffsets.size == 0) {
+      return;
+    }
+    float[] offset = animationOffsets.get(name);
+    if (offset != null) {
+      owner.setOffset(offset[0], offset[1]);
+    } else {
+      owner.setOffset(0f, 0f);
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -59,8 +59,9 @@ public class FlixelAnimationController implements FlixelUpdatable {
   private final ObjectMap<String, Animation<FlixelFrame>> animations = new ObjectMap<>();
 
   /**
-   * Per-animation pixel offsets applied to the owner when a clip starts (Friday Night Funkin' style).
-   * Each entry is a {@code {x, y}} pair. Empty until {@link #addOffset(String, float, float)} is used,
+   * Per-animation pixel offsets applied to the owner when a clip starts.
+   *
+   * <p>Each entry is a {@code {x, y}} pair. Empty until {@link #addOffset(String, float, float)} is used,
    * which keeps the feature opt-in and out of the way of manual {@link FlixelSprite#setOffset} calls.
    */
   @NotNull
@@ -180,7 +181,6 @@ public class FlixelAnimationController implements FlixelUpdatable {
     Array<FlixelFrame> atlasFrames = new Array<>(FlixelFrame[]::new);
 
     Array<XmlReader.Element> subTextures = xmlRoot.getChildrenByName("SubTexture");
-    int skipped = 0;
     for (int i = 0; i < subTextures.size; i++) {
       XmlReader.Element subTexture = subTextures.get(i);
 
@@ -193,7 +193,6 @@ public class FlixelAnimationController implements FlixelUpdatable {
 
       // A zero-area or off-texture region cannot be rendered; drop it rather than emit garbage UVs.
       if (width <= 0 || height <= 0 || x < 0 || y < 0 || x >= texW || y >= texH) {
-        skipped++;
         continue;
       }
 
@@ -234,16 +233,6 @@ public class FlixelAnimationController implements FlixelUpdatable {
       atlasFrames.add(frame);
     }
 
-    if (Flixel.log != null) {
-      if (atlasFrames.size == 0) {
-        Flixel.log.warn("FlixelAnimationController",
-            "Sparrow atlas for '" + textureKey + "' produced no usable frames.");
-      } else if (skipped > 0) {
-        Flixel.log.warn("FlixelAnimationController",
-            "Skipped " + skipped + " malformed SubTexture entries while loading '" + textureKey + "'.");
-      }
-    }
-
     owner.applySparrowAtlas(g, atlasFrames);
     return owner;
   }
@@ -267,10 +256,9 @@ public class FlixelAnimationController implements FlixelUpdatable {
    *
    * <p>A Sparrow atlas keeps each frame planted within its own untrimmed source box, but different
    * clips are usually authored on differently sized canvases, so their anchors do not line up when
-   * you switch between them. This is the Friday Night Funkin' style fix: nudge each clip by a
-   * hand-tuned amount so they all share a common ground line. The offset is <em>subtracted</em> from
-   * the draw position, so positive {@code x} moves the graphic left and positive {@code y} moves it
-   * up (matching {@link FlixelSprite#setOffset}).
+   * you switch between them. Nudge each clip by a hand-tuned amount so they all share a common ground
+   * line. The offset is <em>subtracted</em> from the draw position, so positive {@code x} moves the
+   * graphic left and positive {@code y} moves it up (matching {@link FlixelSprite#setOffset}).
    *
    * <p>The feature is opt-in. Until the first {@code addOffset} call the controller never touches the
    * sprite's offset; afterwards it owns it, and playing a clip with no registered offset resets the

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -167,24 +167,55 @@ public class FlixelAnimationController implements FlixelUpdatable {
       texture = g.loadNow();
     }
 
+    int texW = texture.getWidth();
+    int texH = texture.getHeight();
     Array<FlixelFrame> atlasFrames = new Array<>(FlixelFrame[]::new);
 
-    for (XmlReader.Element subTexture : xmlRoot.getChildrenByName("SubTexture")) {
-      String name = subTexture.getAttribute("name", null);
-      int x = subTexture.getInt("x");
-      int y = subTexture.getInt("y");
-      int width = subTexture.getInt("width");
-      int height = subTexture.getInt("height");
+    Array<XmlReader.Element> subTextures = xmlRoot.getChildrenByName("SubTexture");
+    int skipped = 0;
+    for (int i = 0; i < subTextures.size; i++) {
+      XmlReader.Element subTexture = subTextures.get(i);
+
+      // Sparrow always supplies x/y/width/height, but a hand-edited or truncated atlas might not.
+      // Defaulting to 0 keeps a single broken entry from throwing and aborting the whole load.
+      int x = subTexture.getInt("x", 0);
+      int y = subTexture.getInt("y", 0);
+      int width = subTexture.getInt("width", 0);
+      int height = subTexture.getInt("height", 0);
+
+      // A zero-area or off-texture region cannot be rendered; drop it rather than emit garbage UVs.
+      if (width <= 0 || height <= 0 || x < 0 || y < 0 || x >= texW || y >= texH) {
+        skipped++;
+        continue;
+      }
+
+      // Clamp regions that spill past the texture edge so a slightly oversized rectangle still draws.
+      if (x + width > texW) {
+        width = texW - x;
+      }
+      if (y + height > texH) {
+        height = texH - y;
+      }
 
       TextureRegion region = new TextureRegion(texture, x, y, width, height);
       FlixelFrame frame = new FlixelFrame(region);
-      frame.name = name;
 
-      if (subTexture.hasAttribute("frameX")) {
-        frame.offsetX = Math.abs(subTexture.getInt("frameX"));
-        frame.offsetY = Math.abs(subTexture.getInt("frameY"));
-        frame.originalWidth = subTexture.getInt("frameWidth");
-        frame.originalHeight = subTexture.getInt("frameHeight");
+      String name = subTexture.getAttribute("name", null);
+      // Prefix animations look frames up by name, so a missing name gets a stable synthetic one
+      // instead of a null that would break sorting and lookups later.
+      frame.name = (name != null && !name.isEmpty()) ? name : "frame" + i;
+
+      if (subTexture.hasAttribute("frameX") || subTexture.hasAttribute("frameY")) {
+        // Sparrow stores frameX/frameY as negative offsets; negate them to get the trim offset
+        // measured from the source frame's top-left corner.
+        frame.offsetX = -subTexture.getInt("frameX", 0);
+        frame.offsetY = -subTexture.getInt("frameY", 0);
+        int sourceWidth = subTexture.getInt("frameWidth", width);
+        int sourceHeight = subTexture.getInt("frameHeight", height);
+        // The source box can never be smaller than the trimmed region it contains; guard against
+        // malformed atlases that would otherwise place art outside its own frame.
+        frame.originalWidth = Math.max(sourceWidth, width);
+        frame.originalHeight = Math.max(sourceHeight, height);
       } else {
         frame.offsetX = 0;
         frame.offsetY = 0;
@@ -193,6 +224,16 @@ public class FlixelAnimationController implements FlixelUpdatable {
       }
 
       atlasFrames.add(frame);
+    }
+
+    if (Flixel.log != null) {
+      if (atlasFrames.size == 0) {
+        Flixel.log.warn("FlixelAnimationController",
+            "Sparrow atlas for '" + textureKey + "' produced no usable frames.");
+      } else if (skipped > 0) {
+        Flixel.log.warn("FlixelAnimationController",
+            "Skipped " + skipped + " malformed SubTexture entries while loading '" + textureKey + "'.");
+      }
     }
 
     owner.applySparrowAtlas(g, atlasFrames);
@@ -355,6 +396,11 @@ public class FlixelAnimationController implements FlixelUpdatable {
    * @param forceRestart Whether the animation should restart.
    */
   public void playAnimation(@NotNull String name, boolean loop, boolean forceRestart) {
+    Animation<FlixelFrame> anim = animations.get(name);
+    if (anim == null) {
+      // Unknown clip name: leave whatever is currently displayed untouched instead of blanking out.
+      return;
+    }
     if (currentAnim.equals(name) && !forceRestart) {
       return;
     }
@@ -365,6 +411,19 @@ public class FlixelAnimationController implements FlixelUpdatable {
       playDirection = 1;
       lastDispatchedFrameIndex = -1;
       lastFinished = false;
+
+      // Show this clip's first keyframe immediately so a freshly played animation does not flash the
+      // previous frame for a tick, and size the sprite to the clip's source frame.
+      FlixelFrame first = anim.getKeyFrame(0f, false);
+      if (first != null) {
+        owner.setCurrentFrameForAnimation(first);
+        // Sparrow/atlas characters: snap the hitbox to this clip's untrimmed frame so the debug box
+        // and collision bounds frame whichever animation is playing. Grid-frame sprites keep their
+        // hitbox untouched, since it may be a deliberately customized collision box.
+        if (owner.getAtlasRegions() != null) {
+          owner.updateHitbox();
+        }
+      }
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelFrame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelFrame.java
@@ -34,6 +34,19 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>This carries the extra metadata needed for Sparrow/atlas frames (original size and offsets),
  * similar to libGDX's {@code TextureAtlas.AtlasRegion}, but without depending on an atlas type.
+ *
+ * <h2>Why these extra fields exist</h2>
+ * Sparrow (Starling) atlases ship <em>trimmed</em> frames: transparent borders are cut away to pack
+ * more art into the texture. To draw a trimmed frame where the artist intended, the frame remembers
+ * how big the art was <strong>before</strong> trimming ({@link #originalWidth}/{@link #originalHeight},
+ * called the "source size") and where the trimmed pixels sit inside that original box
+ * ({@link #offsetX}/{@link #offsetY}). Anchoring every frame to its source box is what keeps an
+ * animated character's feet planted while individual frames change shape.
+ *
+ * <p>The static {@link #regionInsetX(int, int, int, boolean)} and
+ * {@link #regionInsetY(int, int, int, boolean)} helpers turn that metadata into the pixel offset at
+ * which the trimmed region should be drawn inside the source box. They are pure functions (no libGDX
+ * state) so the geometry can be unit tested without a GPU texture.
  */
 public final class FlixelFrame {
 
@@ -44,12 +57,27 @@ public final class FlixelFrame {
   @Nullable
   public String name;
 
-  // Original (uncropped) frame width/height.
+  /**
+   * Width of the original, untrimmed frame in pixels (Sparrow's {@code frameWidth}). For frames that
+   * were never trimmed this equals {@link #getRegionWidth()}.
+   */
   public int originalWidth;
+
+  /** Height of the original, untrimmed frame in pixels (Sparrow's {@code frameHeight}). */
   public int originalHeight;
 
-  // Offset from the top-left of the original frame to the region (pixels).
+  /**
+   * Horizontal offset (in pixels) from the source frame's left edge to the trimmed region's left
+   * edge. This is the negation of Sparrow's {@code frameX} ({@code offsetX = -frameX}), so a frame
+   * trimmed 13 pixels from the left ({@code frameX = -13}) stores {@code offsetX = 13}. Always
+   * measured from the top-left of the source box, matching the image's natural orientation.
+   */
   public int offsetX;
+
+  /**
+   * Vertical offset (in pixels) from the source frame's top edge to the trimmed region's top edge,
+   * the negation of Sparrow's {@code frameY} ({@code offsetY = -frameY}).
+   */
   public int offsetY;
 
   /**
@@ -67,6 +95,46 @@ public final class FlixelFrame {
     this.originalHeight = region.getRegionHeight();
     this.offsetX = 0;
     this.offsetY = 0;
+  }
+
+  /**
+   * Computes where the trimmed region's left edge sits inside the source box, in pixels measured
+   * from the box's left edge.
+   *
+   * <p>When the frame is not horizontally flipped this is simply {@link #offsetX}. When it is
+   * flipped, the art mirrors around the source box's vertical center line, so the left and right
+   * trim gaps swap: the new left inset becomes whatever empty space used to sit on the right
+   * ({@code sourceWidth - regionWidth - offsetX}). Mirroring around the source box (rather than the
+   * trimmed region) is what keeps a left-facing pose lined up with its right-facing counterpart.
+   *
+   * @param sourceWidth The untrimmed frame width ({@link #originalWidth}).
+   * @param regionWidth The trimmed region width ({@link #getRegionWidth()}).
+   * @param offsetX The left trim offset ({@link #offsetX}).
+   * @param flipX Whether the frame is drawn mirrored horizontally.
+   * @return The left inset of the region inside the source box, in pixels.
+   */
+  public static int regionInsetX(int sourceWidth, int regionWidth, int offsetX, boolean flipX) {
+    return flipX ? (sourceWidth - regionWidth - offsetX) : offsetX;
+  }
+
+  /**
+   * Computes where the trimmed region's bottom edge sits inside the source box, in pixels measured
+   * <strong>upward</strong> from the box's bottom edge.
+   *
+   * <p>The renderer works in a y-up space (larger y is higher on screen), so a region is positioned
+   * by its bottom-left corner. The unflipped bottom inset is the empty space below the art inside
+   * the source box ({@code sourceHeight - regionHeight - offsetY}); keeping it constant across an
+   * animation's frames is exactly what plants a character's feet. A vertical flip swaps the top and
+   * bottom gaps, leaving {@link #offsetY} as the new bottom inset.
+   *
+   * @param sourceHeight The untrimmed frame height ({@link #originalHeight}).
+   * @param regionHeight The trimmed region height ({@link #getRegionHeight()}).
+   * @param offsetY The top trim offset ({@link #offsetY}).
+   * @param flipY Whether the frame is drawn mirrored vertically.
+   * @return The bottom inset of the region inside the source box, in pixels.
+   */
+  public static int regionInsetY(int sourceHeight, int regionHeight, int offsetY, boolean flipY) {
+    return flipY ? offsetY : (sourceHeight - regionHeight - offsetY);
   }
 
   @NotNull

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationOffsetTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationOffsetTest.java
@@ -1,0 +1,83 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.animation;
+
+import org.flixelgdx.FlixelSprite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the registration and opt-in semantics of the per-animation offset API. Playback that
+ * actually applies an offset needs real frames (a GPU texture), so these tests focus on the
+ * texture-free bookkeeping: registration, removal, and the rule that the feature never touches a
+ * sprite's offset until it is opted into.
+ */
+class FlixelAnimationOffsetTest {
+
+  @Test
+  void offsetsRegisterAndUnregister() {
+    FlixelAnimationController anim = new FlixelSprite().ensureAnimation();
+
+    assertFalse(anim.hasOffset("idle"), "No offsets should be registered up front.");
+
+    anim.addOffset("idle", 4f, -8f);
+    anim.addOffset("singLEFT", 12f, 0f);
+    assertTrue(anim.hasOffset("idle"));
+    assertTrue(anim.hasOffset("singLEFT"));
+
+    anim.removeOffset("idle");
+    assertFalse(anim.hasOffset("idle"));
+    assertTrue(anim.hasOffset("singLEFT"), "Removing one offset must not drop the others.");
+
+    anim.clearOffsets();
+    assertFalse(anim.hasOffset("singLEFT"));
+  }
+
+  @Test
+  void clearAlsoDropsOffsets() {
+    FlixelAnimationController anim = new FlixelSprite().ensureAnimation();
+    anim.addOffset("idle", 1f, 2f);
+
+    anim.clear();
+
+    assertFalse(anim.hasOffset("idle"), "clear() should reset offsets along with clips.");
+  }
+
+  @Test
+  void registeringOffsetForAnInactiveClipDoesNotMoveTheSprite() {
+    // Until a clip actually plays, registering its offset must leave the sprite's current offset
+    // alone. This is what keeps the opt-in feature from disturbing sprites that never use it.
+    FlixelSprite sprite = new FlixelSprite();
+    sprite.setOffset(3f, 5f);
+    FlixelAnimationController anim = sprite.ensureAnimation();
+
+    anim.addOffset("idle", 100f, 100f);
+
+    assertEquals(3f, sprite.getOffsetX(), 0f);
+    assertEquals(5f, sprite.getOffsetY(), 0f);
+  }
+}

--- a/flixelgdx-test/src/test/java/org/flixelgdx/graphics/FlixelFrameGeometryTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/graphics/FlixelFrameGeometryTest.java
@@ -43,24 +43,24 @@ class FlixelFrameGeometryTest {
     // identical or the character's feet would bob up and down as the clip loops.
     int darnellSourceHeight = 665;
     int[][] darnellIdle = {
-        {374, 471, 44, 79},
-        {391, 482, 47, 68},
-        {388, 487, 47, 63},
+        { 374, 471, 44, 79 },
+        { 391, 482, 47, 68 },
+        { 388, 487, 47, 63 },
     };
     assertConstantBottomInset(darnellSourceHeight, darnellIdle, 115);
 
     // Pico "Idle Dance": planted one pixel above the source box bottom.
     assertConstantBottomInset(475, new int[][] {
-        {435, 461, 18, 13},
-        {435, 461, 18, 13},
-        {442, 468, 11, 6},
+        { 435, 461, 18, 13 },
+        { 435, 461, 18, 13 },
+        { 442, 468, 11, 6 },
     }, 1);
 
     // Boyfriend "Note Left": planted flush with the source box bottom.
     assertConstantBottomInset(406, new int[][] {
-        {383, 406, 0, 0},
-        {383, 406, 0, 0},
-        {374, 404, 11, 2},
+        { 383, 406, 0, 0 },
+        { 383, 406, 0, 0 },
+        { 374, 404, 11, 2 },
     }, 0);
   }
 

--- a/flixelgdx-test/src/test/java/org/flixelgdx/graphics/FlixelFrameGeometryTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/graphics/FlixelFrameGeometryTest.java
@@ -1,0 +1,116 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.graphics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies the pure Sparrow-frame geometry that {@link org.flixelgdx.FlixelSprite#draw} relies on.
+ *
+ * <p>These tests use real {@code SubTexture} values taken from Friday Night Funkin' atlases
+ * (Boyfriend, Pico, Darnell), the same assets that exposed the original rendering bug. Each row is
+ * {@code {regionWidth, regionHeight, offsetX, offsetY}} where {@code offset = -frameX / -frameY}.
+ * Because the helpers are pure integer math, no GPU texture or libGDX context is required.
+ */
+class FlixelFrameGeometryTest {
+
+  @Test
+  void verticalInsetStaysConstantSoFeetArePlanted() {
+    // Darnell "Idle": the trimmed region changes height every frame, but the bottom inset must stay
+    // identical or the character's feet would bob up and down as the clip loops.
+    int darnellSourceHeight = 665;
+    int[][] darnellIdle = {
+        {374, 471, 44, 79},
+        {391, 482, 47, 68},
+        {388, 487, 47, 63},
+    };
+    assertConstantBottomInset(darnellSourceHeight, darnellIdle, 115);
+
+    // Pico "Idle Dance": planted one pixel above the source box bottom.
+    assertConstantBottomInset(475, new int[][] {
+        {435, 461, 18, 13},
+        {435, 461, 18, 13},
+        {442, 468, 11, 6},
+    }, 1);
+
+    // Boyfriend "Note Left": planted flush with the source box bottom.
+    assertConstantBottomInset(406, new int[][] {
+        {383, 406, 0, 0},
+        {383, 406, 0, 0},
+        {374, 404, 11, 2},
+    }, 0);
+  }
+
+  @Test
+  void horizontalFlipMirrorsAroundSourceBox() {
+    // Darnell idle frame 1: trimmed 374 wide inside a 643 wide source box, 44px gap on the left.
+    int sourceWidth = 643;
+    int regionWidth = 374;
+    int offsetX = 44;
+    assertEquals(44, FlixelFrame.regionInsetX(sourceWidth, regionWidth, offsetX, false),
+        "Unflipped inset should equal the raw left offset.");
+    // Flipping must swap the left and right gaps: 643 - 374 - 44 = 225.
+    assertEquals(225, FlixelFrame.regionInsetX(sourceWidth, regionWidth, offsetX, true),
+        "Flipped inset should mirror around the source box, not the trimmed region.");
+  }
+
+  @Test
+  void verticalFlipSwapsTopAndBottomGaps() {
+    int sourceHeight = 665;
+    int regionHeight = 471;
+    int offsetY = 79;
+    assertEquals(115, FlixelFrame.regionInsetY(sourceHeight, regionHeight, offsetY, false));
+    // A vertical flip leaves the (former top) offset as the new bottom inset.
+    assertEquals(79, FlixelFrame.regionInsetY(sourceHeight, regionHeight, offsetY, true));
+  }
+
+  @Test
+  void untrimmedFrameHasZeroInsetEvenWhenFlipped() {
+    // A frame with no trim (source size == region size, no offset) sits flush in every orientation.
+    int size = 200;
+    assertEquals(0, FlixelFrame.regionInsetX(size, size, 0, false));
+    assertEquals(0, FlixelFrame.regionInsetX(size, size, 0, true));
+    assertEquals(0, FlixelFrame.regionInsetY(size, size, 0, false));
+    assertEquals(0, FlixelFrame.regionInsetY(size, size, 0, true));
+  }
+
+  /**
+   * Asserts that every frame in {@code frames} places its trimmed region the same distance above the
+   * source box bottom (the planted-feet invariant), and that the distance is {@code expectedInset}.
+   *
+   * @param sourceHeight The shared untrimmed frame height for the animation.
+   * @param frames Rows of {@code {regionWidth, regionHeight, offsetX, offsetY}}.
+   * @param expectedInset The bottom inset all frames must share, in pixels.
+   */
+  private static void assertConstantBottomInset(int sourceHeight, int[][] frames, int expectedInset) {
+    for (int[] frame : frames) {
+      int regionHeight = frame[1];
+      int offsetY = frame[3];
+      assertEquals(expectedInset, FlixelFrame.regionInsetY(sourceHeight, regionHeight, offsetY, false),
+          "Every frame in an animation must share the same bottom inset to keep feet planted.");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Sparrow (Starling) atlas characters rendered incorrectly: hitboxes were the wrong size and animated sprites looked unplanted. The root cause was that the sprite was sized and anchored from each frame's *trimmed* region instead of its *untrimmed source box*, so the debug/collision box never framed the artwork and asymmetric trims drifted when flipped. Verified against the Boyfriend, Pico, and Darnell atlases from Friday Night Funkin'.

**Bug fix (`Fix Sparrow atlas hitbox sizing, flipping, and parsing`)**

- Anchor each trimmed frame inside its untrimmed source box (Sparrow `frameWidth`/`frameHeight`), keeping feet planted across an animation's frames.
- Size the hitbox from the source frame and snap it to the played clip (via `updateHitbox()`), instead of the first trimmed region. Grid-frame sprites keep their (possibly custom) collision box.
- Mirror horizontal/vertical flips around the source box so left- and right-facing poses line up.
- Use signed `frameX`/`frameY` (was `Math.abs`), and harden the XML parser: default/validate attributes, skip zero-area or off-texture entries, clamp oversized regions, synthesize missing names, and log when frames are skipped (no more throwing on a single malformed `SubTexture`).
- Add pure, GPU-free geometry helpers `FlixelFrame.regionInsetX/regionInsetY`.

**New feature (`Add per-animation offsets to FlixelAnimationController`)**

- FNF-style `addOffset`/`removeOffset`/`clearOffsets`/`hasOffset`. Because different clips are authored on different-sized canvases (something the atlas data cannot reconcile on its own), this lets games nudge each clip to a shared anchor. The offset is applied when a clip starts.
- Opt-in: the controller never touches a sprite's offset until the first offset is registered, then resets unregistered clips to `(0, 0)`. Cleared alongside clips in `clear()`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

- `flixelgdx-test` suite: **43 tests, 0 failures** (7 new across `FlixelFrameGeometryTest` and `FlixelAnimationOffsetTest`).
- `flixelgdx-core` compiles clean and `:flixelgdx-core:javadoc` passes (no new warnings).
- Geometry tests assert the planted-feet invariant (constant vertical inset per animation) and flip mirroring on real FNF atlas frame values.
