### PR TITLE
Added base-path loading for Sparrow spritesheets

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -148,6 +148,37 @@ public class FlixelAnimationController implements FlixelUpdatable {
   }
 
   /**
+   * Loads a Sparrow atlas from a single base path, inferring the conventional {@code .png} and
+   * {@code .xml} file names shared by a Sparrow export. For example, passing
+   * {@code "shared/images/foo"} loads the texture from
+   * {@code "shared/images/foo.png"} and the atlas data from
+   * {@code "shared/images/foo.xml"}.
+   *
+   * <pre>{@code
+   * sprite.ensureAnimation().loadSparrowFrames("shared/images/foo");
+   * }</pre>
+   *
+   * @param path The base path, without a file extension, shared by the PNG and XML pair.
+   * @return The owning sprite for chaining.
+   */
+  @NotNull
+  public FlixelSprite loadSparrowFrames(@NotNull String path) {
+    return loadSparrowFrames(path + ".png", path + ".xml");
+  }
+
+  /**
+   * Overload of {@link #loadSparrowFrames(String)} that accepts the base path as a {@link FileHandle}
+   * instead of a path string.
+   *
+   * @param path The base path handle, without a file extension, shared by the PNG and XML pair.
+   * @return The owning sprite for chaining.
+   */
+  @NotNull
+  public FlixelSprite loadSparrowFrames(@NotNull FileHandle path) {
+    return loadSparrowFrames(path.path());
+  }
+
+  /**
    * Loads Sparrow XML from a path string (UTF-8). Tries {@code Gdx.files.internal} then {@code classpath}.
    *
    * @param textureKey Asset key of the {@link FlixelGraphic}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetManager.java
@@ -371,7 +371,7 @@ public interface FlixelAssetManager extends FlixelDestroyable, Disposable {
    * Returns or creates a pooled wrapper and increments its reference count when it implements {@link FlixelAsset}.
    *
    * <p><b>Beginner shorthand:</b> “Give me the shared handle and count me as a user.” This method automatically calls
-   * {@link FlixelAsset#retain()} when executed. Note that you should
+   * {@link FlixelAsset#retain()} when executed.
    *
    * <p>Equivalent to {@link #ensureWrapper} followed by {@link FlixelAsset#retain()} for {@link FlixelAsset} wrappers.
    * Call {@link FlixelAsset#release()} when done (e.g. from {@link org.flixelgdx.FlixelSprite#destroy() FlixelSprite.destroy()}).


### PR DESCRIPTION
## Description

`FlixelAnimationController.loadSparrowFrames` previously required passing the PNG texture key and XML data path explicitly. This adds a single-path overload that infers the conventional `.png` and `.xml` pair from one base path, mirroring `FlixelAnimateSprite.addSpritemapAndAnimation(String)`'s directory-inference pattern.

For example, `sprite.ensureAnimation().loadSparrowFrames("shared/images/characters/BOYFRIEND")` now loads `BOYFRIEND.png` and `BOYFRIEND.xml` automatically. A `FileHandle` overload is included as well, matching the style of other base-path convenience methods.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - API addition, verified by `compileJava`, `javadoc`, and the `flixelgdx-test` suite passing.