### PR TITLE
Fixed the debug sprite picker not including substate members or respecting camera assignment

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -657,10 +657,19 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    * was hit. Topmost is defined as "rendered last": the recursive walk mirrors the draw order,
    * so the first matching member encountered from back to front wins.
    *
+   * <p>The search covers the active state and all of its open substates. Substates are
+   * searched first because they render on top of their parent. A parent state's members are
+   * included only when the parent has no substate, or when {@link FlixelState#persistentDraw}
+   * is {@code true}, mirroring the actual draw chain.
+   *
+   * <p>Only objects assigned to {@code cam} are eligible. An object with a {@code null} or
+   * empty camera list is treated as assigned to all cameras (the libGDX default).
+   *
    * <p>Hidden ({@code visible == false}) and dead ({@code exists == false}) members are skipped so
    * the picker never grabs invisible UI elements or pooled corpses.
    *
-   * @param cam Camera used to convert each candidate's world box into view space.
+   * @param cam Camera used to convert each candidate's world box into view space, and to filter
+   *     objects that are not assigned to it.
    * @param viewX View-space X from {@code viewport.unproject} (before adding scroll / margin).
    * @param viewY View-space Y from {@code viewport.unproject}.
    * @return The topmost hit, or {@code null}.
@@ -671,7 +680,28 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (state == null) {
       return null;
     }
-    return pickRecursive(state.getMembers(), cam, viewX, viewY);
+    return pickFromStateChain(state, cam, viewX, viewY);
+  }
+
+  /**
+   * Walks the state chain starting at {@code state}, searching substates first (deepest renders on
+   * top) and falling back to the parent only when it has no substate or when
+   * {@link FlixelState#persistentDraw} is {@code true}.
+   */
+  @Nullable
+  private FlixelObject pickFromStateChain(@NotNull FlixelState state, @NotNull FlixelCamera cam,
+      float viewX, float viewY) {
+    FlixelState sub = state.getSubState();
+    if (sub != null) {
+      FlixelObject hit = pickFromStateChain(sub, cam, viewX, viewY);
+      if (hit != null) {
+        return hit;
+      }
+    }
+    if (sub == null || state.persistentDraw) {
+      return pickRecursive(state.getMembers(), cam, viewX, viewY);
+    }
+    return null;
   }
 
   @Nullable
@@ -702,7 +732,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
           }
           continue;
         }
-        if (basic instanceof FlixelObject obj && overlapsObjectInView(cam, obj, viewX, viewY)) {
+        if (basic instanceof FlixelObject obj && isAssignedToCamera(basic, cam)
+            && overlapsObjectInView(cam, obj, viewX, viewY)) {
           hit = obj;
           break;
         }
@@ -711,6 +742,23 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
       members.end();
     }
     return hit;
+  }
+
+  /**
+   * Returns {@code true} if {@code basic} should be rendered by {@code cam}. An object with a
+   * {@code null} or empty camera list renders to all cameras (the libGDX default).
+   */
+  private static boolean isAssignedToCamera(@NotNull FlixelBasic basic, @NotNull FlixelCamera cam) {
+    FlixelCamera[] list = basic.cameras;
+    if (list == null || list.length == 0) {
+      return true;
+    }
+    for (FlixelCamera c : list) {
+      if (c == cam) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/flixelgdx-teavm-plugin/src/main/java/org/flixelgdx/gradle/teavm/FlixelTeaVMPlugin.java
+++ b/flixelgdx-teavm-plugin/src/main/java/org/flixelgdx/gradle/teavm/FlixelTeaVMPlugin.java
@@ -78,25 +78,25 @@ import java.util.jar.JarFile;
  *
  * <ul>
  *   <li>{@code copyAssets} - copies the game's asset directory into
-   *       {@code <teavm.js.outputDir>/assets/}.</li>
-   *   <li>{@code copyWebApp} - copies everything in {@code src/main/webapp/} into
-   *       {@code <teavm.js.outputDir>/} (skipped if the directory does not exist), except
-   *       {@code startup-logo.png}, which is placed under {@code assets/} by {@code copyDefaultStartupLogo}.</li>
-   *   <li>{@code generateIndexHtml} - writes a default {@code index.html} into
-   *       {@code <teavm.js.outputDir>/} when no {@code index.html} is present in the webapp directory.
-   *       It runs <strong>after</strong> TeaVM emits JavaScript (and after {@code aliasTeaVmMainScript} and
-   *       {@code extractNativeScripts}) so the page always references the current bundle path and includes
-   *       a {@code <script>} tag for every file found in {@code scripts/}.</li>
-   *   <li>{@code extractNativeScripts} - extracts native JavaScript files (e.g. {@code gdx.wasm.js},
-   *       {@code howler.js}, {@code freetype.js}) from gdx-teavm dependency JARs into
-   *       {@code <teavm.js.outputDir>/scripts/}. These are required at runtime by the gdx-teavm backend.</li>
+ *       {@code <teavm.js.outputDir>/assets/}.</li>
+ *   <li>{@code copyWebApp} - copies everything in {@code src/main/webapp/} into
+ *       {@code <teavm.js.outputDir>/} (skipped if the directory does not exist), except
+ *       {@code startup-logo.png}, which is placed under {@code assets/} by {@code copyDefaultStartupLogo}.</li>
+ *   <li>{@code generateIndexHtml} - writes a default {@code index.html} into
+ *       {@code <teavm.js.outputDir>/} when no {@code index.html} is present in the webapp directory.
+ *       It runs <strong>after</strong> TeaVM emits JavaScript (and after {@code aliasTeaVmMainScript} and
+ *       {@code extractNativeScripts}) so the page always references the current bundle path and includes
+ *       a {@code <script>} tag for every file found in {@code scripts/}.</li>
+ *   <li>{@code extractNativeScripts} - extracts native JavaScript files (e.g. {@code gdx.wasm.js},
+ *       {@code howler.js}, {@code freetype.js}) from gdx-teavm dependency JARs into
+ *       {@code <teavm.js.outputDir>/scripts/}. These are required at runtime by the gdx-teavm backend.</li>
  *   <li>{@code generatePreloadFile} - scans the assets directory and writes a {@code preload.txt}
-   *       manifest into {@code <teavm.js.outputDir>/assets/}. This file is required by gdx-teavm's asset
+ *       manifest into {@code <teavm.js.outputDir>/assets/}. This file is required by gdx-teavm's asset
  *       preloader to discover and download game assets at startup.</li>
-   *   <li>{@code copyDefaultStartupLogo} - writes {@code startup-logo.png} into
-   *       {@code <teavm.js.outputDir>/assets/} for gdx-teavm's preload screen.</li>
-   *   <li>{@code copyFlixelGdxDefaultBitmapFont} - copies {@code lsans-15.fnt} and {@code lsans-15.png} into
-   *       {@code <teavm.js.outputDir>/assets/org/flixelgdx/bitmap/} so the web preloader and
+ *   <li>{@code copyDefaultStartupLogo} - writes {@code startup-logo.png} into
+ *       {@code <teavm.js.outputDir>/assets/} for gdx-teavm's preload screen.</li>
+ *   <li>{@code copyFlixelGdxDefaultBitmapFont} - copies {@code lsans-15.fnt} and {@code lsans-15.png} into
+ *       {@code <teavm.js.outputDir>/assets/org/flixelgdx/bitmap/} so the web preloader and
  *       {@code Gdx.files.internal} can find the default bitmap font (for example
  *       {@code FlixelDebugOverlay}).</li>
  *   <li>{@code aliasTeaVmMainScript} - when {@code teavm.js} {@code targetFileName} is not
@@ -150,16 +150,16 @@ import java.util.jar.JarFile;
  *
  * <pre>{@code
  * flixelgdx {
- *   title = 'My Game Title'                                        // default: My FlixelGDX Game
- *   canvasId = 'my-canvas'                                         // default: 'flixelgdx-canvas'
- *   devServerPort = 1234                                           // default: 8080
- *   assetsDir = file('../assets')                                  // default: rootProject/assets/
- *   webappDir = file('src/main/webapp')                            // default: same value
- *   generateDefaultIndexHtml = true                                // default: true
- *   generateDefaultStartupLogo = true                              // default: true
- *   customIndexHtml = file('src/main/webapp/index.html')           // default: flixelgdx's resource index.html
- *   customStartupLogo = file('src/main/webapp/startup-logo.png')   // default: flixelgdx's resource startup-logo.png
- *   customFavicon = file('src/main/webapp/favicon.ico')            // default: none
+ *   title = 'My Game Title'                                      // default: My FlixelGDX Game
+ *   canvasId = 'my-canvas'                                       // default: 'flixelgdx-canvas'
+ *   devServerPort = 1234                                         // default: 8080
+ *   assetsDir = file('../assets')                                // default: rootProject/assets/
+ *   webappDir = file('src/main/webapp')                          // default: same value
+ *   generateDefaultIndexHtml = true                              // default: true
+ *   generateDefaultStartupLogo = true                            // default: true
+ *   customIndexHtml = file('src/main/webapp/index.html')         // default: flixelgdx's resource index.html
+ *   customStartupLogo = file('src/main/webapp/startup-logo.png') // default: flixelgdx's resource startup-logo.png
+ *   customFavicon = file('src/main/webapp/favicon.ico')          // default: none
  * }
  * }</pre>
  *


### PR DESCRIPTION
## Description

The debug sprite picker (LMB click while paused) only searched the root state's member tree, so objects inside open substates were never selectable. It also had no camera-assignment filter, meaning it could pick objects that were not rendered by the active inspect camera at all.

Fixes both problems in `FlixelDebugOverlay`:

- Extracted a new `pickFromStateChain(FlixelState, ...)` method that mirrors the draw chain: substates are searched first (they render on top), and a parent state's members are only included when there is no active substate or `persistentDraw` is `true`. This matches the pattern already used by `FlixelDebugUtil.forEachDebugDrawable`.
- Added `isAssignedToCamera(FlixelBasic, FlixelCamera)` which replicates the same camera-filter logic used by the bounding-box drawing pass. Objects with a `null` or empty camera list continue to be treated as visible to all cameras (the libGDX default).
- No allocations introduced; the state-chain walk is stack-recursive with no intermediate collections.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).