### PR TITLE
Overhauled the asset management system with new lifecycle modes to allow developers to have more control over how assets are managed

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 
 import org.flixelgdx.asset.FlixelAssetManager;
+import org.flixelgdx.asset.FlixelAssetMode;
 import org.flixelgdx.asset.FlixelDefaultAssetManager;
 import org.flixelgdx.audio.FlixelAudioManager;
 import org.flixelgdx.audio.FlixelSoundBackend;
@@ -948,8 +949,14 @@ public final class Flixel {
       state.destroy();
     }
 
-    if (assets != null) {
-      assets.clearNonPersist();
+    FlixelAssetMode mode = assets != null ? assets.getAssetMode() : FlixelAssetMode.STANDARD;
+    if (mode == FlixelAssetMode.STANDARD || mode == FlixelAssetMode.AGGRESSIVE) {
+      if (sound != null) {
+        sound.clearNonPersist();
+      }
+      if (assets != null) {
+        assets.clearNonPersist();
+      }
     }
     if (clearTweens) {
       FlixelTween.cancelActiveTweens();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -156,6 +156,14 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   /** Where all the global cameras are stored. */
   protected Array<FlixelCamera> cameras;
 
+  /**
+   * Total render calls issued by the framework {@link SpriteBatch} during the most recently
+   * completed draw pass, summed across all camera loops. Derived from the delta of
+   * {@link SpriteBatch#totalRenderCalls} so multiple {@link SpriteBatch#begin()} resets within
+   * a single frame do not erase earlier cameras' counts.
+   */
+  private int frameRenderCalls;
+
   /** Is the game currently closing? */
   private boolean isClosing = false;
 
@@ -455,6 +463,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     ScreenUtils.clear(bgColor); // Clear the screen to refresh the screen.
     FlixelState state = Flixel.getState();
 
+    int totalRenderCallsBefore = this.batch != null ? this.batch.totalRenderCalls : 0;
+
     // Loop through all cameras and draw the state/substate chain onto each camera.
     FlixelCamera[] cameraItems = cameras.items;
     for (int ci = 0, cn = cameras.size; ci < cn; ci++) {
@@ -491,6 +501,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
         Flixel.setDrawCamera(null);
       }
     }
+
+    frameRenderCalls = this.batch != null ? this.batch.totalRenderCalls - totalRenderCallsBefore : 0;
 
     FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
     if (debugOverlay != null) {
@@ -935,6 +947,18 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
   public SpriteBatch getBatch() {
     return batch;
+  }
+
+  /**
+   * Returns the total number of {@link SpriteBatch} render calls issued during the most recently
+   * completed frame, summed across all camera passes. Unlike {@link SpriteBatch#renderCalls},
+   * this value is not reset by intermediate {@link SpriteBatch#begin()} calls, so it correctly
+   * reflects the full per-frame cost when multiple cameras are active.
+   *
+   * @return Per-frame render call count from the last completed draw pass.
+   */
+  public int getFrameRenderCalls() {
+    return frameRenderCalls;
   }
 
   public Color getBgColor() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
@@ -307,6 +307,25 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
    */
   void setGlobalPersist(boolean globalPersist);
 
+  /**
+   * Returns the active asset management mode, which controls when non-persistent assets are reclaimed.
+   *
+   * @return The current {@link FlixelAssetMode}; never {@code null}.
+   * @see FlixelAssetMode
+   */
+  @NotNull
+  FlixelAssetMode getAssetMode();
+
+  /**
+   * Sets the active asset management mode. The change takes effect immediately on the next
+   * {@link FlixelAsset#release()} call or the next {@link org.flixelgdx.Flixel#switchState} call,
+   * whichever comes first.
+   *
+   * @param mode The new mode; must not be {@code null}.
+   * @see FlixelAssetMode
+   */
+  void setAssetMode(@NotNull FlixelAssetMode mode);
+
   /** Clears all cached assets, regardless if {@link FlixelAsset#isPersist()} is true or not. */
   void clear();
 
@@ -436,6 +455,20 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
    * @param respectPersist If {@link FlixelAsset#isPersist()} should be taken into consideration or should be ignored.
    */
   void clearTypedAssets(boolean respectPersist);
+
+  /**
+   * Called by {@link FlixelAsset#release()} on the exact transition from reference count 1 to 0.
+   *
+   * <p>In {@link FlixelAssetMode#AGGRESSIVE} mode the default implementation triggers an immediate
+   * eviction - unloading the asset from libGDX and removing the handle from the manager cache. In
+   * all other modes this is a no-op; cleanup happens at state-switch time via {@link #clearNonPersist()}.
+   *
+   * <p>Custom {@link FlixelAssetManager} implementations that do not extend {@link FlixelDefaultAssetManager}
+   * may override this to hook into the release lifecycle.
+   *
+   * @param handle The asset handle whose reference count just reached zero.
+   */
+  default void onAssetReleased(@NotNull FlixelAsset<?> handle) {}
 
   /**
    * @return The underlying libGDX {@link AssetManager} for advanced use (loaders, descriptors, raw APIs).

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
@@ -1,0 +1,95 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.asset;
+
+/**
+ * Controls when the asset manager reclaims memory for non-persistent assets.
+ *
+ * <p>The active mode is read by {@link org.flixelgdx.Flixel#switchState} and by individual asset
+ * handles on every {@link FlixelAsset#release()} call, so changing the mode mid-session takes
+ * effect immediately without any extra steps.
+ *
+ * <p>Set the mode on {@link FlixelAssetManager} via {@link FlixelAssetManager#setAssetMode(FlixelAssetMode)}.
+ *
+ * <h2>Choosing a mode</h2>
+ * <ul>
+ *   <li>{@link #LAZY} - simplest; assets accumulate. Use when memory is not a concern or when you
+ *     preload everything up front and rarely switch states.</li>
+ *   <li>{@link #STANDARD} - safe default; mirrors how most 2D frameworks manage assets. The right
+ *     choice for most games.</li>
+ *   <li>{@link #AGGRESSIVE} - tightest footprint. Use when you have many short-lived states and
+ *     memory pressure is real. Read the {@link #AGGRESSIVE} docs carefully before opting in.</li>
+ * </ul>
+ */
+public enum FlixelAssetMode {
+
+  /**
+   * Assets are never automatically unloaded. Every asset loaded into the manager stays in memory
+   * for the entire session, regardless of state switches or reference counts.
+   *
+   * <p>Equivalent to setting {@code persist = true} globally. {@link FlixelAssetManager#clearNonPersist()}
+   * is skipped entirely on state switches, so no teardown cost is paid at all.
+   *
+   * <p>Best for games that preload everything up front or have very few, long-lived states.
+   */
+  LAZY,
+
+  /**
+   * Non-persistent assets with a zero reference count are unloaded when
+   * {@link org.flixelgdx.Flixel#switchState} runs. This is the default.
+   *
+   * <p>Persistent assets (see {@link FlixelAsset#isPersist()}) and any asset still held by a
+   * live object (reference count greater than zero) are kept across the switch.
+   */
+  STANDARD,
+
+  /**
+   * Non-persistent assets are unloaded immediately the moment their reference count reaches zero,
+   * without waiting for a state switch.
+   *
+   * <p>This uses O(1) work per {@link FlixelAsset#release()} call - there is no periodic scan.
+   * The asset handle that just dropped to zero triggers the unload inline, then the handle is
+   * evicted from the manager cache so subsequent {@code ensureTypedAsset} or {@code ensureWrapper}
+   * calls start fresh.
+   *
+   * <p><b>Important caveats:</b>
+   * <ul>
+   *   <li>{@link FlixelAsset#release()} must be called on the GL/render thread. Calling it from
+   *     a background thread while libGDX may be uploading or disposing GPU resources is not safe
+   *     in AGGRESSIVE mode (it is fine in LAZY and STANDARD since those only unload at state
+   *     switch boundaries, which is always on the GL thread).</li>
+   *   <li>After an aggressive eviction, the underlying libGDX asset is disposed. Any code that
+   *     still holds a raw reference to the same {@link com.badlogic.gdx.graphics.Texture} (or
+   *     other resource) object will encounter a disposed object. The automated sprite pipeline
+   *     ({@code loadGraphic} and {@code destroy}) handles this correctly; direct raw-asset usage
+   *     outside that pipeline must ensure no other references remain before releasing.</li>
+   *   <li>Re-requesting an aggressively evicted asset requires calling
+   *     {@link FlixelAssetManager#load(String)} again and awaiting the async load cycle.</li>
+   * </ul>
+   *
+   * <p>{@link org.flixelgdx.Flixel#switchState} still calls {@link FlixelAssetManager#clearNonPersist()}
+   * as a safety net for assets that were loaded but never retained.
+   */
+  AGGRESSIVE
+}

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -78,6 +78,8 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
   /** Per-instance extension (e.g. {@code .png}) to source factory for {@link #load(String)}. */
   private final ObjectMap<String, Function<String, FlixelSource<?>>> extensionRegistry = new ObjectMap<>();
 
+  private FlixelAssetMode assetMode = FlixelAssetMode.STANDARD;
+
   /** Default {@link FlixelTypedAsset#isPersist()} for handles created after construction; see {@link #getGlobalPersist()}. */
   private boolean globalPersist = false;
 
@@ -438,6 +440,8 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
       return diagnosticsString.toString();
     }
 
+    diagnosticsString.concat("Mode: ").concat(assetMode.name()).concat("\n");
+
     // Output loaded assets in the libGDX AssetManager.
     diagnosticsString.concat("------------------------- LOADED ASSETS -------------------------\n");
     Array<String> assetNames = manager.getAssetNames();
@@ -543,6 +547,40 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     this.globalPersist = globalPersist;
   }
 
+  @NotNull
+  @Override
+  public FlixelAssetMode getAssetMode() {
+    return assetMode;
+  }
+
+  @Override
+  public void setAssetMode(@NotNull FlixelAssetMode mode) {
+    this.assetMode = Objects.requireNonNull(mode, "mode cannot be null.");
+  }
+
+  @Override
+  public void onAssetReleased(@NotNull FlixelAsset<?> handle) {
+    if (assetMode != FlixelAssetMode.AGGRESSIVE) {
+      return;
+    }
+    if (handle.isPersist()) {
+      return;
+    }
+    String key = handle.getAssetKey();
+    if (handle instanceof FlixelPooledWrapper wrapper) {
+      FlixelWrapperFactory<?> factory = wrapperFactories.get(wrapper.wrapperRegistrationClass());
+      if (factory != null) {
+        factory.evict(this, key);
+      }
+      return;
+    }
+    Class<?> type = handle.getType();
+    typedAssetCache.remove(new AssetId(key, type));
+    if (manager != null && manager.isLoaded(key, type)) {
+      manager.unload(key);
+    }
+  }
+
   @Override
   public void clearNonPersist() {
     clearWrapperAssets(true);
@@ -562,6 +600,7 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
       manager = null;
     }
     syntheticWrapperId = 0;
+    assetMode = FlixelAssetMode.STANDARD;
     for (FlixelWrapperFactory<?> f : wrapperFactories.values()) {
       f.clearAll(this);
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelTypedAsset.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelTypedAsset.java
@@ -107,9 +107,13 @@ public class FlixelTypedAsset<T> implements FlixelAsset<T> {
   @NotNull
   @Override
   public FlixelTypedAsset<T> release() {
-    refCount--;
-    if (refCount < 0) {
+    if (refCount <= 0) {
       refCount = 0;
+      return this;
+    }
+    refCount--;
+    if (refCount == 0) {
+      assetManager.onAssetReleased(this);
     }
     return this;
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelWrapperFactory.java
@@ -60,6 +60,21 @@ public interface FlixelWrapperFactory<W> {
   void forEachWrappedAsset(Consumer<W> consumer);
 
   /**
+   * Disposes and evicts a single wrapper by key. For owned wrappers, the dedicated resource is
+   * disposed immediately. For path-keyed wrappers, the asset is unloaded from the underlying
+   * {@link com.badlogic.gdx.assets.AssetManager} if it is currently loaded.
+   *
+   * <p>This is the targeted single-entry counterpart to {@link #clearNonPersist(FlixelAssetManager)}.
+   * It is called by {@link FlixelAssetManager#onAssetReleased(FlixelAsset)} in
+   * {@link FlixelAssetMode#AGGRESSIVE} mode to evict a wrapper the moment its reference count
+   * reaches zero, without scanning the whole cache.
+   *
+   * @param assets The manager that owns this factory.
+   * @param key The asset key of the wrapper to evict.
+   */
+  void evict(@NotNull FlixelAssetManager assets, @NotNull String key);
+
+  /**
    * Disposes and evicts all wrapper objects. Path-keyed assets should be unloaded from the
    * underlying {@link com.badlogic.gdx.assets.AssetManager} when applicable.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelAudioManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelAudioManager.java
@@ -23,9 +23,11 @@
  */
 package org.flixelgdx.audio;
 
+import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.asset.FlixelAsset;
 import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.jetbrains.annotations.NotNull;
@@ -47,6 +49,7 @@ import org.jetbrains.annotations.Nullable;
 public class FlixelAudioManager implements FlixelDestroyable, Disposable {
 
   private final FlixelSoundBackend.Factory factory;
+  private final Array<FlixelSound> activeSounds = new Array<>(false, 8);
   private Object sfxGroup;
   private Object musicGroup;
 
@@ -78,6 +81,13 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
       music.dispose();
       music = null;
     }
+    for (int i = 0; i < activeSounds.size; i++) {
+      FlixelSound s = activeSounds.get(i);
+      if (s.isExists()) {
+        s.destroy();
+      }
+    }
+    activeSounds.clear();
     if (sfxGroup != null) {
       factory.disposeGroup(sfxGroup);
     }
@@ -87,6 +97,34 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
     sfxGroup = factory.createGroup();
     musicGroup = factory.createGroup();
     factory.setMasterVolume(masterVolume);
+  }
+
+  /**
+   * Destroys all non-persistent {@link FlixelSound} instances tracked by this manager, including
+   * the current music track if it is not persistent.
+   *
+   * <p>Called automatically by {@link org.flixelgdx.Flixel#switchState} on every state switch
+   * when the asset mode is {@link org.flixelgdx.asset.FlixelAssetMode#STANDARD} or
+   * {@link org.flixelgdx.asset.FlixelAssetMode#AGGRESSIVE}. Sounds whose {@link FlixelSound#isPersist()}
+   * flag is set survive the switch unchanged.
+   *
+   * <p>Sounds that were already destroyed (for example, via {@link FlixelSound#setAutoDestroy}) are
+   * pruned from the tracking list without being double-destroyed.
+   */
+  public void clearNonPersist() {
+    for (int i = activeSounds.size - 1; i >= 0; i--) {
+      FlixelSound s = activeSounds.get(i);
+      if (!s.isExists()) {
+        activeSounds.removeIndex(i);
+      } else if (!s.isPersist()) {
+        s.destroy();
+        activeSounds.removeIndex(i);
+      }
+    }
+    if (music != null && !music.isPersist()) {
+      music.destroy();
+      music = null;
+    }
   }
 
   /**
@@ -311,6 +349,7 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
       s.setVolume(volume);
       s.setLooped(looping);
       s.play();
+      activeSounds.add(s);
       return s;
     }
     FlixelAssetManager assets = Flixel.ensureAssets();
@@ -318,11 +357,14 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
       assets.load(path, FlixelSoundSource.class);
       assets.finishLoadingAsset(path);
     }
+    FlixelAsset<FlixelSoundSource> sourceHandle = assets.obtainTypedAsset(path, FlixelSoundSource.class);
     FlixelSoundSource source = assets.get(path, FlixelSoundSource.class);
     FlixelSound flixelSound = source.create(targetGroup);
+    flixelSound.setSourceAsset(sourceHandle);
     flixelSound.setVolume(volume);
     flixelSound.setLooped(looping);
     flixelSound.play();
+    activeSounds.add(flixelSound);
     return flixelSound;
   }
 
@@ -351,6 +393,13 @@ public class FlixelAudioManager implements FlixelDestroyable, Disposable {
       music.dispose();
       music = null;
     }
+    for (int i = 0; i < activeSounds.size; i++) {
+      FlixelSound s = activeSounds.get(i);
+      if (s.isExists()) {
+        s.destroy();
+      }
+    }
+    activeSounds.clear();
     factory.disposeGroup(sfxGroup);
     factory.disposeGroup(musicGroup);
     factory.disposeEngine();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
@@ -67,6 +67,9 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
   @Nullable
   private FlixelAudioManager manager;
 
+  @Nullable
+  private FlixelAsset<FlixelSoundSource> sourceAsset;
+
   private int refCount;
 
   /** Cached pitch (some backends have no getPitch). */
@@ -156,6 +159,21 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
     return this;
   }
 
+  /**
+   * Attaches the backing {@link FlixelAsset} handle for the {@link FlixelSoundSource} that was
+   * retained when this sound was created through {@link FlixelAudioManager}. The handle is
+   * released in {@link #destroy()} so the source asset is eligible for cleanup according to the
+   * active {@link org.flixelgdx.asset.FlixelAssetMode}.
+   *
+   * @param sourceAsset The retained source handle, or {@code null} to clear it.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  public FlixelSound setSourceAsset(@Nullable FlixelAsset<FlixelSoundSource> sourceAsset) {
+    this.sourceAsset = sourceAsset;
+    return this;
+  }
+
   @NotNull
   @Override
   public String getAssetKey() {
@@ -183,10 +201,11 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
   @NotNull
   @Override
   public FlixelSound release() {
-    refCount--;
-    if (refCount < 0) {
+    if (refCount <= 0) {
       refCount = 0;
+      return this;
     }
+    refCount--;
     return this;
   }
 
@@ -684,6 +703,10 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
   @Override
   public void destroy() {
     release();
+    if (sourceAsset != null) {
+      sourceAsset.release();
+      sourceAsset = null;
+    }
     super.destroy();
     clearAudioEffectChain();
     cancelFadeTween();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -358,10 +358,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   private int sampleRenderCallsNow() {
     int total = 0;
     if (Flixel.game != null) {
-      SpriteBatch frameworkBatch = Flixel.game.getBatch();
-      if (frameworkBatch != null) {
-        total += frameworkBatch.renderCalls;
-      }
+      total += Flixel.game.getFrameRenderCalls();
     }
     FlixelDebugManager mgr = Flixel.debug;
     if (mgr != null) {
@@ -808,10 +805,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   private void snapshotRenderCalls() {
     int total = 0;
     if (Flixel.game != null) {
-      SpriteBatch frameworkBatch = Flixel.game.getBatch();
-      if (frameworkBatch != null) {
-        total += frameworkBatch.renderCalls;
-      }
+      total += Flixel.game.getFrameRenderCalls();
     }
     FlixelDebugManager mgr = Flixel.debug;
     if (mgr != null) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphicWrapperFactory.java
@@ -108,6 +108,26 @@ public final class FlixelGraphicWrapperFactory implements FlixelWrapperFactory<F
   }
 
   @Override
+  public void evict(@NotNull FlixelAssetManager assets, @NotNull String key) {
+    FlixelGraphic g = cache.get(key);
+    if (g == null) {
+      return;
+    }
+    if (g.isOwned()) {
+      Texture t = g.getOwnedTexture();
+      if (t != null) {
+        t.dispose();
+      }
+    } else {
+      AssetManager am = assets.getManager();
+      if (am != null && am.isLoaded(key, Texture.class)) {
+        am.unload(key);
+      }
+    }
+    cache.remove(key);
+  }
+
+  @Override
   public void forEachWrappedAsset(Consumer<FlixelGraphic> consumer) {
     for (FlixelGraphic graphic : cache.values()) {
       consumer.accept(graphic);


### PR DESCRIPTION
## Description

This PR covers three areas of work that came out of investigating asset lifecycle issues and a debug counter bug.

**Asset management lifecycle modes (`FlixelAssetMode`):**
Added a new `FlixelAssetMode` enum with three policies - `LAZY` (never auto-unload), `STANDARD` (clear non-persistent assets on state switch, the previous default behavior), and `AGGRESSIVE` (immediately unload assets the moment their ref count hits zero, inline in `release()`). The mode is set on `FlixelAssetManager` and branches in `Flixel.switchState()` so LAZY skips all cleanup entirely. AGGRESSIVE eviction is O(1) - no game loop scan - and dispatches through `onAssetReleased()` into wrapper factories (`FlixelGraphicWrapperFactory.evict()`) for pooled wrappers, or directly into `typedAssetCache` + libGDX `AssetManager.unload()` for plain typed assets.

**Sound lifecycle fixes:**
Fixed two related bugs where sounds stayed in memory across state switches:
- `FlixelAudioManager.createAndPlaySoundFromPath()` was calling `assets.load()` and `assets.get()` directly, bypassing `typedAssetCache` entirely, making the source invisible to `clearNonPersist()`. Fixed by switching to `obtainTypedAsset()` (retained) and storing the handle on `FlixelSound` via `setSourceAsset()`, released in `destroy()`.
- `FlixelAudioManager` never tracked created `FlixelSound` instances, so `clearNonPersist()` on the asset manager could not reach them. Added an `activeSounds` tracking array and a `clearNonPersist()` method that destroys non-persistent live sounds and prunes already-destroyed ones (e.g. from `autoDestroy`). Called from `Flixel.switchState()` before `assets.clearNonPersist()` so source handle ref counts hit zero before the asset manager's sweep runs.
- `FlixelTypedAsset.release()` and `FlixelSound.release()` both had a double-fire bug where repeated calls below zero could trigger `onAssetReleased()` more than once. Fixed with a `refCount <= 0` guard.

**Render call counter fix:**
`SpriteBatch.renderCalls` resets to 0 on every `begin()`, so with multiple cameras the debug overlay was only ever showing the last camera's count - silently discarding all previous cameras' data. Fixed by tracking `batch.totalRenderCalls` delta across the full camera loop in `FlixelGame` (exposed via `getFrameRenderCalls()`), which both `snapshotRenderCalls()` and `sampleRenderCallsNow()` in `FlixelDebugOverlay` now read instead.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).