### PR TITLE
Reworked the animation state machine into a real FSM with transitions, hooks, and auto-advancing one-shot clips

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -462,31 +462,48 @@ public class FlixelAnimationController implements FlixelUpdatable {
       // Unknown clip name: leave whatever is currently displayed untouched instead of blanking out.
       return;
     }
-    if (currentAnim.equals(name) && !forceRestart) {
+    // Keep playing only when this exact clip is already mid-play and the caller did not force a
+    // restart. A clip that has finished (or a different clip) always (re)starts, so a non-looping
+    // clip can be replayed once it ends and switching clips never silently no-ops.
+    if (!shouldRestart(forceRestart, currentAnim.equals(name), isAnimationFinished())) {
       return;
     }
-    if (isAnimationFinished() || forceRestart) {
-      currentAnim = name;
-      looping = loop;
-      stateTime = 0f;
-      playDirection = 1;
-      lastDispatchedFrameIndex = -1;
-      lastFinished = false;
 
-      // Show this clip's first keyframe immediately so a freshly played animation does not flash the
-      // previous frame for a tick, and size the sprite to the clip's source frame.
-      FlixelFrame first = anim.getKeyFrame(0f, false);
-      if (first != null) {
-        owner.setCurrentFrameForAnimation(first);
-        // Sparrow/atlas characters: snap the hitbox to this clip's untrimmed frame so the debug box
-        // and collision bounds frame whichever animation is playing. Grid-frame sprites keep their
-        // hitbox untouched, since it may be a deliberately customized collision box.
-        if (owner.getAtlasRegions() != null) {
-          owner.updateHitbox();
-        }
+    currentAnim = name;
+    looping = loop;
+    stateTime = 0f;
+    playDirection = 1;
+    lastDispatchedFrameIndex = -1;
+    lastFinished = false;
+
+    // Show this clip's first keyframe immediately so a freshly played animation does not flash the
+    // previous frame for a tick, and size the sprite to the clip's source frame.
+    FlixelFrame[] keyframes = anim.getKeyFrames();
+    if (keyframes.length > 0) {
+      owner.setCurrentFrameForAnimation(keyframes[0]);
+      // Sparrow/atlas characters: snap the hitbox to this clip's untrimmed frame so the debug box
+      // and collision bounds frame whichever animation is playing. Grid-frame sprites keep their
+      // hitbox untouched, since it may be a deliberately customized collision box.
+      if (owner.getAtlasRegions() != null) {
+        owner.updateHitbox();
       }
-      applyAnimationOffset(name);
     }
+    applyAnimationOffset(name);
+  }
+
+  /**
+   * Pure decision for whether a {@code playAnimation} call should (re)start the clip, split out so it
+   * can be unit tested. A clip restarts when the caller forces it, when it is a different clip than
+   * the one playing, or when the current clip has already finished; only a still-playing same clip
+   * without a force is left alone.
+   *
+   * @param forceRestart Whether the caller forced a restart.
+   * @param sameClip Whether the requested clip is the one already current.
+   * @param finished Whether the current clip has finished.
+   * @return {@code true} if playback should (re)start from frame zero.
+   */
+  static boolean shouldRestart(boolean forceRestart, boolean sameClip, boolean finished) {
+    return forceRestart || !sameClip || finished;
   }
 
   /**
@@ -540,8 +557,16 @@ public class FlixelAnimationController implements FlixelUpdatable {
       stateTime = MathUtils.clamp(stateTime, 0f, duration);
     }
 
-    FlixelFrame frame = anim.getKeyFrame(stateTime, looping);
     int frameIndex = computeKeyframeIndex(anim);
+    // Pick the displayed frame by the same index the controller reports elsewhere, rather than
+    // anim.getKeyFrame(stateTime, looping). That libGDX call honors the clip's *registered* PlayMode,
+    // so a clip registered to loop but played non-looping wraps back to frame 0 when it finishes;
+    // indexing the keyframes directly keeps a finished non-looping clip parked on its last frame.
+    FlixelFrame[] keyframes = anim.getKeyFrames();
+    if (keyframes.length == 0) {
+      return;
+    }
+    FlixelFrame frame = keyframes[frameIndex];
     owner.setCurrentFrameForAnimation(frame);
 
     if (frameIndex != lastDispatchedFrameIndex) {
@@ -615,13 +640,23 @@ public class FlixelAnimationController implements FlixelUpdatable {
    * @return A keyframe index in {@code [0, keyframeCount - 1]}, or {@code 0} for degenerate clips.
    */
   private int computeKeyframeIndex(@NotNull Animation<FlixelFrame> anim) {
-    Object[] keyframes = anim.getKeyFrames();
-    int total = (keyframes != null) ? keyframes.length : 0;
-    if (total <= 0) {
-      return 0;
-    }
-    float frameDuration = anim.getFrameDuration();
-    if (frameDuration <= 0f) {
+    FlixelFrame[] keyframes = anim.getKeyFrames();
+    return keyframeIndex(stateTime, anim.getFrameDuration(), keyframes.length, looping);
+  }
+
+  /**
+   * Pure keyframe-index math, split out from {@link #computeKeyframeIndex} so it can be unit tested
+   * without a GPU texture. Non-looping playback past the end returns the <strong>last</strong> index
+   * ({@code total - 1}), never wrapping back to {@code 0}; looping playback wraps into range.
+   *
+   * @param stateTime Elapsed playback time in seconds.
+   * @param frameDuration Seconds per keyframe.
+   * @param total Number of keyframes in the clip.
+   * @param looping Whether playback wraps.
+   * @return A keyframe index in {@code [0, total - 1]}, or {@code 0} for degenerate clips.
+   */
+  static int keyframeIndex(float stateTime, float frameDuration, int total, boolean looping) {
+    if (total <= 0 || frameDuration <= 0f) {
       return 0;
     }
     int idx = (int) (stateTime / frameDuration);

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -98,7 +98,8 @@ public class FlixelAnimationController implements FlixelUpdatable {
   public final FlixelSignal<FlixelAnimationFrameSignalData> onAnimationFinished = new FlixelSignal<>();
 
   /** The current frame signal data to prevent allocation of a new object every time. */
-  private FlixelAnimationFrameSignalData currentFrameSignalData = new FlixelAnimationFrameSignalData("", -1, null);
+  private final FlixelAnimationFrameSignalData currentFrameSignalData =
+      new FlixelAnimationFrameSignalData("", -1, null);
 
   /**
    * Creates a new animation controller for the given sprite.
@@ -477,9 +478,7 @@ public class FlixelAnimationController implements FlixelUpdatable {
     lastFinished = false;
 
     // Show this clip's first keyframe immediately so a freshly played animation does not flash the
-    // previous frame for a tick, and size the sprite to the clip's source frame. getKeyFrames() is
-    // typed FlixelFrame[] but is often backed by an Object[] at runtime (clips built from a default
-    // libGDX Array), so cast per element rather than casting the whole array.
+    // previous frame for a tick, and size the sprite to the clip's source frame.
     Object[] keyframes = anim.getKeyFrames();
     if (keyframes.length > 0) {
       owner.setCurrentFrameForAnimation((FlixelFrame) keyframes[0]);
@@ -643,8 +642,6 @@ public class FlixelAnimationController implements FlixelUpdatable {
    * @return A keyframe index in {@code [0, keyframeCount - 1]}, or {@code 0} for degenerate clips.
    */
   private int computeKeyframeIndex(@NotNull Animation<FlixelFrame> anim) {
-    // getKeyFrames() only gives the count here; read it as Object[] to avoid an array-type cast that
-    // would fail when the clip is backed by an Object[] at runtime.
     Object[] keyframes = anim.getKeyFrames();
     return keyframeIndex(stateTime, anim.getFrameDuration(), keyframes.length, looping);
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -39,6 +39,7 @@ import org.flixelgdx.graphics.FlixelFrame;
 import org.flixelgdx.graphics.FlixelGraphic;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.StringReader;
 import java.util.Comparator;
@@ -47,6 +48,10 @@ import java.util.Comparator;
  * Playback state and clip registration for {@link FlixelSprite} animations. Obtain a controller with
  * {@link FlixelSprite#ensureAnimation()} (or assign one directly), then call {@code sprite.ensureAnimation().loadSparrowFrames(...)},
  * {@code .playAnimation(...)}, etc. Decouples animation timing from rendering and physics.
+ *
+ * <p>Optionally link a {@link FlixelAnimationStateMachine} via {@link #setStateMachine} so the
+ * machine is ticked automatically inside {@link #update(float)} - no separate machine update call
+ * needed in your game loop.
  */
 public class FlixelAnimationController implements FlixelUpdatable {
 
@@ -66,6 +71,13 @@ public class FlixelAnimationController implements FlixelUpdatable {
    */
   @NotNull
   private final ObjectMap<String, float[]> animationOffsets = new ObjectMap<>();
+
+  /**
+   * Optional state machine to update automatically alongside this controller. When non-null,
+   * {@link #update(float)} ticks the machine so callers only need to update the sprite.
+   */
+  @Nullable
+  private FlixelAnimationStateMachine stateMachine;
 
   /** The current state time of the animation. */
   private float stateTime;
@@ -585,6 +597,10 @@ public class FlixelAnimationController implements FlixelUpdatable {
       onAnimationFinished.dispatch(data);
     }
     lastFinished = finished;
+
+    if (stateMachine != null) {
+      stateMachine.update(elapsed);
+    }
   }
 
   @NotNull
@@ -680,5 +696,33 @@ public class FlixelAnimationController implements FlixelUpdatable {
 
   public boolean isLooping() {
     return looping;
+  }
+
+  /**
+   * @return The linked {@link FlixelAnimationStateMachine}, or {@code null} if none is set.
+   */
+  @Nullable
+  public FlixelAnimationStateMachine getStateMachine() {
+    return stateMachine;
+  }
+
+  /**
+   * Links a {@link FlixelAnimationStateMachine} to this controller so it is ticked automatically by
+   * {@link #update(float)}. Pass {@code null} to detach a previously linked machine.
+   *
+   * <p>This is the recommended way to drive an FSM: link it once and update only the sprite each
+   * frame. The machine still works independently if you prefer to call its own
+   * {@link FlixelAnimationStateMachine#update(float)} by hand - just do not link it here.
+   *
+   * <pre>{@code
+   * var fsm = new FlixelAnimationStateMachine(player);
+   * player.ensureAnimation().setStateMachine(fsm);
+   * // From now on player.update(elapsed) advances both the controller and the FSM.
+   * }</pre>
+   *
+   * @param stateMachine The machine to auto-tick, or {@code null} to clear the link.
+   */
+  public void setStateMachine(@Nullable FlixelAnimationStateMachine stateMachine) {
+    this.stateMachine = stateMachine;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -477,10 +477,12 @@ public class FlixelAnimationController implements FlixelUpdatable {
     lastFinished = false;
 
     // Show this clip's first keyframe immediately so a freshly played animation does not flash the
-    // previous frame for a tick, and size the sprite to the clip's source frame.
-    FlixelFrame[] keyframes = anim.getKeyFrames();
+    // previous frame for a tick, and size the sprite to the clip's source frame. getKeyFrames() is
+    // typed FlixelFrame[] but is often backed by an Object[] at runtime (clips built from a default
+    // libGDX Array), so cast per element rather than casting the whole array.
+    Object[] keyframes = anim.getKeyFrames();
     if (keyframes.length > 0) {
-      owner.setCurrentFrameForAnimation(keyframes[0]);
+      owner.setCurrentFrameForAnimation((FlixelFrame) keyframes[0]);
       // Sparrow/atlas characters: snap the hitbox to this clip's untrimmed frame so the debug box
       // and collision bounds frame whichever animation is playing. Grid-frame sprites keep their
       // hitbox untouched, since it may be a deliberately customized collision box.
@@ -559,14 +561,15 @@ public class FlixelAnimationController implements FlixelUpdatable {
 
     int frameIndex = computeKeyframeIndex(anim);
     // Pick the displayed frame by the same index the controller reports elsewhere, rather than
-    // anim.getKeyFrame(stateTime, looping). That libGDX call honors the clip's *registered* PlayMode,
+    // anim.getKeyFrame(stateTime, looping). That libGDX call honors the clip's REGISTERED PlayMode,
     // so a clip registered to loop but played non-looping wraps back to frame 0 when it finishes;
     // indexing the keyframes directly keeps a finished non-looping clip parked on its last frame.
-    FlixelFrame[] keyframes = anim.getKeyFrames();
+    // Typed FlixelFrame[] but may be an Object[] at runtime, so cast the element, not the array.
+    Object[] keyframes = anim.getKeyFrames();
     if (keyframes.length == 0) {
       return;
     }
-    FlixelFrame frame = keyframes[frameIndex];
+    FlixelFrame frame = (FlixelFrame) keyframes[frameIndex];
     owner.setCurrentFrameForAnimation(frame);
 
     if (frameIndex != lastDispatchedFrameIndex) {
@@ -640,7 +643,9 @@ public class FlixelAnimationController implements FlixelUpdatable {
    * @return A keyframe index in {@code [0, keyframeCount - 1]}, or {@code 0} for degenerate clips.
    */
   private int computeKeyframeIndex(@NotNull Animation<FlixelFrame> anim) {
-    FlixelFrame[] keyframes = anim.getKeyFrames();
+    // getKeyFrames() only gives the count here; read it as Object[] to avoid an array-type cast that
+    // would fail when the clip is backed by an Object[] at runtime.
+    Object[] keyframes = anim.getKeyFrames();
     return keyframeIndex(stateTime, anim.getFrameDuration(), keyframes.length, looping);
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.utils.ObjectSet;
 
 import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.functional.FlixelDestroyable;
+import org.flixelgdx.functional.FlixelUpdatable;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -48,17 +49,36 @@ import org.jetbrains.annotations.Nullable;
  *   <li>the animation clip to play (or none, for an invisible logic-only state),</li>
  *   <li>whether that clip loops,</li>
  *   <li>an {@link State#autoAdvanceTo(String) auto-advance} target, so a one-shot clip (such as an
- *       attack) automatically returns to another state the moment it finishes,</li>
+ *       attack) automatically returns to another state the moment it finishes, optionally after a
+ *       {@link State#delay(float) delay},</li>
  *   <li>{@link State#onEnter(Runnable) onEnter} / {@link State#onExit(Runnable) onExit} hooks for
  *       side effects, and</li>
  *   <li>the set of {@link State#allowTo(String...) legal transitions} out of it.</li>
+ * </ul>
+ *
+ * <h2>Concepts and terminology</h2>
+ * <ul>
+ *   <li><strong>State</strong>: one named mode the sprite can be in, such as {@code "idle"} or
+ *       {@code "attack"}. The machine is in exactly one state at a time. Register states with
+ *       {@link #addState(String, String)}.</li>
+ *   <li><strong>Transition</strong>: a move from one state to another, requested with
+ *       {@link #setState(String)}. Asking for the state that is already active is a no-op.</li>
+ *   <li><strong>Guard</strong>: a rule that decides whether a transition is allowed. Configured per
+ *       source state with {@link State#allowTo(String...)}; a state with no rule allows any move.</li>
+ *   <li><strong>Entry / exit actions</strong>: callbacks run when a state is entered or left
+ *       ({@link State#onEnter(Runnable)} / {@link State#onExit(Runnable)}).</li>
+ *   <li><strong>Auto-advance</strong>: an automatic transition that fires when a one-shot clip
+ *       finishes ({@link State#autoAdvanceTo(String)}), optionally after a delay.</li>
+ *   <li><strong>Self-transition</strong>: deliberately re-entering the current state with
+ *       {@link #setState(String, boolean) setState(name, true)}, which replays its clip.</li>
  * </ul>
  *
  * <h2>How it drives the sprite</h2>
  * The machine holds a reference to the sprite's {@link FlixelAnimationController} and subscribes to
  * its {@link FlixelAnimationController#onAnimationFinished} signal, which is what powers
  * auto-advance. You must still call {@code sprite.update(...)} every frame so the controller advances
- * animation time and reports when clips end.
+ * animation time and reports when clips end. If any state uses a {@link State#delay(float) delayed}
+ * auto-advance, also call this machine's {@link #update(float)} each frame so the delay can elapse.
  *
  * <h2>Typical usage</h2>
  * <pre>{@code
@@ -80,7 +100,7 @@ import org.jetbrains.annotations.Nullable;
  * @see FlixelAnimationController
  * @see org.flixelgdx.FlixelSprite#ensureAnimation()
  */
-public class FlixelAnimationStateMachine implements FlixelDestroyable {
+public class FlixelAnimationStateMachine implements FlixelDestroyable, FlixelUpdatable {
 
   /** The controller whose clips this machine plays. */
   @NotNull
@@ -97,6 +117,13 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
   /** The current logical state, or {@code ""} before the first {@link #setState}. */
   @NotNull
   private String state = "";
+
+  /** Target of a delayed auto-advance waiting on {@link #update(float)}, or {@code null} when idle. */
+  @Nullable
+  private String pendingState;
+
+  /** Seconds remaining before {@link #pendingState} is entered. */
+  private float pendingTimer;
 
   /**
    * Fired with the new state name whenever the machine moves to a different state. Not fired for a
@@ -215,6 +242,10 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
       return false;
     }
 
+    // Any real (or forced) transition cancels an auto-advance that was waiting on a delay.
+    pendingState = null;
+    pendingTimer = 0f;
+
     // Leaving the old state (skipped on a forced self-replay, where the machine never actually left).
     if (!sameState && current != null && current.onExit != null) {
       current.onExit.run();
@@ -251,8 +282,36 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
     }
     // Only advance when the clip that finished is the one this state drives, so an unrelated
     // animation ending cannot bounce the machine forward.
-    if (current.clipName.equals(data.getAnimationName())) {
+    if (!current.clipName.equals(data.getAnimationName())) {
+      return;
+    }
+    if (current.delay > 0f) {
+      // Hold on the final frame; update(float) counts the delay down and then advances.
+      pendingState = current.autoNext;
+      pendingTimer = current.delay;
+    } else {
       transition(current.autoNext, false, false);
+    }
+  }
+
+  /**
+   * Advances a pending {@link State#delay(float) delayed} auto-advance. Only needed when a state uses
+   * a delay; immediate auto-advance and manual {@link #setState} calls work without it. Safe to call
+   * every frame regardless.
+   *
+   * @param elapsed Seconds since the last frame.
+   */
+  @Override
+  public void update(float elapsed) {
+    if (pendingState == null) {
+      return;
+    }
+    pendingTimer -= elapsed;
+    if (pendingTimer <= 0f) {
+      String target = pendingState;
+      pendingState = null;
+      pendingTimer = 0f;
+      transition(target, false, false);
     }
   }
 
@@ -260,6 +319,8 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
   public void clear() {
     states.clear();
     state = "";
+    pendingState = null;
+    pendingTimer = 0f;
   }
 
   /**
@@ -271,6 +332,8 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
     controller.onAnimationFinished.remove(finishListener);
     states.clear();
     state = "";
+    pendingState = null;
+    pendingTimer = 0f;
     onStateChanged.clear();
   }
 
@@ -299,7 +362,7 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
   public static final class State {
 
     @Nullable
-    private String clipName;
+    private final String clipName;
 
     @Nullable
     private String autoNext;
@@ -313,6 +376,9 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
     /** Allowed transition targets, or {@code null} when transitions out of this state are unrestricted. */
     @Nullable
     private ObjectSet<String> allowed;
+
+    /** Seconds to hold the final frame before auto-advancing. {@code 0} advances immediately. */
+    private float delay;
 
     /** Whether the clip loops. Defaults to {@code true}; auto-advance sets it to {@code false}. */
     private boolean loop = true;
@@ -334,7 +400,8 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
 
     /**
      * Makes this state automatically transition to {@code target} as soon as its clip finishes. This
-     * implies a non-looping clip, so it also sets {@link #loop(boolean) loop} to {@code false}.
+     * implies a non-looping clip, so it also sets {@link #loop(boolean) loop} to {@code false}. Pair
+     * with {@link #delay(float)} to hold the final frame for a moment before advancing.
      *
      * @param target The state to enter when this state's clip finishes.
      * @return This state, for chaining.
@@ -342,6 +409,24 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable {
     public State autoAdvanceTo(@NotNull String target) {
       this.autoNext = target;
       this.loop = false;
+      return this;
+    }
+
+    /**
+     * Sets how long, in seconds, to wait after this state's clip finishes before
+     * {@link #autoAdvanceTo(String) auto-advancing}. Useful for letting a finished pose linger (for
+     * example, holding the last frame of an attack before returning to idle).
+     *
+     * <p>This only affects the auto-advance transition, so it does nothing unless
+     * {@link #autoAdvanceTo(String)} is also set. The owning machine's
+     * {@link FlixelAnimationStateMachine#update(float)} must be called each frame for the delay to
+     * elapse.
+     *
+     * @param seconds The hold time in seconds; values {@code <= 0} advance immediately.
+     * @return This state, for chaining.
+     */
+    public State delay(float seconds) {
+      this.delay = seconds;
       return this;
     }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
@@ -26,8 +26,8 @@ package org.flixelgdx.animation;
 import com.badlogic.gdx.utils.ObjectMap;
 import com.badlogic.gdx.utils.ObjectSet;
 
-import org.flixelgdx.Flixel;
 import org.flixelgdx.FlixelSprite;
+import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -80,7 +80,7 @@ import org.jetbrains.annotations.Nullable;
  * @see FlixelAnimationController
  * @see org.flixelgdx.FlixelSprite#ensureAnimation()
  */
-public class FlixelAnimationStateMachine {
+public class FlixelAnimationStateMachine implements FlixelDestroyable {
 
   /** The controller whose clips this machine plays. */
   @NotNull
@@ -212,10 +212,6 @@ public class FlixelAnimationStateMachine {
     State next = states.get(newState);
 
     if (!sameState && enforceLegality && current != null && !current.canTransitionTo(newState)) {
-      if (Flixel.log != null) {
-        Flixel.log.warn("FlixelAnimationStateMachine",
-            "Illegal transition from '" + state + "' to '" + newState + "'; ignoring.");
-      }
       return false;
     }
 
@@ -270,6 +266,7 @@ public class FlixelAnimationStateMachine {
    * Detaches this machine from its controller and clears all states. Call when the owning sprite is
    * destroyed so the machine does not keep receiving {@code onAnimationFinished} callbacks.
    */
+  @Override
   public void destroy() {
     controller.onAnimationFinished.remove(finishListener);
     states.clear();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
@@ -78,7 +78,10 @@ import org.jetbrains.annotations.Nullable;
  * its {@link FlixelAnimationController#onAnimationFinished} signal, which is what powers
  * auto-advance. You must still call {@code sprite.update(...)} every frame so the controller advances
  * animation time and reports when clips end. If any state uses a {@link State#delay(float) delayed}
- * auto-advance, also call this machine's {@link #update(float)} each frame so the delay can elapse.
+ * auto-advance, the machine's {@link #update(float)} must also be called each frame so the delay can
+ * elapse. The easiest way to satisfy that requirement is to link the machine to the controller with
+ * {@link FlixelAnimationController#setStateMachine}, which makes {@code sprite.update(...)} tick both
+ * automatically. Alternatively, call {@link #update(float)} yourself each frame.
  *
  * <h2>Typical usage</h2>
  * <pre>{@code
@@ -90,6 +93,9 @@ import org.jetbrains.annotations.Nullable;
  *    .autoAdvanceTo("idle")          // one-shot: snaps back to idle when the clip ends
  *    .onEnter(() -> sword.swing());
  * fsm.setState("idle");
+ *
+ * // Link the machine so player.update(...) ticks it automatically - no separate fsm.update() needed:
+ * player.ensureAnimation().setStateMachine(fsm);
  *
  * // Each frame, just describe the situation; calling setState with the current state is a no-op:
  * if (attackPressed)        fsm.setState("attack");

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
@@ -24,146 +24,261 @@
 package org.flixelgdx.animation;
 
 import com.badlogic.gdx.utils.ObjectMap;
+import com.badlogic.gdx.utils.ObjectSet;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Optional indirection between <strong>game logic state labels</strong> and <strong>registered animation clip
- * names</strong> on a {@link FlixelAnimationController}.
+ * A lightweight finite state machine that drives a sprite's animations.
  *
- * <h2>What this is for</h2>
- * <p>
- * {@link org.flixelgdx.FlixelSprite} stores clips on its {@link FlixelAnimationController} (from
- * {@link org.flixelgdx.FlixelSprite#ensureAnimation()}) when you call {@code sprite.ensureAnimation().addAnimation} or
- * {@code .addAnimationByPrefix}. Those keys often match asset or sheet naming ({@code "player_run"},
- * {@code "hit_01"}) while your gameplay code thinks in terms of behavior ({@code "running"},
- * {@code "hurt"}).
- * </p>
- * <p>
- * This class keeps a map {@code logicalState -> clipName}. When you {@link #setState(String,
- * FlixelAnimationController, boolean, boolean) setState}, it updates the remembered logical state,
- * optionally notifies listeners, and if a mapping exists, calls {@link FlixelAnimationController#playAnimation(String,
- * boolean, boolean)} so the correct clip plays. That lets you rename or reorganize clips in one place
- * (the map) instead of hunting every {@code playAnimation} call.
- * </p>
+ * <h2>Why this exists</h2>
+ * Calling {@link FlixelAnimationController#playAnimation(String, boolean, boolean) playAnimation}
+ * directly from gameplay code works, but it spreads animation rules everywhere: which clip plays for
+ * which behavior, which transitions are legal, what should happen when a one-shot clip finishes, and
+ * what side effects (sound, particles) a transition triggers. A state machine gathers those rules in
+ * one place so the gameplay code can simply say "I am now {@code running}" and trust the machine to
+ * play the right clip, reject illegal moves, and chain follow-up animations on its own.
  *
- * <h2>What this is not</h2>
+ * <h2>What a state can describe</h2>
  * <ul>
- *   <li>It does not register frames or build {@link com.badlogic.gdx.graphics.g2d.Animation}; clips must
- *       already exist on the controller (via the owning {@link org.flixelgdx.FlixelSprite}).</li>
- *   <li>It does not poll input or physics; your code must call {@link #setState} when the character's
- *       situation changes.</li>
- *   <li>It does not auto-transition when a non-looping clip ends; listen to
- *       {@link FlixelAnimationController#onAnimationFinished} if you need that.</li>
- *   <li>A {@link #setState} to a state with <em>no</em> mapping still updates {@link #getState()} and fires
- *       {@link #onStateChanged}, but does not call {@code playAnimation} (useful for invisible states).</li>
+ *   <li>the animation clip to play (or none, for an invisible logic-only state),</li>
+ *   <li>whether that clip loops,</li>
+ *   <li>an {@link State#autoAdvanceTo(String) auto-advance} target, so a one-shot clip (such as an
+ *       attack) automatically returns to another state the moment it finishes,</li>
+ *   <li>{@link State#onEnter(Runnable) onEnter} / {@link State#onExit(Runnable) onExit} hooks for
+ *       side effects, and</li>
+ *   <li>the set of {@link State#allowTo(String...) legal transitions} out of it.</li>
  * </ul>
  *
+ * <h2>How it drives the sprite</h2>
+ * The machine holds a reference to the sprite's {@link FlixelAnimationController} and subscribes to
+ * its {@link FlixelAnimationController#onAnimationFinished} signal, which is what powers
+ * auto-advance. You must still call {@code sprite.update(...)} every frame so the controller advances
+ * animation time and reports when clips end.
+ *
  * <h2>Typical usage</h2>
- * <p>
- * Hold one instance per character (or shared rules object). After loading graphics and registering clips on
- * the sprite, wire the map once, then drive states from movement, AI, or timers.
- * </p>
  * <pre>{@code
- * // After player.loadGraphic(...) and player.ensureAnimation().addAnimation("walk", ...), etc.:
- * FlixelAnimationStateMachine sm = new FlixelAnimationStateMachine();
- * sm.mapStateToAnimation("idle", "idle");
- * sm.mapStateToAnimation("run", "walk");
- * sm.onStateChanged.add(s -> reactToLogicalState(s));  // optional: audio, VFX, etc.
- * sm.setState("idle", player.ensureAnimation(), true, true);
+ * // After loading frames and registering clips on the sprite:
+ * var fsm = new FlixelAnimationStateMachine(player);
+ * fsm.addState("idle", "idle").allowTo("run", "attack");
+ * fsm.addState("run", "run").allowTo("idle", "attack");
+ * fsm.addState("attack", "attack")
+ *    .autoAdvanceTo("idle")          // one-shot: snaps back to idle when the clip ends
+ *    .onEnter(() -> sword.swing());
+ * fsm.setState("idle");
  *
- * // Each frame or on events:
- * if (onGround && speed > threshold) {
- *   sm.setState("run", player.ensureAnimation(), true, false);
- * } else if (onGround) {
- *   sm.setState("idle", player.ensureAnimation(), true, false);
- * }
+ * // Each frame, just describe the situation; calling setState with the current state is a no-op:
+ * if (attackPressed)        fsm.setState("attack");
+ * else if (speed > 0.1f)    fsm.setState("run");
+ * else                      fsm.setState("idle");
  * }</pre>
- *
- * <p>
- * Use {@code forceRestart == false} when you may call {@code setState} repeatedly for the same state
- * (e.g. every frame while running) so the clip is not restarted from frame 0 each time. Use
- * {@code forceRestart == true} when re-entering the same state should replay from the start (e.g. hurt
- * stun).
- * </p>
- *
- * <p>
- * {@link org.flixelgdx.FlixelSprite#update(float)} must still run each frame so the {@link FlixelAnimationController}
- * advances time and updates the drawn frame.
- * </p>
  *
  * @see FlixelAnimationController
  * @see org.flixelgdx.FlixelSprite#ensureAnimation()
  */
 public class FlixelAnimationStateMachine {
 
+  /** The controller whose clips this machine plays. */
+  @NotNull
+  private final FlixelAnimationController controller;
+
+  /** Registered states, keyed by their logical name. */
+  @NotNull
+  private final ObjectMap<String, State> states = new ObjectMap<>();
+
+  /** Listener kept so it can be detached again in {@link #destroy()}. */
+  @NotNull
+  private final FlixelSignal.SignalHandler<FlixelAnimationFrameSignalData> finishListener;
+
+  /** The current logical state, or {@code ""} before the first {@link #setState}. */
   @NotNull
   private String state = "";
 
-  private final ObjectMap<String, String> stateToAnimation = new ObjectMap<>();
-
   /**
-   * Fired immediately after the internal state string changes in {@link #setState}, with the new state as
-   * payload. Not fired when {@code setState} is called with the same state as {@link #getState()} (no-op).
+   * Fired with the new state name whenever the machine moves to a different state. Not fired for a
+   * no-op {@link #setState} call that targets the current state.
    */
   @NotNull
   public final FlixelSignal<String> onStateChanged = new FlixelSignal<>();
 
   /**
-   * Associates a logical state label with an animation clip name that must already be registered on the
-   * sprite/controller (same string you passed to {@code addAnimation} / {@code addAnimationByPrefix}).
-   * Later {@link #setState} calls for {@code state} will {@link FlixelAnimationController#playAnimation(String,
-   * boolean, boolean)} the given {@code animationName}.
+   * Creates a machine that drives the given sprite's {@link FlixelAnimationController}.
    *
-   * @param state arbitrary non-null key (e.g. {@code "air"}, {@code "crouch"})
-   * @param animationName clip key on the controller; if wrong, {@code setState} will not find a clip to play
+   * @param sprite The sprite to animate; its controller is obtained via {@link FlixelSprite#ensureAnimation()}.
    */
-  public void mapStateToAnimation(@NotNull String state, @NotNull String animationName) {
-    stateToAnimation.put(state, animationName);
+  public FlixelAnimationStateMachine(@NotNull FlixelSprite sprite) {
+    this(sprite.ensureAnimation());
   }
 
   /**
-   * Removes a mapping so {@link #setState} for that label no longer triggers {@code playAnimation}.
-   * Does not change {@link #getState()} by itself.
+   * Creates a machine that drives the given controller.
+   *
+   * @param controller The controller whose registered clips the states refer to.
    */
-  public void removeState(@NotNull String state) {
-    stateToAnimation.remove(state);
+  public FlixelAnimationStateMachine(@NotNull FlixelAnimationController controller) {
+    if (controller == null) {
+      throw new IllegalArgumentException("Controller cannot be null.");
+    }
+    this.controller = controller;
+    this.finishListener = this::handleAnimationFinished;
+    controller.onAnimationFinished.add(finishListener);
   }
 
   /**
-   * Switches the logical state and, when {@code newState} differs from {@link #getState()}, dispatches
-   * {@link #onStateChanged}. If {@code stateToAnimation} contains {@code newState}, calls
-   * {@link FlixelAnimationController#playAnimation(String, boolean, boolean)} on {@code controller} with
-   * the given {@code loop} and {@code forceRestart}.
+   * Registers a logic-only state with no animation clip. Entering it still fires hooks and
+   * {@link #onStateChanged}, but plays nothing.
    *
-   * <p>
-   * If {@code newState} equals the current state, returns immediately (no signal, no {@code playAnimation}).
-   * </p>
-   *
-   * @param newState The logical state to enter.
-   * @param controller The animation controller to use. Typically {@code sprite.ensureAnimation()}. Must be the controller that owns the mapped clips.
-   * @param loop Forwarded to {@code playAnimation} (often {@code true} for idle/run, {@code false} for one-shot clips).
-   * @param forceRestart Forwarded to {@code playAnimation}; use {@code false} when polling the same state every frame.
+   * @param name The logical state name.
+   * @return The new {@link State} for fluent configuration.
    */
-  public void setState(
-      @NotNull String newState,
-      @NotNull FlixelAnimationController controller,
-      boolean loop,
-      boolean forceRestart) {
-    if (state.equals(newState)) {
+  @NotNull
+  public State addState(@NotNull String name) {
+    return addState(name, null);
+  }
+
+  /**
+   * Registers a state that plays {@code clipName} (a clip already registered on the controller via
+   * {@code addAnimation} / {@code addAnimationByPrefix}) when entered.
+   *
+   * @param name The logical state name.
+   * @param clipName The animation clip to play, or {@code null} for a logic-only state.
+   * @return The new {@link State} for fluent configuration.
+   */
+  @NotNull
+  public State addState(@NotNull String name, @Nullable String clipName) {
+    State newState = new State(clipName);
+    states.put(name, newState);
+    return newState;
+  }
+
+  /**
+   * Removes a registered state. Does not change the current {@link #getState()}.
+   *
+   * @param name The state to remove.
+   */
+  public void removeState(@NotNull String name) {
+    states.remove(name);
+  }
+
+  /**
+   * Moves to {@code newState} if the transition is legal. Calling this with the state that is already
+   * active is a cheap no-op, so it is safe to call every frame.
+   *
+   * @param newState The state to enter.
+   * @return {@code true} if the machine is now in {@code newState}, {@code false} if the transition
+   *     was rejected as illegal.
+   */
+  public boolean setState(@NotNull String newState) {
+    return transition(newState, false, true);
+  }
+
+  /**
+   * Moves to {@code newState}, optionally re-entering it even if it is already active.
+   *
+   * <p>A forced re-entry replays the state's clip from the start and runs its
+   * {@link State#onEnter(Runnable) onEnter} hook again (but not {@code onExit}, since the machine
+   * never left). This is handy for retriggering a one-shot, such as attacking again mid-swing.
+   *
+   * @param newState The state to enter.
+   * @param force {@code true} to re-enter even when {@code newState} is already active.
+   * @return {@code true} if the machine is now in {@code newState}, {@code false} if a real
+   *     (state-changing) transition was rejected as illegal.
+   */
+  public boolean setState(@NotNull String newState, boolean force) {
+    return transition(newState, force, true);
+  }
+
+  /**
+   * Core transition routine shared by the public {@code setState} overloads and the internal
+   * auto-advance path.
+   *
+   * @param newState The state to enter.
+   * @param force {@code true} to re-enter {@code newState} even if it is already active.
+   * @param enforceLegality {@code true} to honor the source state's {@link State#allowTo} rules;
+   *     auto-advance passes {@code false} because it follows a transition the developer configured.
+   * @return {@code true} if the machine ends up in {@code newState}.
+   */
+  private boolean transition(@NotNull String newState, boolean force, boolean enforceLegality) {
+    boolean sameState = state.equals(newState);
+    if (sameState && !force) {
+      return true;
+    }
+
+    State current = states.get(state);
+    State next = states.get(newState);
+
+    if (!sameState && enforceLegality && current != null && !current.canTransitionTo(newState)) {
+      if (Flixel.log != null) {
+        Flixel.log.warn("FlixelAnimationStateMachine",
+            "Illegal transition from '" + state + "' to '" + newState + "'; ignoring.");
+      }
+      return false;
+    }
+
+    // Leaving the old state (skipped on a forced self-replay, where the machine never actually left).
+    if (!sameState && current != null && current.onExit != null) {
+      current.onExit.run();
+    }
+
+    state = newState;
+
+    // Entering the new state: run its entry hook, then (re)start its clip from the beginning.
+    if (next != null) {
+      if (next.onEnter != null) {
+        next.onEnter.run();
+      }
+      if (next.clipName != null) {
+        controller.playAnimation(next.clipName, next.loop, true);
+      }
+    }
+
+    if (!sameState) {
+      onStateChanged.dispatch(newState);
+    }
+    return true;
+  }
+
+  /**
+   * Auto-advance hook: when the clip belonging to the current state finishes, follow that state's
+   * {@link State#autoAdvanceTo(String)} target if one is configured.
+   *
+   * @param data The finished-animation payload from the controller.
+   */
+  private void handleAnimationFinished(@NotNull FlixelAnimationFrameSignalData data) {
+    State current = states.get(state);
+    if (current == null || current.autoNext == null || current.clipName == null) {
       return;
     }
-    state = newState;
-    onStateChanged.dispatch(newState);
-    String anim = stateToAnimation.get(newState);
-    if (anim != null) {
-      controller.playAnimation(anim, loop, forceRestart);
+    // Only advance when the clip that finished is the one this state drives, so an unrelated
+    // animation ending cannot bounce the machine forward.
+    if (current.clipName.equals(data.getAnimationName())) {
+      transition(current.autoNext, false, false);
     }
   }
 
+  /** Clears all registered states and resets to the empty state, keeping the machine usable. */
+  public void clear() {
+    states.clear();
+    state = "";
+  }
+
   /**
-   * The last logical state set by {@link #setState}, or {@code ""} if none yet.
+   * Detaches this machine from its controller and clears all states. Call when the owning sprite is
+   * destroyed so the machine does not keep receiving {@code onAnimationFinished} callbacks.
+   */
+  public void destroy() {
+    controller.onAnimationFinished.remove(finishListener);
+    states.clear();
+    state = "";
+    onStateChanged.clear();
+  }
+
+  /**
+   * @return The current logical state, or {@code ""} if {@link #setState} has not run yet.
    */
   @NotNull
   public String getState() {
@@ -171,12 +286,110 @@ public class FlixelAnimationStateMachine {
   }
 
   /**
-   * Resets logical state to empty and clears all {@code mapStateToAnimation} entries. Does not stop or
-   * clear clips on any {@link FlixelAnimationController}; call {@link FlixelAnimationController#clear} on
-   * the sprite if you need that.
+   * @param name The state name to look up.
+   * @return {@code true} if a state with that name is registered.
    */
-  public void clear() {
-    state = "";
-    stateToAnimation.clear();
+  public boolean hasState(@NotNull String name) {
+    return states.containsKey(name);
+  }
+
+  /**
+   * One configurable state in a {@link FlixelAnimationStateMachine}, built fluently.
+   *
+   * <p>Obtain one from {@link FlixelAnimationStateMachine#addState(String, String)} and chain the
+   * setters, for example {@code addState("attack", "attack").autoAdvanceTo("idle").onEnter(...)}.
+   */
+  public static final class State {
+
+    @Nullable
+    private String clipName;
+
+    @Nullable
+    private String autoNext;
+
+    @Nullable
+    private Runnable onEnter;
+
+    @Nullable
+    private Runnable onExit;
+
+    /** Allowed transition targets, or {@code null} when transitions out of this state are unrestricted. */
+    @Nullable
+    private ObjectSet<String> allowed;
+
+    /** Whether the clip loops. Defaults to {@code true}; auto-advance sets it to {@code false}. */
+    private boolean loop = true;
+
+    private State(@Nullable String clipName) {
+      this.clipName = clipName;
+    }
+
+    /**
+     * Sets whether this state's clip loops.
+     *
+     * @param loop {@code true} to loop, {@code false} to play once.
+     * @return This state, for chaining.
+     */
+    public State loop(boolean loop) {
+      this.loop = loop;
+      return this;
+    }
+
+    /**
+     * Makes this state automatically transition to {@code target} as soon as its clip finishes. This
+     * implies a non-looping clip, so it also sets {@link #loop(boolean) loop} to {@code false}.
+     *
+     * @param target The state to enter when this state's clip finishes.
+     * @return This state, for chaining.
+     */
+    public State autoAdvanceTo(@NotNull String target) {
+      this.autoNext = target;
+      this.loop = false;
+      return this;
+    }
+
+    /**
+     * Sets an action run when the machine enters this state (after a forced re-entry too).
+     *
+     * @param action The entry action.
+     * @return This state, for chaining.
+     */
+    public State onEnter(@NotNull Runnable action) {
+      this.onEnter = action;
+      return this;
+    }
+
+    /**
+     * Sets an action run when the machine leaves this state for a different one.
+     *
+     * @param action The exit action.
+     * @return This state, for chaining.
+     */
+    public State onExit(@NotNull Runnable action) {
+      this.onExit = action;
+      return this;
+    }
+
+    /**
+     * Restricts which states may be entered directly from this one. Without any call to this method,
+     * every transition out of this state is allowed; once called, only the listed targets are legal.
+     * May be called more than once to add more targets.
+     *
+     * @param targets The state names reachable from this state.
+     * @return This state, for chaining.
+     */
+    public State allowTo(@NotNull String... targets) {
+      if (allowed == null) {
+        allowed = new ObjectSet<>();
+      }
+      for (String target : targets) {
+        allowed.add(target);
+      }
+      return this;
+    }
+
+    private boolean canTransitionTo(@NotNull String target) {
+      return allowed == null || allowed.contains(target);
+    }
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationStateMachine.java
@@ -242,7 +242,7 @@ public class FlixelAnimationStateMachine implements FlixelDestroyable, FlixelUpd
       return false;
     }
 
-    // Any real (or forced) transition cancels an auto-advance that was waiting on a delay.
+    // Any real (or forced) transition cancels an auto-advance waiting on a delay.
     pendingState = null;
     pendingTimer = 0f;
 

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationPlaybackTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationPlaybackTest.java
@@ -23,10 +23,18 @@
  */
 package org.flixelgdx.animation;
 
+import com.badlogic.gdx.graphics.g2d.Animation;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.Array;
+
+import org.flixelgdx.FlixelSprite;
+import org.flixelgdx.graphics.FlixelFrame;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -70,5 +78,27 @@ class FlixelAnimationPlaybackTest {
     assertTrue(FlixelAnimationController.shouldRestart(false, true, true));
     // Same clip still mid-play and not forced: leave it running.
     assertFalse(FlixelAnimationController.shouldRestart(false, true, false));
+  }
+
+  @Test
+  void playingAndUpdatingAnObjectBackedClipDoesNotThrow() {
+    // Clips registered through addAnimationByPrefix use a default libGDX Array, whose backing store
+    // is an Object[]. getKeyFrames() is typed FlixelFrame[], so casting the whole array (rather than
+    // each element) throws a ClassCastException at runtime. Empty TextureRegions keep this GPU-free.
+    FlixelSprite sprite = new FlixelSprite();
+    FlixelAnimationController controller = sprite.ensureAnimation();
+
+    Array<FlixelFrame> frames = new Array<>();
+    for (int i = 0; i < 3; i++) {
+      frames.add(new FlixelFrame(new TextureRegion()));
+    }
+    controller.getAnimations().put("test", new Animation<>(0.1f, frames, Animation.PlayMode.NORMAL));
+
+    assertDoesNotThrow(() -> {
+      controller.playAnimation("test", false);
+      controller.update(0.05f);
+      controller.update(0.5f); // advance past the end of the clip
+    });
+    assertNotNull(sprite.getCurrentFrame());
   }
 }

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationPlaybackTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationPlaybackTest.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.animation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the two pure playback decisions in {@link FlixelAnimationController} that back the
+ * non-looping-frame and replay fixes. They are split into static helpers precisely so they can be
+ * checked here without registering real clips (which would need a GPU texture).
+ */
+class FlixelAnimationPlaybackTest {
+
+  // A 3-frame clip at 0.1s per frame: total duration 0.3s.
+
+  @Test
+  void finishedNonLoopingClipHoldsItsLastFrame() {
+    // Past the end, a non-looping clip must stay on the last index, not snap back to the first.
+    assertEquals(2, FlixelAnimationController.keyframeIndex(0.35f, 0.1f, 3, false));
+    assertEquals(2, FlixelAnimationController.keyframeIndex(100f, 0.1f, 3, false));
+    // Mid-clip indices are unaffected.
+    assertEquals(0, FlixelAnimationController.keyframeIndex(0.05f, 0.1f, 3, false));
+    assertEquals(1, FlixelAnimationController.keyframeIndex(0.15f, 0.1f, 3, false));
+  }
+
+  @Test
+  void loopingClipWrapsBackIntoRange() {
+    assertEquals(0, FlixelAnimationController.keyframeIndex(0.35f, 0.1f, 3, true)); // index 3 -> 0
+    assertEquals(1, FlixelAnimationController.keyframeIndex(0.45f, 0.1f, 3, true)); // index 4 -> 1
+  }
+
+  @Test
+  void degenerateClipsReturnZeroSafely() {
+    assertEquals(0, FlixelAnimationController.keyframeIndex(1f, 0f, 3, false));
+    assertEquals(0, FlixelAnimationController.keyframeIndex(1f, 0.1f, 0, false));
+  }
+
+  @Test
+  void replayRulesAllowReplayingAFinishedClip() {
+    // A forced call always restarts.
+    assertTrue(FlixelAnimationController.shouldRestart(true, true, false));
+    // Switching to a different clip restarts.
+    assertTrue(FlixelAnimationController.shouldRestart(false, false, false));
+    // Same clip, but it already finished: restart (this is the "can't play again" fix).
+    assertTrue(FlixelAnimationController.shouldRestart(false, true, true));
+    // Same clip still mid-play and not forced: leave it running.
+    assertFalse(FlixelAnimationController.shouldRestart(false, true, false));
+  }
+}

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationStateMachineTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationStateMachineTest.java
@@ -164,4 +164,42 @@ class FlixelAnimationStateMachineTest {
     assertEquals("", fsm.getState(), "A detached machine must not auto-advance to idle.");
     assertFalse(fsm.hasState("idle"), "destroy() should clear registered states.");
   }
+
+  @Test
+  void delayedAutoAdvanceWaitsForTheDelayToElapse() {
+    FlixelSprite sprite = new FlixelSprite();
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(sprite);
+    fsm.addState("idle", "idle");
+    fsm.addState("attack", "attack").autoAdvanceTo("idle").delay(0.5f);
+    fsm.setState("attack");
+
+    // The clip finishes, but the delay means the machine should hold "attack" for now.
+    sprite.ensureAnimation().onAnimationFinished
+        .dispatch(new FlixelAnimationFrameSignalData("attack", 0, null));
+    assertEquals("attack", fsm.getState());
+
+    fsm.update(0.3f);
+    assertEquals("attack", fsm.getState(), "Still inside the delay window.");
+
+    fsm.update(0.3f); // 0.6s total, past the 0.5s delay
+    assertEquals("idle", fsm.getState(), "Delay elapsed, so it should auto-advance.");
+  }
+
+  @Test
+  void manualTransitionCancelsAPendingDelayedAdvance() {
+    FlixelSprite sprite = new FlixelSprite();
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(sprite);
+    fsm.addState("idle", "idle");
+    fsm.addState("run", "run");
+    fsm.addState("attack", "attack").autoAdvanceTo("idle").delay(0.5f);
+    fsm.setState("attack");
+    sprite.ensureAnimation().onAnimationFinished
+        .dispatch(new FlixelAnimationFrameSignalData("attack", 0, null));
+
+    // The player interrupts before the delay elapses; the queued auto-advance must be dropped.
+    fsm.setState("run");
+    fsm.update(1.0f);
+
+    assertEquals("run", fsm.getState());
+  }
 }

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationStateMachineTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationStateMachineTest.java
@@ -1,0 +1,167 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.animation;
+
+import com.badlogic.gdx.utils.Array;
+
+import org.flixelgdx.FlixelSprite;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises {@link FlixelAnimationStateMachine} transition logic, legality rules, lifecycle hooks,
+ * and auto-advance.
+ *
+ * <p>No clips are registered on the controller, so {@code playAnimation} is a no-op here; that is
+ * fine because every behavior under test is driven by the machine's own state, signals, and the
+ * controller's {@code onAnimationFinished} signal (which the tests dispatch manually to simulate a
+ * clip ending). That keeps the suite free of any GPU texture.
+ */
+class FlixelAnimationStateMachineTest {
+
+  @Test
+  void transitionsUpdateStateAndFireSignalOnce() {
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(new FlixelSprite());
+    fsm.addState("idle", "idle");
+    fsm.addState("run", "run");
+
+    Array<String> seen = new Array<>();
+    fsm.onStateChanged.add(seen::add);
+
+    assertTrue(fsm.setState("idle"));
+    assertEquals("idle", fsm.getState());
+
+    // Re-entering the active state is a no-op: no change, no extra signal.
+    assertTrue(fsm.setState("idle"));
+    assertTrue(fsm.setState("run"));
+
+    assertEquals("run", fsm.getState());
+    assertEquals(2, seen.size, "Signal should fire only on real state changes.");
+    assertEquals("idle", seen.get(0));
+    assertEquals("run", seen.get(1));
+  }
+
+  @Test
+  void illegalTransitionsAreRejectedButLegalOnesPass() {
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(new FlixelSprite());
+    fsm.addState("idle", "idle").allowTo("run");
+    fsm.addState("run", "run");
+    fsm.addState("hurt", "hurt");
+    fsm.setState("idle");
+
+    // "idle" only allows "run", so jumping straight to "hurt" must be refused.
+    assertFalse(fsm.setState("hurt"));
+    assertEquals("idle", fsm.getState());
+
+    assertTrue(fsm.setState("run"));
+    assertEquals("run", fsm.getState());
+
+    // "run" declared no restrictions, so any target is allowed from it.
+    assertTrue(fsm.setState("hurt"));
+    assertEquals("hurt", fsm.getState());
+  }
+
+  @Test
+  void enterAndExitHooksRunInOrder() {
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(new FlixelSprite());
+    Array<String> log = new Array<>();
+    fsm.addState("idle", "idle").onExit(() -> log.add("exit-idle"));
+    fsm.addState("run", "run").onEnter(() -> log.add("enter-run"));
+
+    fsm.setState("idle");
+    fsm.setState("run");
+
+    assertEquals(2, log.size);
+    assertEquals("exit-idle", log.get(0), "The old state must exit before the new one enters.");
+    assertEquals("enter-run", log.get(1));
+  }
+
+  @Test
+  void forcedReentryReplaysWithoutExiting() {
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(new FlixelSprite());
+    int[] enters = {0};
+    int[] exits = {0};
+    fsm.addState("attack", "attack").onEnter(() -> enters[0]++).onExit(() -> exits[0]++);
+
+    fsm.setState("attack");
+    fsm.setState("attack", true); // forced re-entry
+
+    assertEquals(2, enters[0], "A forced re-entry should run onEnter again.");
+    assertEquals(0, exits[0], "A forced re-entry never leaves the state, so onExit must not run.");
+  }
+
+  @Test
+  void autoAdvanceFollowsWhenTheClipFinishes() {
+    FlixelSprite sprite = new FlixelSprite();
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(sprite);
+    fsm.addState("idle", "idle");
+    fsm.addState("attack", "attack").autoAdvanceTo("idle");
+
+    fsm.setState("attack");
+    assertEquals("attack", fsm.getState());
+
+    // Simulate the controller reporting that the "attack" clip finished.
+    sprite.ensureAnimation().onAnimationFinished
+        .dispatch(new FlixelAnimationFrameSignalData("attack", 0, null));
+
+    assertEquals("idle", fsm.getState(), "The one-shot clip finishing should advance to idle.");
+  }
+
+  @Test
+  void autoAdvanceIgnoresAnUnrelatedClipFinishing() {
+    FlixelSprite sprite = new FlixelSprite();
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(sprite);
+    fsm.addState("idle", "idle");
+    fsm.addState("attack", "attack").autoAdvanceTo("idle");
+    fsm.setState("attack");
+
+    // A different clip ending must not bounce the machine forward.
+    sprite.ensureAnimation().onAnimationFinished
+        .dispatch(new FlixelAnimationFrameSignalData("somethingElse", 0, null));
+
+    assertEquals("attack", fsm.getState());
+  }
+
+  @Test
+  void destroyStopsDrivingAutoAdvance() {
+    FlixelSprite sprite = new FlixelSprite();
+    FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(sprite);
+    fsm.addState("idle", "idle");
+    fsm.addState("attack", "attack").autoAdvanceTo("idle");
+    fsm.setState("attack");
+
+    fsm.destroy();
+
+    // After destroy the machine is detached, so a finished clip must not advance it. destroy() also
+    // resets the state to empty, so the tell-tale of a leak would be the state becoming "idle".
+    sprite.ensureAnimation().onAnimationFinished
+        .dispatch(new FlixelAnimationFrameSignalData("attack", 0, null));
+
+    assertEquals("", fsm.getState(), "A detached machine must not auto-advance to idle.");
+    assertFalse(fsm.hasState("idle"), "destroy() should clear registered states.");
+  }
+}

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationStateMachineTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationStateMachineTest.java
@@ -103,8 +103,8 @@ class FlixelAnimationStateMachineTest {
   @Test
   void forcedReentryReplaysWithoutExiting() {
     FlixelAnimationStateMachine fsm = new FlixelAnimationStateMachine(new FlixelSprite());
-    int[] enters = {0};
-    int[] exits = {0};
+    int[] enters = { 0 };
+    int[] exits = { 0 };
     fsm.addState("attack", "attack").onEnter(() -> enters[0]++).onExit(() -> exits[0]++);
 
     fsm.setState("attack");

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationTypesTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimationTypesTest.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.animation;
 
+import org.flixelgdx.FlixelSprite;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -36,9 +37,10 @@ class FlixelAnimationTypesTest {
   }
 
   @Test
-  void stateMachineTracksStateWithoutControllerSideEffects() {
-    FlixelAnimationStateMachine sm = new FlixelAnimationStateMachine();
+  void stateMachineStartsEmptyAndClears() {
+    FlixelAnimationStateMachine sm = new FlixelAnimationStateMachine(new FlixelSprite());
     assertEquals("", sm.getState());
+    sm.addState("idle", "idle");
     sm.clear();
     assertEquals("", sm.getState());
   }


### PR DESCRIPTION
## Description

Reworks `FlixelAnimationStateMachine` from a thin state-label-to-clip-name map into an actual finite state machine, so animation rules (which clip, which transitions are legal, what happens when a one-shot ends, and side effects) live in one place instead of being scattered across `playAnimation` calls.

Each state is configured fluently and can declare:

- a looping or one-shot animation clip (or none, for a logic-only state),
- the set of legal transition targets (`allowTo(...)`) — unrestricted unless you opt in,
- `onEnter` / `onExit` hooks for side effects (sound, particles), and
- an `autoAdvanceTo(...)` target so a one-shot clip (e.g. an attack) returns to another state the instant it finishes.

The machine holds its `FlixelAnimationController` and subscribes to `onAnimationFinished`, which powers auto-advance. `setState(name)` is a cheap no-op when already in that state (safe to call every frame); `setState(name, true)` forces a replay/re-entry.

```java
var fsm = new FlixelAnimationStateMachine(player);
fsm.addState("idle", "idle").allowTo("run", "attack");
fsm.addState("run", "run").allowTo("idle", "attack");
fsm.addState("attack", "attack").autoAdvanceTo("idle").onEnter(() -> sword.swing());
fsm.setState("idle");
```

**Breaking change:** this replaces the previous `mapStateToAnimation(...)` / `setState(name, controller, loop, forceRestart)` API. The class is self-contained (it only uses existing controller signals/methods), so it touches no other source files.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

- `flixelgdx-test`: **43 tests, 0 failures**, including a new `FlixelAnimationStateMachineTest` covering transitions, the no-op-on-same-state rule, legality enforcement, `onEnter`/`onExit` ordering, forced re-entry, auto-advance (and that it ignores unrelated clips), and `destroy()` teardown.
- `flixelgdx-core` compiles clean and `:flixelgdx-core:javadoc` passes with no new warnings.
- Auto-advance is tested without a GPU texture by dispatching the controller's `onAnimationFinished` signal directly.
