### PR TITLE
Raised the maximum OpenGL texture binds from 16 to 32 for FlixelSpriteBatch

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelSpriteBatch.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelSpriteBatch.java
@@ -80,7 +80,7 @@ public class FlixelSpriteBatch implements FlixelBatch {
   private static final int VERTICES_PER_QUAD = 4;
   private static final int INDICES_PER_QUAD = 6;
   private static final int DEFAULT_MAX_QUADS = 1000;
-  private static final int MAX_SLOTS_DESKTOP = 16;
+  private static final int MAX_SLOTS_DESKTOP = 32;
 
   private final int maxTextureSlots;
   private int renderCalls;


### PR DESCRIPTION
## Description

Before, the default hard-coded cap for the maximum amount of textures to be batched at once was 16. Most hardware (and even older, weaker hardware) can typically render up to 32 textures at once in a single flush call.

This pull request makes a simple change that raises that bar, from 16 to 32.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [ ] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
