### PR TITLE
Fixed FlixelText hitbox not syncing with field size and text attributes

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -350,7 +350,9 @@ public class FlixelText extends FlixelSprite {
   }
 
   /**
-   * Sets the width of the text field. Enables auto-sizing if {@code <= 0}.
+   * Sets the width of the text field. A positive value disables auto-sizing so
+   * the hitbox and layout use this fixed width; a value {@code <= 0} re-enables
+   * auto-sizing so dimensions are derived from the text content.
    *
    * @param fieldWidth The field width in pixels.
    * @return This instance for chaining.
@@ -359,9 +361,7 @@ public class FlixelText extends FlixelSprite {
     float newWidth = Math.max(0, fieldWidth);
     if (this.fieldWidth != newWidth) {
       this.fieldWidth = newWidth;
-      if (newWidth <= 0) {
-        autoSize = true;
-      }
+      autoSize = newWidth <= 0;
       layoutDirty = true;
     }
     return this;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -829,6 +829,38 @@ public class FlixelText extends FlixelSprite {
   }
 
   /**
+   * Returns the hitbox width, triggering a layout rebuild first if any text
+   * attributes have changed since the last rebuild.
+   *
+   * <p>This ensures that callers such as {@link #screenCenter()} always operate
+   * on up-to-date dimensions, even before the first {@link #draw(Batch)} call.
+   *
+   * <p>If no font is available yet (for example, before a GL context exists),
+   * the returned value is {@code 0} until the first successful rebuild.
+   */
+  @Override
+  public float getWidth() {
+    rebuildIfDirty();
+    return super.getWidth();
+  }
+
+  /**
+   * Returns the hitbox height, triggering a layout rebuild first if any text
+   * attributes have changed since the last rebuild.
+   *
+   * <p>This ensures that callers such as {@link #screenCenter()} always operate
+   * on up-to-date dimensions, even before the first {@link #draw(Batch)} call.
+   *
+   * <p>If no font is available yet (for example, before a GL context exists),
+   * the returned value is {@code 0} until the first successful rebuild.
+   */
+  @Override
+  public float getHeight() {
+    rebuildIfDirty();
+    return super.getHeight();
+  }
+
+  /**
    * Returns the actual rendered width of the text content (which may differ from
    * {@link #getFieldWidth()} when a fixed field width is set). Triggers a layout
    * rebuild if necessary.
@@ -1011,8 +1043,8 @@ public class FlixelText extends FlixelSprite {
       layoutDirty = true;
     }
     if (layoutDirty) {
-      rebuildLayout();
       layoutDirty = false;
+      rebuildLayout();
     }
   }
 


### PR DESCRIPTION
## Description

Fixes two related bugs in `FlixelText` where the hitbox dimensions were out of sync with the actual text field.

**Bug 1: `setFieldWidth()` did not disable `autoSize`**

When `setFieldWidth(n)` was called directly (rather than through the constructor), `autoSize` was never set to `false`. This meant `rebuildLayout()` computed the hitbox width from `glyphLayout.width` (raw text content width) instead of the explicit `fieldWidth`, so the hitbox did not match the visible field. The full constructor worked around this by calling `setAutoSize(fieldWidth <= 0)` explicitly right after `setFieldWidth()`, which is why `FlixelText(x, y, fieldWidth)` appeared to work but post-construction `setFieldWidth()` calls did not.

Fix: Changed `if (newWidth <= 0) { autoSize = true; }` to `autoSize = newWidth <= 0` in `setFieldWidth()` so the flag always stays in sync.

**Bug 2: Hitbox was always 0x0 until the first `draw()` call**

`rebuildLayout()` was only ever called from inside `draw()`. This meant that calls to `getWidth()`/`getHeight()` — including `screenCenter()`, collision checks, or any size query — returned `0` before the first rendered frame. For example:

```java
FlixelText label = new FlixelText(220, 200);
label.setText("PAUSED");
label.setTextSize(48);
label.screenCenter(); // centers on 0x0 — wrong!
```

Fix: Overrode `getWidth()` and `getHeight()` in `FlixelText` to call `rebuildIfDirty()` before delegating to the superclass. Dimensions are now always current when queried.

Also moved the `layoutDirty = false` clear to **before** the `rebuildLayout()` call (not after) to prevent infinite recursion. Without this, `rebuildLayout()` → `setOriginCenter()` → `getWidth()` → `rebuildIfDirty()` would re-enter `rebuildLayout()` since `layoutDirty` was still `true` at that point.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - these are logic/correctness fixes with no visual output to screenshot.