### PR TITLE
Reworked camera access into a Flixel.cameras field for cleaner Kotlin and Java usage

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -217,21 +217,43 @@ public final class Flixel {
    * controls such as fullscreen toggling and framerate caps.
    *
    * <p>Most game code never needs to touch {@code Flixel.game} directly. Prefer the specialized
-   * fields ({@link #sound}, {@link #assets}, {@link #keys}, etc.) for day-to-day work. Reach for
-   * this field only when the high-level APIs do not cover what you need, such as setting a custom
-   * background color or querying the raw camera array.
+   * fields ({@link #sound}, {@link #assets}, {@link #keys}, {@link #cameras}, etc.) for day-to-day
+   * work. Reach for this field only when the high-level APIs do not cover what you need, such as
+   * setting a custom background color or toggling fullscreen.
    *
    * <p>Example:
    * <pre>{@code
    * // Change the game's background color.
    * Flixel.game.bgColor.set(Color.CORNFLOWER_BLUE);
-   *
-   * // Query the active camera list.
-   * Array<FlixelCamera> cameras = Flixel.game.getCameras();
    * }</pre>
    */
   @NotNull
   public static FlixelGame game;
+
+  /**
+   * The global list of active {@link FlixelCamera cameras}, ordered back-to-front.
+   *
+   * <p>The first entry, {@code Flixel.cameras.first()}, is the main camera that the framework follows
+   * and renders to by default. Add more cameras for split-screen, picture-in-picture, or separate UI
+   * layers.
+   *
+   * <p>This reference is {@code final} and never {@code null}: the framework creates a default camera
+   * at startup and refreshes the list (in place) on a state switch, so it is safe to read from your
+   * state's {@code create()} onward. Mutate it through the list's own methods (for example
+   * {@link Array#add}); the array itself is never replaced.
+   *
+   * <p>Example:
+   * <pre>{@code
+   * // The main camera.
+   * FlixelCamera main = Flixel.cameras.first();
+   * main.follow(player);
+   *
+   * // A second camera for a UI overlay.
+   * Flixel.cameras.add(new FlixelCamera(Gdx.graphics.getWidth(), Gdx.graphics.getHeight()));
+   * }</pre>
+   */
+  @NotNull
+  public static final Array<FlixelCamera> cameras = new Array<>(FlixelCamera[]::new);
 
   /**
    * The platform-specific alert dialog provider.
@@ -1131,18 +1153,6 @@ public final class Flixel {
 
   public static FlixelState getState() {
     return state;
-  }
-
-  /** @see FlixelGame#getCamera() */
-  public static FlixelCamera getCamera() {
-    Objects.requireNonNull(game, "Cannot get the camera when the game object is not initialized!");
-    return game.getCamera();
-  }
-
-  /** @see FlixelGame#getCameras() */
-  public static Array<FlixelCamera> getCameras() {
-    Objects.requireNonNull(game, "Cannot get the cameras when the game object is not initialized!");
-    return game.getCameras();
   }
 
   public static int getViewWidth() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -129,8 +129,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   /** 1x1 white texture used to draw solid fills (camera bg, FX); tinted via {@link FlixelSpriteBatch#setColor(Color)}. */
   protected Texture bgTexture;
 
-  /** Where all the global cameras are stored. */
-  protected Array<FlixelCamera> cameras;
+  /** Convenience reference to the global {@link Flixel#cameras} list (the single source of truth). */
+  protected final Array<FlixelCamera> cameras = Flixel.cameras;
 
   /**
    * Total render calls issued by the framework {@link FlixelBatch} during the most recently
@@ -333,7 +333,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     stateLifecyclePauseDispatched = false;
 
     batch = new FlixelSpriteBatch();
-    cameras = new Array<>(FlixelCamera[]::new);
+    cameras.clear();
     cameras.add(new FlixelCamera((int) viewSize.x, (int) viewSize.y));
 
     Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
@@ -609,7 +609,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   }
 
   private void snapshotCamerasForDebugPause() {
-    if (cameras == null || cameras.size == 0) {
+    if (cameras.size == 0) {
       debugPauseCameraScroll = null;
       debugPauseCameraZoom = null;
       return;
@@ -626,7 +626,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   }
 
   private void restoreCamerasAfterDebugPause() {
-    if (debugPauseCameraScroll == null || debugPauseCameraZoom == null || cameras == null) {
+    if (debugPauseCameraScroll == null || debugPauseCameraZoom == null) {
       debugPauseCameraScroll = null;
       debugPauseCameraZoom = null;
       return;
@@ -836,7 +836,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     for (FlixelCamera camera : cameras) {
       camera.destroy();
     }
-    cameras = null;
+    cameras.clear();
     debugPauseCameraScroll = null;
     debugPauseCameraZoom = null;
     gamePaused = false;
@@ -880,16 +880,13 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   }
 
   /**
-   * Gets the first camera that is part of the list. If the list is {@code null} or empty, then a new list (with a
-   * default camera accordingly) is created.
+   * Gets the first camera in {@link Flixel#cameras}. If the list is empty, a default camera is created and added
+   * first so this never returns {@code null}.
    *
    * @return The first camera in the list.
    */
   public FlixelCamera getCamera() {
     Vector2 windowSize = viewSize;
-    if (cameras == null) {
-      cameras = new Array<>(FlixelCamera[]::new);
-    }
     if (cameras.isEmpty()) {
       cameras.add(new FlixelCamera((int) windowSize.x, (int) windowSize.y));
       cameras.first().apply();
@@ -903,7 +900,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   public void resetCameras() {
     FlixelCamera camera = new FlixelCamera((int) viewSize.x, (int) viewSize.y);
     camera.update((int) windowSize.x, (int) windowSize.y, camera.centerCameraOnResize);
-    cameras = new Array<>(FlixelCamera[]::new);
+    cameras.clear();
     cameras.add(camera);
     if (desktopTransparencyActive) {
       applyDesktopTransparencyBackdropOnly();
@@ -1022,9 +1019,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    */
   private void applyDesktopTransparencyBackdropOnly() {
     bgColor.a = 0f;
-    if (cameras == null) {
-      return;
-    }
     FlixelCamera[] camItems = cameras.items;
     for (int i = 0, n = cameras.size; i < n; i++) {
       FlixelCamera cam = camItems[i];
@@ -1045,7 +1039,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     g[1] = bgColor.g;
     g[2] = bgColor.b;
     g[3] = bgColor.a;
-    int n = cameras == null ? 0 : cameras.size;
+    int n = cameras.size;
     ensureDesktopTransparencyCameraSnapshotCapacity(n);
     FlixelCamera[] camItems = n == 0 ? null : cameras.items;
     float[] p = desktopTransparencyRestoreCamerasPacked;
@@ -1088,9 +1082,6 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       bgColor.a = g[3];
     } else {
       bgColor.set(Color.BLACK);
-    }
-    if (cameras == null) {
-      return;
     }
     FlixelCamera[] camItems = cameras.items;
     int n = cameras.size;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -424,7 +424,7 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     if (!isOnDrawCamera()) {
       return;
     }
-    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.getCamera();
+    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.cameras.first();
     float wx = cam.worldToViewX(getX(), scrollX);
     float wy = cam.worldToViewY(getY(), scrollY);
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -398,7 +398,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
     }
 
     // World position with scroll factor (matches FlixelSprite.draw() / FlixelObject.getDrawX()).
-    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.getCamera();
+    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.cameras.first();
     float wx = cam.worldToViewX(getX(), scrollX);
     float wy = cam.worldToViewY(getY(), scrollY);
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -245,7 +245,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
 
   /** Returns the camera currently selected by Alt+arrow cycling, clamped to a valid index. */
   public final int getInspectCameraIndex() {
-    Array<FlixelCamera> cams = Flixel.getCameras();
+    Array<FlixelCamera> cams = Flixel.cameras;
     int n = (cams != null) ? cams.size : 0;
     if (n == 0) {
       return -1;
@@ -509,7 +509,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (Flixel.mouse == null) {
       return;
     }
-    Array<FlixelCamera> cams = Flixel.getCameras();
+    Array<FlixelCamera> cams = Flixel.cameras;
     if (cams == null || cams.size == 0) {
       return;
     }
@@ -584,7 +584,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
       return;
     }
 
-    Array<FlixelCamera> cams = Flixel.getCameras();
+    Array<FlixelCamera> cams = Flixel.cameras;
     if (cams == null || cams.size == 0) {
       return;
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
@@ -196,7 +196,7 @@ public class FlixelMouseManager implements FlixelInputProcessorManager {
   @Nullable
   private static FlixelCamera safeGetDefaultCamera() {
     try {
-      return Flixel.getCamera();
+      return Flixel.cameras.first();
     } catch (Exception e) {
       return null;
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -864,7 +864,7 @@ public class FlixelText extends FlixelSprite {
       return;
     }
 
-    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.getCamera();
+    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.cameras.first();
     float wx = cam.worldToViewX(getX(), getScrollX());
     float wy = cam.worldToViewY(getY(), getScrollY());
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/ui/FlixelBar.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/ui/FlixelBar.java
@@ -661,7 +661,7 @@ public class FlixelBar extends FlixelSprite {
     }
     ensureWhitePixel();
 
-    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.getCamera();
+    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.cameras.first();
     float px = getX();
     float py = getY();
     if (screenSpace) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelSpriteUtil.java
@@ -349,7 +349,7 @@ public final class FlixelSpriteUtil {
       boolean top,
       boolean bottom) {
     Objects.requireNonNull(sprite, "The sprite provided cannot be null!");
-    FlixelCamera cam = camera != null ? camera : Flixel.getCamera();
+    FlixelCamera cam = camera != null ? camera : Flixel.cameras.first();
     float minX = cam.getViewLeft();
     float minY = cam.getViewTop();
     float maxX = cam.getViewRight();
@@ -390,7 +390,7 @@ public final class FlixelSpriteUtil {
       boolean top,
       boolean bottom) {
     Objects.requireNonNull(sprite, "The sprite provided cannot be null!");
-    FlixelCamera cam = camera != null ? camera : Flixel.getCamera();
+    FlixelCamera cam = camera != null ? camera : Flixel.cameras.first();
     float minX = cam.getViewLeft();
     float minY = cam.getViewTop();
     float maxX = cam.getViewRight();

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -925,7 +925,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
       text(COLOR_OK, "RUNNING");
     }
 
-    Array<FlixelCamera> cams = Flixel.getCameras();
+    Array<FlixelCamera> cams = Flixel.cameras;
     int camCount = cams != null ? cams.size : 0;
     int inspect = getInspectCameraIndex();
     text(COLOR_KEY, "Cameras");
@@ -1071,7 +1071,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
 
     ImGui.separator();
     if (ImGui.button("Reset zoom on inspected camera")) {
-      Array<FlixelCamera> cams = Flixel.getCameras();
+      Array<FlixelCamera> cams = Flixel.cameras;
       if (cams != null && cams.size > 0) {
         FlixelCamera cam = cams.get(getInspectCameraIndex());
         cam.setZoom(1f);


### PR DESCRIPTION
## Description

Kotlin only synthesizes a property from a Java **instance** getter, never from a `static` method. Because
`Flixel.getCamera()` and `Flixel.getCameras()` were static, Kotlin (and Java) always had to call them as methods,
which read awkwardly next to the rest of the `Flixel` facade (`Flixel.sound`, `Flixel.keys`, etc. are fields).

This exposes the active cameras as a public static **field** instead:

```java
public static final Array<FlixelCamera> cameras = new Array<>(FlixelCamera[]::new);
```

so both languages can write `Flixel.cameras` and `Flixel.cameras.first()` (the main camera).

**What changed**

- Added `Flixel.cameras` as the single source of truth for the active camera list. It is `final` and never `null`:
  a default camera is created at startup and the list is refreshed **in place** on a state switch, so the array
  identity is stable.
- Removed `Flixel.getCamera()` and `Flixel.getCameras()`.
- `FlixelGame` now keeps a `final` reference to `Flixel.cameras` and mutates it in place (`clear()` / `add(...)`)
  instead of reassigning a new array. Its instance `getCamera()` / `getCameras()` helpers are kept for the engine's
  internal lifecycle (e.g. the lazy default-camera guarantee).
- Updated all internal call sites: `Flixel.getCamera()` → `Flixel.cameras.first()`, `Flixel.getCameras()` →
  `Flixel.cameras`.

**Breaking change:** code calling `Flixel.getCamera()` / `Flixel.getCameras()` must switch to `Flixel.cameras.first()`
/ `Flixel.cameras`. The website docs and project templates are being updated alongside this.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

> No new tests were added: this is a behavior-preserving refactor of how the existing camera list is stored and
> accessed. The current `:flixelgdx-test:test` suite passes, and `./gradlew classes` + `spotlessCheck` are clean.

## Screenshots / Evidence (if applicable)

`./gradlew classes`, `./gradlew :flixelgdx-test:test`, and `./gradlew spotlessCheck` all pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
