### PR TITLE
Fixed the debug overlay ignoring substates when drawing hitboxes and counting objects

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
@@ -54,11 +54,17 @@ public final class FlixelDebugUtil {
    * @return The number of active members, or {@code 0} if no state is loaded.
    */
   public static int countActiveMembers() {
-    FlixelState state = Flixel.getState();
-    if (state == null) {
-      return 0;
+    int count = 0;
+    FlixelState current = Flixel.getState();
+    while (current != null) {
+      FlixelState sub = current.getSubState();
+      boolean hasSubState = (sub != null);
+      if (!hasSubState || current.persistentUpdate) {
+        count += countActiveMembersRecursive(current.getMembers());
+      }
+      current = sub;
     }
-    return countActiveMembersRecursive(state.getMembers());
+    return count;
   }
 
   private static int countActiveMembersRecursive(SnapshotArray<?> members) {
@@ -91,11 +97,15 @@ public final class FlixelDebugUtil {
    * @param callback Invoked once per visible {@link FlixelDebugDrawable}.
    */
   public static void forEachDebugDrawable(Consumer<FlixelDebugDrawable> callback) {
-    FlixelState state = Flixel.getState();
-    if (state == null) {
-      return;
+    FlixelState current = Flixel.getState();
+    while (current != null) {
+      FlixelState sub = current.getSubState();
+      boolean hasSubState = (sub != null);
+      if (!hasSubState || current.persistentDraw) {
+        forEachDebugDrawableRecursive(current.getMembers(), callback);
+      }
+      current = sub;
     }
-    forEachDebugDrawableRecursive(state.getMembers(), callback);
   }
 
   private static void forEachDebugDrawableRecursive(@NotNull SnapshotArray<?> members,


### PR DESCRIPTION
## Description

`FlixelDebugUtil.forEachDebugDrawable` and `countActiveMembers` both only looked at the root state returned by `Flixel.getState()`, completely skipping any open substates. This meant hitboxes were never drawn for objects inside a substate, and the debug object count was wrong whenever a substate was active.

Both methods now walk the full state/substate chain using the same `while (current != null)` pattern that `FlixelGame` uses for updating and drawing. Hitbox rendering is gated on `persistentDraw` and the object count is gated on `persistentUpdate`, matching the draw and update loops respectively.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - the fix is behavioral (hitboxes now appear in substates when the debug overlay is open).