### PR TITLE
Fixed audio effect chain (reverb, echo, low-pass) never actually applying to output

### DIFF
--- a/flixelgdx-common/src/main/java/org/flixelgdx/backend/common/audio/FlixelMiniAudioSoundHandler.java
+++ b/flixelgdx-common/src/main/java/org/flixelgdx/backend/common/audio/FlixelMiniAudioSoundHandler.java
@@ -106,6 +106,13 @@ public class FlixelMiniAudioSoundHandler implements FlixelSoundBackend.Factory {
   }
 
   @Override
+  public void attachEffectToEngineOutput(FlixelSoundBackend.EffectNode node, int outputBusIndex) {
+    if (node instanceof MiniAudioEffectNode n) {
+      engine.attachToEngineOutput(n.node(), outputBusIndex);
+    }
+  }
+
+  @Override
   public FlixelSoundBackend.EffectNode createReverbNode(float wet) {
     MAReverbNode rev = new MAReverbNode(engine);
     float w = Math.max(0f, Math.min(1f, wet));
@@ -133,13 +140,16 @@ public class FlixelMiniAudioSoundHandler implements FlixelSoundBackend.Factory {
 
     @Override
     public void attachToUpstream(FlixelSoundBackend upstream, int bus) {
-      MANode upstreamNode;
       if (upstream instanceof FlixelMiniAudioSound mas) {
-        upstreamNode = mas.getMASound();
-      } else {
-        return;
+        node.attachToThisNode(mas.getMASound(), bus);
       }
-      node.attachToThisNode(upstreamNode, bus);
+    }
+
+    @Override
+    public void attachToUpstreamNode(FlixelSoundBackend.EffectNode upstream, int bus) {
+      if (upstream instanceof MiniAudioEffectNode upstreamNode) {
+        node.attachToThisNode(upstreamNode.node(), bus);
+      }
     }
 
     @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
@@ -688,15 +688,14 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
 
   private void attachEffectNode(@NotNull FlixelSoundBackend.EffectNode node) {
     FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
-    FlixelSoundBackend upstream = audioEffectNodes.size == 0
-        ? sound
-        : null;
-    if (upstream != null) {
-      node.attachToUpstream(upstream, 0);
+    if (audioEffectNodes.size == 0) {
+      node.attachToUpstream(sound, 0);
+    } else {
+      node.attachToUpstreamNode(audioEffectNodes.peek(), 0);
     }
     audioEffectNodes.add(node);
     if (factory != null) {
-      factory.attachToEngineOutput(sound, 0);
+      factory.attachEffectToEngineOutput(node, 0);
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundBackend.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundBackend.java
@@ -225,13 +225,25 @@ public interface FlixelSoundBackend {
     }
 
     /**
-     * Attaches a sound (or effect node output) to the engine endpoint.
+     * Attaches a sound directly to the engine endpoint, bypassing any effect
+     * chain. Used to restore direct routing after clearing effects.
      * Implementations that do not support an audio graph should no-op.
      *
      * @param sound The sound backend whose output to route.
      * @param outputBusIndex Output bus index (typically 0).
      */
     void attachToEngineOutput(FlixelSoundBackend sound, int outputBusIndex);
+
+    /**
+     * Attaches the tail effect node in a chain to the engine endpoint so that
+     * processed audio reaches the output. Must be called each time a new node
+     * is appended to the chain.
+     * Implementations that do not support an audio graph should no-op.
+     *
+     * @param node The tail effect node whose output to route.
+     * @param outputBusIndex Output bus index (typically 0).
+     */
+    void attachEffectToEngineOutput(EffectNode node, int outputBusIndex);
 
     /**
      * Creates a reverb effect node.
@@ -269,12 +281,21 @@ public interface FlixelSoundBackend {
   interface EffectNode {
 
     /**
-     * Wires an upstream source into this node.
+     * Wires a sound source into this node's input.
      *
-     * @param upstream The upstream sound or node output.
+     * @param upstream The upstream sound backend.
      * @param bus Input bus index (typically 0).
      */
     void attachToUpstream(FlixelSoundBackend upstream, int bus);
+
+    /**
+     * Wires another effect node into this node's input, allowing effects to be
+     * chained together (e.g. reverb feeding into a low-pass filter).
+     *
+     * @param upstream The upstream effect node.
+     * @param bus Input bus index (typically 0).
+     */
+    void attachToUpstreamNode(EffectNode upstream, int bus);
 
     /**
      * Detaches this node from its input bus.

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/audio/FlixelTeaVMSoundHandler.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/audio/FlixelTeaVMSoundHandler.java
@@ -189,6 +189,11 @@ public class FlixelTeaVMSoundHandler implements FlixelSoundBackend.Factory {
   }
 
   @Override
+  public void attachEffectToEngineOutput(FlixelSoundBackend.EffectNode node, int outputBusIndex) {
+    // No-op on web.
+  }
+
+  @Override
   public FlixelSoundBackend.EffectNode createReverbNode(float wet) {
     return NoOpEffectNode.INSTANCE;
   }
@@ -242,6 +247,11 @@ public class FlixelTeaVMSoundHandler implements FlixelSoundBackend.Factory {
 
     @Override
     public void attachToUpstream(FlixelSoundBackend upstream, int bus) {
+      // No-op.
+    }
+
+    @Override
+    public void attachToUpstreamNode(FlixelSoundBackend.EffectNode upstream, int bus) {
       // No-op.
     }
 

--- a/gradle/spotless/eclipse-formatter.xml
+++ b/gradle/spotless/eclipse-formatter.xml
@@ -332,6 +332,7 @@
   <setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_method_body_on_one_line" value="one_line_if_empty"/>
+  <setting id="org.eclipse.jdt.core.formatter.keep_record_constructor_on_one_line" value="one_line_if_empty"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_simple_class_on_one_line" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_simple_getter_setter_on_one_line" value="false"/>
   <setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>


### PR DESCRIPTION
## Description

Fixes two bugs in `FlixelSound.attachEffectNode` that caused all audio effects (reverb, echo, low-pass) to be silently ignored.

**Bug 1 - Output always bypassed effects:** `factory.attachToEngineOutput(sound, 0)` was always called with the raw sound backend, wiring it directly to the engine endpoint on every `addReverb`/`addEcho`/`addLowPassMuffle` call. This meant processed audio was never routed to the output - the dry unaffected sound played instead.

**Bug 2 - Multi-effect chains were never wired:** When adding a second (or later) effect, `upstream` was set to `null` and `attachToUpstream` was never called, leaving each subsequent node disconnected from the chain.

To support the correct routing, two new methods were added to the `EffectNode` and `Factory` interfaces:

- `EffectNode.attachToUpstreamNode(EffectNode, int)` - lets a node receive input from another node rather than only from a raw sound source, enabling actual chaining
- `Factory.attachEffectToEngineOutput(EffectNode, int)` - routes the tail effect node's output to the engine endpoint

Both are implemented in `FlixelMiniAudioSoundHandler` and stubbed as no-ops in `FlixelTeaVMSoundHandler`/`NoOpEffectNode` (the web platform does not support an audio graph).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - audio graph wiring is not visually observable; the fix is verified by code inspection and build passing.