### PR TITLE
Fixed FlixelText objects not rendering on the TeaVM web backend

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRegistry.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelFontRegistry.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.text;
 
+import com.badlogic.gdx.Application;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Texture;
@@ -37,6 +38,7 @@ import org.flixelgdx.functional.FlixelDestroyable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -308,9 +310,12 @@ public final class FlixelFontRegistry {
       FileHandle fnt = useInternal
           ? Gdx.files.internal(DEFAULT_BITMAP_FNT)
           : Gdx.files.classpath(DEFAULT_BITMAP_FNT);
-      if (fnt == null || !fnt.exists()) {
+      if (fnt == null) {
         return null;
       }
+      // Skip the exists() check intentionally: on TeaVM web the in-memory VFS may report a file as
+      // absent even though it was successfully preloaded, depending on how the backend normalizes
+      // paths. Attempting the load and catching any exception is the safest cross-platform approach.
       return new BitmapFont(fnt);
     } catch (Throwable ignored) {
       return null;
@@ -342,7 +347,8 @@ public final class FlixelFontRegistry {
     FreeTypeFontParameter param = new FreeTypeFontParameter();
     param.size = size;
     param.spaceX = letterSpacing;
-    param.genMipMaps = true;
+    // WebGL 1.0 rejects glGenerateMipmap on non-power-of-two textures, so skip on that backend.
+    param.genMipMaps = Gdx.app.getType() != Application.ApplicationType.WebGL;
     param.minFilter = Texture.TextureFilter.Linear;
     param.magFilter = Texture.TextureFilter.Linear;
     BitmapFont font = generator.generateFont(param);
@@ -370,6 +376,28 @@ public final class FlixelFontRegistry {
     }
     entries.clear();
     defaultFontId = null;
+  }
+
+  /**
+   * Creates a {@link FreeTypeFontGenerator} for the given font file, applying a WebGL-safe
+   * workaround on that backend.
+   *
+   * <p>On WebGL, {@code gdx-freetype-teavm} uses {@link com.badlogic.gdx.utils.StreamUtils#copyStream}
+   * to fill the font's {@link java.nio.ByteBuffer}, which advances the buffer's position to its
+   * limit. The subsequent call into the Emscripten FreeType module then receives
+   * {@code dataSize = buffer.remaining() = 0}, causing FreeType to produce garbage glyph metrics
+   * (raw EM units instead of pixel units). Reporting {@code length() = 0} for the file handle
+   * forces the alternate branch in the emulation that uses {@link com.badlogic.gdx.utils.BufferUtils#copy},
+   * which correctly resets the buffer position to zero before the native call.
+   *
+   * @param fontFile The font asset handle. Not modified.
+   * @return A newly created generator.
+   */
+  static FreeTypeFontGenerator createGenerator(FileHandle fontFile) {
+    if (Gdx.app.getType() == Application.ApplicationType.WebGL) {
+      fontFile = new ZeroLengthFileHandle(fontFile);
+    }
+    return new FreeTypeFontGenerator(fontFile);
   }
 
   private static void disposeAllCachedBitmapFonts() {
@@ -418,7 +446,7 @@ public final class FlixelFontRegistry {
 
     FreeTypeFontGenerator getOrCreateGenerator() {
       if (generator == null) {
-        generator = new FreeTypeFontGenerator(fontFile);
+        generator = createGenerator(fontFile);
       }
       return generator;
     }
@@ -429,6 +457,87 @@ public final class FlixelFontRegistry {
         generator.dispose();
         generator = null;
       }
+    }
+  }
+
+  /**
+   * Wraps a {@link FileHandle} and always returns {@code 0} from {@link #length()}.
+   *
+   * <p>This tricks {@code gdx-freetype-teavm}'s {@code FreeType.Library.newFace()} into taking
+   * the {@code fileSize == 0} code path, which copies the font bytes via
+   * {@link com.badlogic.gdx.utils.BufferUtils#copy} (a native call that resets the buffer
+   * position). The alternative path ({@code fileSize != 0}) uses
+   * {@link com.badlogic.gdx.utils.StreamUtils#copyStream}, which fills the buffer and leaves
+   * its position at the end - causing the Emscripten FreeType module to receive
+   * {@code dataSize = 0} and produce unusable glyph metrics.
+   */
+  private static final class ZeroLengthFileHandle extends FileHandle {
+
+    private final FileHandle wrapped;
+
+    ZeroLengthFileHandle(FileHandle wrapped) {
+      this.type = wrapped.type();
+      this.wrapped = wrapped;
+    }
+
+    @Override
+    public String path() {
+      return wrapped.path();
+    }
+
+    @Override
+    public String name() {
+      return wrapped.name();
+    }
+
+    @Override
+    public String extension() {
+      return wrapped.extension();
+    }
+
+    @Override
+    public String nameWithoutExtension() {
+      return wrapped.nameWithoutExtension();
+    }
+
+    @Override
+    public String pathWithoutExtension() {
+      return wrapped.pathWithoutExtension();
+    }
+
+    @Override
+    public long length() {
+      return 0;
+    }
+
+    @Override
+    public boolean exists() {
+      return wrapped.exists();
+    }
+
+    @Override
+    public InputStream read() {
+      return wrapped.read();
+    }
+
+    @Override
+    public byte[] readBytes() {
+      return wrapped.readBytes();
+    }
+
+    @Override
+    public FileHandle parent() {
+      return wrapped.parent();
+    }
+
+    @Override
+    public FileHandle child(String name) {
+      return wrapped.child(name);
+    }
+
+    @Override
+    public FileHandle sibling(String name) {
+      return wrapped.sibling(name);
     }
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -23,6 +23,8 @@
  */
 package org.flixelgdx.text;
 
+import com.badlogic.gdx.Application;
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -1067,7 +1069,14 @@ public class FlixelText extends FlixelSprite {
     BitmapFont oldFont = bitmapFont;
     boolean oldPrivate = privateBitmapFontOwned;
 
-    FreeTypeFontGenerator gen = resolveGenerator();
+    FreeTypeFontGenerator gen;
+    try {
+      gen = resolveGenerator();
+    } catch (Exception e) {
+      Gdx.app.log("FlixelText", "Font generator unavailable: " + e.getMessage());
+      gen = null;
+    }
+
     if (gen != null) {
       float screenScale = currentScreenScale();
       lastBakeScreenScale = screenScale;
@@ -1083,21 +1092,48 @@ public class FlixelText extends FlixelSprite {
 
       // Incremental generation (glyphs on demand) only makes sense for a private file handle;
       // registry generators serve multiple callers and work better with an upfront bake.
+      // WebGL 1.0 rejects glGenerateMipmap on non-power-of-two textures, so skip on that backend.
       if (fontFile != null) {
         freeTypeParams.incremental = true;
         freeTypeParams.genMipMaps = false;
       } else {
         freeTypeParams.incremental = false;
-        freeTypeParams.genMipMaps = true;
+        freeTypeParams.genMipMaps = Gdx.app.getType() != Application.ApplicationType.WebGL;
       }
 
-      bitmapFont = gen.generateFont(freeTypeParams);
-      // Scale glyph metrics down so the layout measures in game pixels, not baked pixels.
-      // The viewport's world-to-screen projection then maps those game pixels to the
-      // correct screen pixels automatically.
-      bitmapFont.getData().setScale(1f / screenScale);
-      privateBitmapFontOwned = true;
+      BitmapFont generated = null;
+      try {
+        generated = gen.generateFont(freeTypeParams);
+      } catch (Exception e) {
+        Gdx.app.log("FlixelText", "Font generation failed: " + e.getMessage());
+      }
+
+      if (generated != null) {
+        // Guard against garbage metrics from gdx-freetype-teavm's dataSize=0 bug: FreeType
+        // returns raw EM units (thousands of units) instead of pixel-sized metrics, making
+        // lineHeight vastly larger than the requested bake size. Treat that as a failed bake.
+        boolean metricsPlausible = generated.getData().lineHeight <= bakeSize * 4;
+        if (!metricsPlausible) {
+          generated.dispose();
+          generated = null;
+        }
+      }
+      if (generated != null) {
+        // Scale glyph metrics down so the layout measures in game pixels, not baked pixels.
+        // The viewport's world-to-screen projection then maps those game pixels to the
+        // correct screen pixels automatically.
+        bitmapFont = generated;
+        bitmapFont.getData().setScale(1f / screenScale);
+        privateBitmapFontOwned = true;
+      } else {
+        bitmapFont = FlixelFontRegistry.obtainDefaultBitmapFont(size);
+        privateBitmapFontOwned = false;
+      }
     } else {
+      // Sync lastBakeScreenScale even when falling back to the default bitmap font. Without
+      // this the per-frame scale check in rebuildIfDirty() sees a stale 0 and marks the font
+      // dirty every frame, creating an infinite rebuild loop for embedded-font text objects.
+      lastBakeScreenScale = currentScreenScale();
       bitmapFont = FlixelFontRegistry.obtainDefaultBitmapFont(size);
       privateBitmapFontOwned = false;
     }
@@ -1152,7 +1188,7 @@ public class FlixelText extends FlixelSprite {
       String path = fontFile.path();
       if (!ownsGenerator || generator == null || !path.equals(currentGeneratorPath)) {
         disposeOwnedGenerator();
-        generator = new FreeTypeFontGenerator(fontFile);
+        generator = FlixelFontRegistry.createGenerator(fontFile);
         currentGeneratorPath = path;
         ownsGenerator = true;
       }

--- a/flixelgdx-teavm-plugin/src/main/java/org/flixelgdx/gradle/teavm/FlixelTeaVMPlugin.java
+++ b/flixelgdx-teavm-plugin/src/main/java/org/flixelgdx/gradle/teavm/FlixelTeaVMPlugin.java
@@ -195,9 +195,8 @@ public class FlixelTeaVMPlugin implements Plugin<Project> {
     // Copy any user-made web config files into the build output.
     project.getTasks().register("copyWebApp", Copy.class, task -> {
       task.setGroup(TASK_GROUP);
-      task
-          .setDescription(
-              "Copies user-provided web resources (e.g. a custom index.html) into the web output directory.");
+      task.setDescription(
+          "Copies user-provided web resources (e.g. a custom index.html) into the web output directory.");
       task.onlyIf(t -> ext.getWebappDir().get().getAsFile().exists());
       task.from(ext.getWebappDir());
       task.into(teaVmWebRoot);

--- a/flixelgdx-teavm-plugin/src/main/resources/org/flixelgdx/gradle/teavm/default-index.html
+++ b/flixelgdx-teavm-plugin/src/main/resources/org/flixelgdx/gradle/teavm/default-index.html
@@ -25,6 +25,7 @@
 </head>
 <body>
   <canvas id="{{CANVAS_ID}}"></canvas>
+  <script src="scripts/freetype.js"></script>
   <script src="{{TEAVM_SCRIPT}}"></script>
   <script>
     main();

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -25,8 +25,6 @@ package org.flixelgdx.backend.teavm;
 
 import com.github.xpenatan.gdx.teavm.backends.web.WebApplication;
 import com.github.xpenatan.gdx.teavm.backends.web.WebApplicationConfiguration;
-import com.github.xpenatan.gdx.teavm.backends.web.assetloader.AssetInstance;
-import com.github.xpenatan.gdx.teavm.backends.web.assetloader.AssetLoaderListener;
 
 import org.flixelgdx.Flixel;
 import org.flixelgdx.FlixelGame;
@@ -206,19 +204,6 @@ public class FlixelTeaVMLauncher {
       protected void init() {
         super.init();
         Flixel.mouse.setMouseIconManager(new FlixelTeaVMMouseIconManager(configuration.canvasID));
-        addInitQueue();
-        AssetInstance.getLoaderInstance().loadScript("freetype.js", new AssetLoaderListener<>() {
-          @Override
-          public void onSuccess(String url, String result) {
-            subtractInitQueue();
-          }
-
-          @Override
-          public void onFailure(String url) {
-            subtractInitQueue();
-            System.err.println("[FlixelGDX] freetype.js failed to load. FreeType fonts will not work.");
-          }
-        });
       }
     };
   }


### PR DESCRIPTION
## Description

`FlixelText` objects were completely invisible when a game was compiled to TeaVM (web). After ruling out the screen-scale issue, the root cause was traced to a bug in `gdx-freetype-teavm`'s `FreeType.Library.newFace()`.

**Root cause:** When a font file has a known length (`fontFile.length() != 0`), `newFace()` fills a `ByteBuffer` using `StreamUtils.copyStream()`, which advances the buffer position to its limit. The subsequent `newMemoryFace()` call reads `buffer.remaining()` as `dataSize` - which is `0`. FreeType's Emscripten module receives `dataSize = 0`, loads the face but produces glyph metrics in raw EM units (thousands of units) rather than the requested pixel size. The result is text that renders far off-screen with enormous coordinates - invisible to the game.

**Fix:** A `ZeroLengthFileHandle` wrapper in `FlixelFontRegistry` reports `length() = 0` for the font file, which forces `newFace()` into its alternate code path using `BufferUtils.copy()`. That path correctly resets the buffer position to zero before passing it to the native call, so `buffer.remaining() = fontFileSize` and FreeType receives the correct size. A secondary sanity guard in `FlixelText.rebuildFont()` also discards any generated font whose `lineHeight` is more than 4x the requested bake size, as a defensive catch for this class of metric corruption.

Additionally, `freetype.js` is now loaded via a static `<script>` tag in the default HTML template instead of being injected dynamically at runtime, which was unreliable and timing-sensitive.

Fixes #203

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Not applicable - this fix requires a live TeaVM build to verify, which cannot be automated in this repository's test suite.