### PR TITLE
Fixed animation state machine not transitioning on web due to a float precision bug

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -545,7 +545,8 @@ public class FlixelAnimationController implements FlixelUpdatable {
     if (anim == null) {
       return true;
     }
-    return anim.isAnimationFinished(stateTime);
+    float duration = anim.getAnimationDuration();
+    return !looping && duration > 0f && stateTime >= duration;
   }
 
   @Override
@@ -591,7 +592,7 @@ public class FlixelAnimationController implements FlixelUpdatable {
       onFrameChanged.dispatch(currentFrameSignalData);
     }
 
-    boolean finished = anim.isAnimationFinished(stateTime);
+    boolean finished = !looping && duration > 0f && stateTime >= duration;
     if (finished && !lastFinished) {
       FlixelAnimationFrameSignalData data = new FlixelAnimationFrameSignalData(currentAnim, frameIndex, frame);
       onAnimationFinished.dispatch(data);


### PR DESCRIPTION
## Description

Fixes a platform-specific bug where `FlixelAnimationStateMachine` auto-advance transitions never fired on TeaVM/web for certain clip lengths.

**Root cause:** `anim.isAnimationFinished(stateTime)` in libGDX uses `(int)(stateTime / frameDuration) >= keyFrames.length`. When `stateTime` is clamped to exactly `getAnimationDuration() = frameDuration * N`, floating-point division can yield `N - epsilon`, which truncates to `N - 1` — permanently returning `false`. This is most pronounced on TeaVM/web where Java `float` operations are compiled to 64-bit JS doubles: `7 frames at 24 fps` → `(int)(6.999...) = 6`, so `6 >= 7` is always `false`.

In practice this broke the Right, Up, and Down note-hit animations in an FNF-style test (all happen to be 7-frame clips at 24 fps), leaving them stuck on their last frame instead of transitioning back to Idle. Desktop JVM was unaffected because 80-bit extended precision rounded the same expression to exactly `7.0`.

**Fix:** Replace `anim.isAnimationFinished(stateTime)` in both `update()` (the dispatch gate) and the public `isAnimationFinished()` accessor with a direct `!looping && duration > 0f && stateTime >= duration` comparison. This is a simple float `>=` which is immune to the integer-division truncation trap on all platforms.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - requires a running web build with animations loaded in a test project to verify.