### PR TITLE
Reworked applying global antialiasing for added state members to an optional global property

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -43,6 +43,7 @@ import org.flixelgdx.debug.FlixelDebugManager;
 import org.flixelgdx.debug.FlixelDebugOverlay;
 import org.flixelgdx.debug.FlixelDebugWatchManager;
 import org.flixelgdx.debug.FlixelHeadlessDebugOverlay;
+import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.group.FlixelGroupable;
 import org.flixelgdx.input.gamepad.FlixelGamepadManager;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
@@ -208,6 +209,13 @@ public final class Flixel {
    * to at most this value so a long hitch does not move physics too far in one step.
    */
   public static final float MAX_ELAPSED = 0.1f;
+
+  /**
+   * Automatically applies antialiasing for any member added to the current {@link FlixelState}.
+   * Note that when this value is set to {@code true}, any {@link FlixelSprite}'s / {@link FlixelAntialiasable}'s
+   * antialiasing property will be ignored.
+   */
+  public static boolean applyAntialiasingOnStateAdd = false;
 
   /**
    * The active {@link FlixelGame} instance driving the game lifecycle.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -34,6 +34,7 @@ import com.badlogic.gdx.utils.Array;
 
 import org.flixelgdx.animation.FlixelAnimationController;
 import org.flixelgdx.asset.FlixelAssetManager;
+import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.functional.FlixelColorable;
 import org.flixelgdx.graphics.FlixelFrame;
 import org.flixelgdx.graphics.FlixelGraphic;
@@ -55,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>It is common to extend {@code FlixelSprite} for your own game's needs; for example, a
  * {@code SpaceShip} class may extend {@code FlixelSprite} but add additional game-specific fields.
  */
-public class FlixelSprite extends FlixelObject implements FlixelColorable {
+public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, FlixelColorable {
 
   /** Graphic backing this sprite (shared/cached wrapper around a Texture). */
   @Nullable
@@ -124,13 +125,25 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     this(0, 0);
   }
 
+  /**
+   * Constructs a new sprite at the given position.
+   *
+   * @param x The X coordinate to place the new sprite at.
+   * @param y The X coordinate to place the new sprite at.
+   */
   public FlixelSprite(float x, float y) {
     this(x, y, null);
   }
 
+  /**
+   * Constructs a new sprite at the given position with a loaded graphic.
+   *
+   * @param x The X coordinate to place the new sprite at.
+   * @param y The X coordinate to place the new sprite at.
+   */
   public FlixelSprite(float x, float y, String graphicAssetKey) {
     super(x, y);
-    if (graphicAssetKey != null && graphicAssetKey.isEmpty()) {
+    if (graphicAssetKey != null && !graphicAssetKey.isEmpty()) {
       loadGraphic(graphicAssetKey);
     }
   }
@@ -736,10 +749,12 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     this.offsetY = y;
   }
 
+  @Override
   public boolean isAntialiasing() {
     return antialiasing;
   }
 
+  @Override
   public void setAntialiasing(boolean antialiasing) {
     this.antialiasing = antialiasing;
     Texture texture = currentRegion != null ? currentRegion.getTexture() : null;
@@ -748,6 +763,11 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
           antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest,
           antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest);
     }
+  }
+
+  @Override
+  public void toggleAntialiasing() {
+    setAntialiasing(!isAntialiasing());
   }
 
   public float getAlpha() {
@@ -810,18 +830,6 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     offsetY = y;
   }
 
-  /** {@inheritDoc} */
-  @Override
-  public float getShakeWidth() {
-    return getWidth();
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public float getShakeHeight() {
-    return getHeight();
-  }
-
   public void setAlpha(float a) {
     color.a = a;
   }
@@ -859,7 +867,7 @@ public class FlixelSprite extends FlixelObject implements FlixelColorable {
     return atlasFrames;
   }
 
-  public FlixelFrame getCurrentFrame() {
+  public @Nullable FlixelFrame getCurrentFrame() {
     return currentFrame;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.Batch;
 import com.badlogic.gdx.utils.SnapshotArray;
 
+import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.functional.IFlixelBasic;
 import org.flixelgdx.group.FlixelBasicGroup;
 import org.jetbrains.annotations.NotNull;
@@ -276,16 +277,13 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
   }
 
   /**
-   * Adds a new object to {@code this} state.
+   * Adds a new member to {@code this} state.
    *
-   * @param basic The object to add to the state.
+   * @param basic The new member to add to the state.
    */
   @Override
   public void add(@NotNull IFlixelBasic basic) {
     super.add(basic);
-    if (basic instanceof FlixelSprite sprite) {
-      sprite.setAntialiasing(Flixel.isAntialiasing());
-    }
   }
 
   @Nullable

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
@@ -284,6 +284,9 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
   @Override
   public void add(@NotNull IFlixelBasic basic) {
     super.add(basic);
+    if (basic instanceof FlixelAntialiasable b && Flixel.applyAntialiasingOnStateAdd) {
+      b.setAntialiasing(Flixel.isAntialiasing());
+    }
   }
 
   @Nullable

--- a/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelAntialiasable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/functional/FlixelAntialiasable.java
@@ -1,0 +1,49 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.functional;
+
+/**
+ * Something that can apply antialiasing on itself.
+ *
+ * @see org.flixelgdx.FlixelSprite
+ */
+public interface FlixelAntialiasable {
+
+  /**
+   * @return Whether antialiasing is currently applied on {@code this} object.
+   */
+  boolean isAntialiasing();
+
+  /**
+   * Applies antialiasing to {@code this} object.
+   *
+   * @param antialiasing Whether antialiasing should be applied.
+   */
+  void setAntialiasing(boolean antialiasing);
+
+  /**
+   * Flips antialiasing on and off, depending on the current value.
+   */
+  void toggleAntialiasing();
+}

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
@@ -219,7 +219,7 @@ public class FlixelSpriteGroup extends FlixelSprite implements FlixelBasicGroupa
 
   /** Sets a color tint on the group and propagates it to all current members. */
   @Override
-  public void setColor(Color tint) {
+  public void setColor(@NotNull Color tint) {
     super.setColor(tint);
     FlixelSprite[] items = members.begin();
     for (int i = 0, n = members.size; i < n; i++) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -969,8 +969,6 @@ public class FlixelText extends FlixelSprite {
     ownsGenerator = false;
     fontDirty = true;
     layoutDirty = true;
-    setPosition(0, 0);
-    setColor(Color.WHITE);
   }
 
   @Override


### PR DESCRIPTION
## Description

Originally, when a new member was added to a `FlixelState`, the members antialiasing property would be overridden by the frameworks *global* antialiasing property via `Flixel.setAntialiasing()`. While this was an intended feature, it ended up confusing users on why their sprite's antialiasing property was being ignored.

This pull request reworks the system a bit to a new **`applyAntialiasingOnStateAdd`** property, placed inside `Flixel`. By default, this boolean value is `false`, so HaxeFlixel users can expect the typical behavior. When this value is `true`, any member added to a `FlixelState` will automatically have their antialiasing property applied from the global `Flixel.isAntialiasing()` property, regardless of the objects value.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
