### PR TITLE
Upgraded the Sparrow and Rig atlas systems to allow merging multiple Sparrow sheets into a single sprite

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -67,6 +67,16 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   protected Array<FlixelFrame> atlasFrames;
 
   /**
+   * Extra {@link FlixelGraphic} handles retained when additional spritesheets are merged onto this
+   * sprite, so those atlases' textures stay loaded for the sprite's lifetime. The primary graphic is
+   * still tracked by the {@link #graphic} field; this list only holds graphics appended <em>after</em>
+   * the initial load, for example through {@link #mergeSparrowAtlas} or an appended Animate rig atlas.
+   * Lazily allocated to avoid the per-instance footprint for sprites that only ever load one atlas.
+   */
+  @Nullable
+  protected Array<FlixelGraphic> secondaryGraphics;
+
+  /**
    * Heavy controller object for handling animations. {@code null} until {@link #ensureAnimation()} or assigned directly.
    */
   @Nullable
@@ -429,6 +439,64 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     }
   }
 
+  /**
+   * Merges parsed Sparrow atlas frames onto this sprite's existing atlas instead of replacing it.
+   *
+   * <p>Where {@link #applySparrowAtlas} swaps in a fresh atlas and clears the sprite's clips, this
+   * <em>appends</em> {@code parsedFrames} to whatever atlas the sprite already has (creating one when
+   * it had none) and retains {@code newGraphic} as a {@link #retainSecondaryGraphic secondary graphic}
+   * so its texture stays loaded. That lets a single sprite carry frames from more than one sheet,
+   * which is what {@link FlixelAnimationController#addSparrowAtlas(String)} builds on. The currently
+   * displayed frame and the registered clips are left untouched, so a sprite already showing a rig
+   * clip or another atlas keeps rendering exactly as before; play one of the newly registered clips to
+   * show the merged art.
+   *
+   * @param newGraphic The graphic backing {@code parsedFrames}, already retained by its loader.
+   * @param parsedFrames The frames to append, which may be empty.
+   */
+  public void mergeSparrowAtlas(
+      @NotNull FlixelGraphic newGraphic, @NotNull Array<FlixelFrame> parsedFrames) {
+    retainSecondaryGraphic(newGraphic);
+    if (atlasFrames == null) {
+      atlasFrames = parsedFrames;
+    } else {
+      atlasFrames.addAll(parsedFrames);
+    }
+  }
+
+  /**
+   * Retains an additional {@link FlixelGraphic} so its texture stays loaded until this sprite is
+   * destroyed, and propagates the sprite's current antialiasing setting onto the new graphic's
+   * texture so an appended atlas matches the visual filter of the original.
+   *
+   * <p>The graphic is assumed to have already been retained by the caller (typically via
+   * {@link org.flixelgdx.asset.FlixelAssetManager#obtainWrapper FlixelAssetManager.obtainWrapper},
+   * which retains automatically), so this method only stores the reference and does not call
+   * {@link FlixelGraphic#retain()} again. This is an advanced hook used by atlas-merging code such as
+   * {@link FlixelAnimationController#addSparrowAtlas(String)} and the Animate rig loader; most game
+   * code never calls it directly.
+   *
+   * @param graphic The graphic to retain for the sprite's lifetime. Must not be {@code null}.
+   */
+  public void retainSecondaryGraphic(@NotNull FlixelGraphic graphic) {
+    if (secondaryGraphics == null) {
+      secondaryGraphics = new Array<>(2);
+    }
+    secondaryGraphics.add(graphic);
+
+    if (antialiasing) {
+      Texture texture;
+      try {
+        texture = graphic.requireTexture();
+      } catch (IllegalStateException notLoaded) {
+        texture = null;
+      }
+      if (texture != null) {
+        texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+      }
+    }
+  }
+
   @Override
   public void draw(Batch batch) {
     if (!visible) {
@@ -663,6 +731,18 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
       atlasFrames = null;
     }
     frames = null;
+    if (secondaryGraphics != null) {
+      // Balance every retain from merged sheets (obtainWrapper()); the primary graphic below is
+      // released separately through its own field.
+      for (int i = 0; i < secondaryGraphics.size; i++) {
+        FlixelGraphic g = secondaryGraphics.get(i);
+        if (g != null) {
+          g.release();
+        }
+      }
+      secondaryGraphics.clear();
+      secondaryGraphics = null;
+    }
     if (graphic != null) {
       graphic.release();
       graphic = null;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -32,6 +32,7 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Affine2;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.XmlReader;
 
 import org.flixelgdx.Flixel;
 import org.flixelgdx.FlixelCamera;
@@ -42,6 +43,7 @@ import org.flixelgdx.util.FlixelDirectionFlags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.StringReader;
 import java.util.Objects;
 
 /**
@@ -97,8 +99,14 @@ import java.util.Objects;
  * and register clip names on the same {@link FlixelAnimationController#playAnimation} path. Names from a later sheet
  * override earlier registrations on collisions.
  *
+ * <h2>Mixing in a Sparrow atlas</h2>
+ * A character can also carry Sparrow XML clips on the same body via {@link #addSparrowAtlas(String)}.
+ * Rig clips keep rendering from the baked rig; clips registered against the merged Sparrow frames
+ * render through the standard frame path, and the sprite picks the right one per clip automatically.
+ *
  * @see #addSpritemapAndAnimation(String)
  * @see #addSpritemapAndAnimation(String, String, String)
+ * @see #addSparrowAtlas(String)
  * @see #defaultSpritemapName
  * @see #defaultAnimationName
  */
@@ -558,6 +566,91 @@ public class FlixelAnimateSprite extends FlixelSprite {
   }
 
   /**
+   * Merges a Sparrow XML atlas onto this sprite, alongside any Adobe Animate rig already installed.
+   *
+   * <p>Adobe Animate atlases ({@link #addSpritemapAndAnimation}) and Sparrow atlases normally live on
+   * different sprites, because the plain Sparrow loader ({@code animation.loadSparrowFrames}) replaces the
+   * sprite's atlas and clears its clips. This method instead <em>appends</em> the Sparrow sheet's
+   * frames to the sprite's existing atlas, so one character can mix both formats: rig clips keep
+   * rendering through the baked rig, while Sparrow clips render through the standard frame path. After
+   * calling this, register the Sparrow clips the usual way, for example
+   * {@code sprite.amimation.addAnimationByPrefix("singLEFT-censor", "pico swear left", 24, false)}.
+   *
+   * <p>A clip counts as rig-backed only when its name matches a baked rig clip; every other clip
+   * (including the Sparrow clips registered after this call) renders from {@link FlixelSprite#currentRegion},
+   * so the two coexist on the same body without extra bookkeeping in game code.
+   *
+   * <pre>{@code
+   * FlixelAnimateSprite pico = new FlixelAnimateSprite();
+   * pico.addSpritemapAndAnimation("characters/pico/basic-animations"); // Animate rig (idle, sing)
+   * pico.addSparrowAtlas("characters/Pico_Censored");                  // Sparrow sheet (censor poses)
+   * pico.animation.addAnimationByPrefix("singLEFT-censor", "pico swear left", 24, false);
+   * pico.animation.playAnimation("Idle");           // rig clip
+   * pico.animation.playAnimation("singLEFT-censor"); // Sparrow clip
+   * }</pre>
+   *
+   * @param path The base path shared by the PNG and XML pair, without a file extension.
+   * @return {@code this} sprite, for chaining.
+   * @see #addSparrowAtlas(String, String)
+   */
+  @NotNull
+  public FlixelAnimateSprite addSparrowAtlas(@NotNull String path) {
+    return addSparrowAtlas(path + ".png", path + ".xml");
+  }
+
+  /**
+   * Overload of {@link #addSparrowAtlas(String)} that accepts the base path as a {@link FileHandle}.
+   *
+   * @param path The base path handle shared by the PNG and XML pair, without a file extension.
+   * @return {@code this} sprite, for chaining.
+   */
+  @NotNull
+  public FlixelAnimateSprite addSparrowAtlas(@NotNull FileHandle path) {
+    return addSparrowAtlas(pathOf(path, "path"));
+  }
+
+  /**
+   * Merges a Sparrow XML atlas from an explicit texture key and XML path. See {@link #addSparrowAtlas(String)}
+   * for the typical base-path form and the rendering contract.
+   *
+   * @param textureKey The asset key of the Sparrow PNG. Must not be {@code null}.
+   * @param xmlPath The path to the Sparrow XML. Must not be {@code null}.
+   * @return {@code this} sprite, for chaining.
+   * @throws IllegalArgumentException If either file is missing or malformed.
+   */
+  @NotNull
+  public FlixelAnimateSprite addSparrowAtlas(@NotNull String textureKey, @NotNull String xmlPath) {
+    ensureAnimation();
+
+    FileHandle xmlHandle = FlixelSpritemapJsonLoader.resolveAssetPath(xmlPath);
+    String xmlText = FlixelSpritemapJsonLoader.readUtf8Text(xmlHandle);
+    XmlReader.Element xmlRoot = new XmlReader().parse(new StringReader(xmlText));
+
+    FlixelGraphic graphic = Flixel.ensureAssets().obtainWrapper(textureKey, FlixelGraphic.class);
+    Texture texture;
+    try {
+      texture = graphic.requireTexture();
+    } catch (IllegalStateException notLoaded) {
+      texture = graphic.loadNow();
+    }
+
+    Array<FlixelFrame> parsed = FlixelAnimationController.parseSparrowFrames(texture, xmlRoot);
+
+    // Append onto whatever atlas the sprite already has. When a rig is installed its atlas array is
+    // shared by reference with the sprite, so appending here also feeds the rig's antialiasing pass
+    // and keeps getAtlasRegions()-driven clip lookups (addAnimationByPrefix) working across formats.
+    Array<FlixelFrame> existing = getAtlasRegions();
+    if (existing == null) {
+      atlasFrames = parsed;
+    } else {
+      existing.addAll(parsed);
+    }
+
+    retainSecondaryGraphic(graphic);
+    return this;
+  }
+
+  /**
    * Resolves a {@link FileHandle} into the path string the rest of {@code addSpritemapAndAnimation}
    * overloads operate on. Asset-manager lookups (the spritemap PNG) and direct JSON reads both resolve
    * a plain path through {@code Gdx.files}, so converting up front lets every {@link FileHandle} overload
@@ -612,20 +705,54 @@ public class FlixelAnimateSprite extends FlixelSprite {
   }
 
   /**
-   * When a rig is installed we render directly from its pre-baked parts and never touch
-   * {@link FlixelSprite#currentRegion}, so we swallow the animation controller's per-frame "current
-   * keyframe" callback. Without a rig, behavior falls through to the normal
-   * {@link FlixelSprite#setCurrentFrameForAnimation} path so the sprite still works for simple atlases.
+   * Routes the controller's per-frame "current keyframe" callback to the right renderer.
    *
-   * @param frame The frame being advanced to by {@link FlixelAnimationController}; ignored when a rig
-   *   is installed.
+   * <p>When the clip that is playing is rig-backed we render directly from its pre-baked parts and
+   * never touch {@link FlixelSprite#currentRegion}, so we swallow the callback (and clear any leftover
+   * Sparrow frame so switching from a Sparrow clip to a rig clip does not flash stale art). For a
+   * Sparrow or simple-atlas clip the callback falls through to the normal
+   * {@link FlixelSprite#setCurrentFrameForAnimation} path, which is what lets a Sparrow sheet merged
+   * with {@link #addSparrowAtlas(String)} share the same sprite as the rig.
+   *
+   * @param frame The frame being advanced to by {@link FlixelAnimationController}; ignored while a
+   *   rig clip is playing.
    */
   @Override
   public void setCurrentFrameForAnimation(@Nullable FlixelFrame frame) {
-    if (rig != null) {
+    if (isCurrentClipRig()) {
+      currentFrame = null;
       return;
     }
     super.setCurrentFrameForAnimation(frame);
+  }
+
+  /**
+   * Whether the clip the controller is currently playing is backed by the installed rig.
+   *
+   * <p>A clip is rig-backed only when a rig is installed and the clip name matches one of the rig's
+   * baked clips. Clips registered against merged Sparrow frames (or any non-rig atlas) are not
+   * rig-backed and therefore render through {@link FlixelSprite#currentRegion}.
+   *
+   * @return {@code true} if the current clip should be drawn from the rig.
+   */
+  private boolean isCurrentClipRig() {
+    FlixelAnimationController controller = animation;
+    String name = (controller != null) ? controller.getCurrentAnim() : "";
+    boolean rigHasClip = rig != null && !name.isEmpty() && rig.getClip(name) != null;
+    return useRigClip(rig != null, rigHasClip);
+  }
+
+  /**
+   * Pure decision for whether the rig draw path should be used, split out so it can be unit tested
+   * without a GPU-backed rig. The rig path is used only when a rig is installed and it actually holds
+   * the clip being played.
+   *
+   * @param hasRig Whether a rig is installed.
+   * @param rigHasClip Whether the rig holds the clip currently playing.
+   * @return {@code true} if the rig draw path should be used.
+   */
+  static boolean useRigClip(boolean hasRig, boolean rigHasClip) {
+    return hasRig && rigHasClip;
   }
 
   /**
@@ -645,11 +772,14 @@ public class FlixelAnimateSprite extends FlixelSprite {
    */
   @Override
   public @NotNull FlixelSprite updateHitbox() {
-    if (rig == null) {
+    // A Sparrow clip merged onto this sprite sizes its hitbox from the frame, like a normal sprite;
+    // only a rig clip uses the rig's anchor bounding box.
+    if (!isCurrentClipRig()) {
       return super.updateHitbox();
     }
-    float effW = Math.abs(getScaleX()) * rig.anchorWidth;
-    float effH = Math.abs(getScaleY()) * rig.anchorHeight;
+    FlixelAnimateRig activeRig = rig;
+    float effW = Math.abs(getScaleX()) * activeRig.anchorWidth;
+    float effH = Math.abs(getScaleY()) * activeRig.anchorHeight;
     return updateHitbox(effW, effH);
   }
 
@@ -773,6 +903,9 @@ public class FlixelAnimateSprite extends FlixelSprite {
     }
     FlixelAnimateRig.Clip clip = activeRig.getClip(clipName);
     if (clip == null) {
+      // Not a rig clip: a Sparrow clip merged via addSparrowAtlas() (or any non-rig atlas clip)
+      // renders through the standard frame path off currentFrame / currentRegion.
+      super.draw(batch);
       return;
     }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -32,18 +32,15 @@ import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Affine2;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.XmlReader;
 
 import org.flixelgdx.Flixel;
 import org.flixelgdx.FlixelCamera;
 import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.graphics.FlixelFrame;
-import org.flixelgdx.graphics.FlixelGraphic;
 import org.flixelgdx.util.FlixelDirectionFlags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.io.StringReader;
 import java.util.Objects;
 
 /**
@@ -100,13 +97,14 @@ import java.util.Objects;
  * override earlier registrations on collisions.
  *
  * <h2>Mixing in a Sparrow atlas</h2>
- * A character can also carry Sparrow XML clips on the same body via {@link #addSparrowAtlas(String)}.
- * Rig clips keep rendering from the baked rig; clips registered against the merged Sparrow frames
- * render through the standard frame path, and the sprite picks the right one per clip automatically.
+ * A character can also carry Sparrow XML clips on the same body via
+ * {@link FlixelAnimationController#addSparrowAtlas(String)}. Rig clips keep rendering from the baked
+ * rig; clips registered against the merged Sparrow frames render through the standard frame path, and
+ * the sprite picks the right one per clip automatically.
  *
  * @see #addSpritemapAndAnimation(String)
  * @see #addSpritemapAndAnimation(String, String, String)
- * @see #addSparrowAtlas(String)
+ * @see FlixelAnimationController#addSparrowAtlas(String)
  * @see #defaultSpritemapName
  * @see #defaultAnimationName
  */
@@ -150,16 +148,6 @@ public class FlixelAnimateSprite extends FlixelSprite {
    */
   @NotNull
   private final Affine2 drawAffine = new Affine2();
-
-  /**
-   * Extra {@link FlixelGraphic} handles retained when additional spritesheets are merged so those atlases' textures stay
-   * loaded for the lifetime of this sprite. The first (primary) graphic is
-   * still tracked by {@link FlixelSprite}'s own {@code graphic} field; this list only holds graphics
-   * appended <em>after</em> the initial load. Lazily allocated to avoid the per-instance footprint
-   * for sprites that only ever load a single atlas.
-   */
-  @Nullable
-  private Array<FlixelGraphic> secondaryGraphics;
 
   /** Creates an empty sprite at {@code (0, 0)}. Call {@link #addSpritemapAndAnimation} before using BTA rigs. */
   public FlixelAnimateSprite() {
@@ -566,91 +554,6 @@ public class FlixelAnimateSprite extends FlixelSprite {
   }
 
   /**
-   * Merges a Sparrow XML atlas onto this sprite, alongside any Adobe Animate rig already installed.
-   *
-   * <p>Adobe Animate atlases ({@link #addSpritemapAndAnimation}) and Sparrow atlases normally live on
-   * different sprites, because the plain Sparrow loader ({@code animation.loadSparrowFrames}) replaces the
-   * sprite's atlas and clears its clips. This method instead <em>appends</em> the Sparrow sheet's
-   * frames to the sprite's existing atlas, so one character can mix both formats: rig clips keep
-   * rendering through the baked rig, while Sparrow clips render through the standard frame path. After
-   * calling this, register the Sparrow clips the usual way, for example
-   * {@code sprite.amimation.addAnimationByPrefix("singLEFT-censor", "pico swear left", 24, false)}.
-   *
-   * <p>A clip counts as rig-backed only when its name matches a baked rig clip; every other clip
-   * (including the Sparrow clips registered after this call) renders from {@link FlixelSprite#currentRegion},
-   * so the two coexist on the same body without extra bookkeeping in game code.
-   *
-   * <pre>{@code
-   * FlixelAnimateSprite pico = new FlixelAnimateSprite();
-   * pico.addSpritemapAndAnimation("characters/pico/basic-animations"); // Animate rig (idle, sing)
-   * pico.addSparrowAtlas("characters/Pico_Censored");                  // Sparrow sheet (censor poses)
-   * pico.animation.addAnimationByPrefix("singLEFT-censor", "pico swear left", 24, false);
-   * pico.animation.playAnimation("Idle");           // rig clip
-   * pico.animation.playAnimation("singLEFT-censor"); // Sparrow clip
-   * }</pre>
-   *
-   * @param path The base path shared by the PNG and XML pair, without a file extension.
-   * @return {@code this} sprite, for chaining.
-   * @see #addSparrowAtlas(String, String)
-   */
-  @NotNull
-  public FlixelAnimateSprite addSparrowAtlas(@NotNull String path) {
-    return addSparrowAtlas(path + ".png", path + ".xml");
-  }
-
-  /**
-   * Overload of {@link #addSparrowAtlas(String)} that accepts the base path as a {@link FileHandle}.
-   *
-   * @param path The base path handle shared by the PNG and XML pair, without a file extension.
-   * @return {@code this} sprite, for chaining.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSparrowAtlas(@NotNull FileHandle path) {
-    return addSparrowAtlas(pathOf(path, "path"));
-  }
-
-  /**
-   * Merges a Sparrow XML atlas from an explicit texture key and XML path. See {@link #addSparrowAtlas(String)}
-   * for the typical base-path form and the rendering contract.
-   *
-   * @param textureKey The asset key of the Sparrow PNG. Must not be {@code null}.
-   * @param xmlPath The path to the Sparrow XML. Must not be {@code null}.
-   * @return {@code this} sprite, for chaining.
-   * @throws IllegalArgumentException If either file is missing or malformed.
-   */
-  @NotNull
-  public FlixelAnimateSprite addSparrowAtlas(@NotNull String textureKey, @NotNull String xmlPath) {
-    ensureAnimation();
-
-    FileHandle xmlHandle = FlixelSpritemapJsonLoader.resolveAssetPath(xmlPath);
-    String xmlText = FlixelSpritemapJsonLoader.readUtf8Text(xmlHandle);
-    XmlReader.Element xmlRoot = new XmlReader().parse(new StringReader(xmlText));
-
-    FlixelGraphic graphic = Flixel.ensureAssets().obtainWrapper(textureKey, FlixelGraphic.class);
-    Texture texture;
-    try {
-      texture = graphic.requireTexture();
-    } catch (IllegalStateException notLoaded) {
-      texture = graphic.loadNow();
-    }
-
-    Array<FlixelFrame> parsed = FlixelAnimationController.parseSparrowFrames(texture, xmlRoot);
-
-    // Append onto whatever atlas the sprite already has. When a rig is installed its atlas array is
-    // shared by reference with the sprite, so appending here also feeds the rig's antialiasing pass
-    // and keeps getAtlasRegions()-driven clip lookups (addAnimationByPrefix) working across formats.
-    Array<FlixelFrame> existing = getAtlasRegions();
-    if (existing == null) {
-      atlasFrames = parsed;
-    } else {
-      existing.addAll(parsed);
-    }
-
-    retainSecondaryGraphic(graphic);
-    return this;
-  }
-
-  /**
    * Resolves a {@link FileHandle} into the path string the rest of {@code addSpritemapAndAnimation}
    * overloads operate on. Asset-manager lookups (the spritemap PNG) and direct JSON reads both resolve
    * a plain path through {@code Gdx.files}, so converting up front lets every {@link FileHandle} overload
@@ -672,39 +575,6 @@ public class FlixelAnimateSprite extends FlixelSprite {
   }
 
   /**
-   * Retains an additional {@link FlixelGraphic} so its texture stays loaded until this sprite is
-   * destroyed, and propagates the sprite's current antialiasing setting onto the new graphic's
-   * texture so an appended atlas matches the visual filter of the original. Called by
-   * {@link FlixelAnimateRigLoader#append} for every secondary atlas merged into the rig; not part
-   * of the public game-code API.
-   *
-   * <p>The graphic is assumed to have already been retained by the caller (typically via
-   * {@link org.flixelgdx.asset.FlixelAssetManager#obtainWrapper FlixelAssetManager.obtainWrapper}, which retains
-   * automatically), so this method only stores the reference and does not call
-   * {@link FlixelGraphic#retain()} again.
-   *
-   * @param graphic The graphic to retain for the sprite's lifetime. Must not be {@code null}.
-   */
-  void retainSecondaryGraphic(@NotNull FlixelGraphic graphic) {
-    if (secondaryGraphics == null) {
-      secondaryGraphics = new Array<>(2);
-    }
-    secondaryGraphics.add(graphic);
-
-    if (antialiasing) {
-      Texture texture;
-      try {
-        texture = graphic.requireTexture();
-      } catch (IllegalStateException notLoaded) {
-        texture = null;
-      }
-      if (texture != null) {
-        texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
-      }
-    }
-  }
-
-  /**
    * Routes the controller's per-frame "current keyframe" callback to the right renderer.
    *
    * <p>When the clip that is playing is rig-backed we render directly from its pre-baked parts and
@@ -712,7 +582,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
    * Sparrow frame so switching from a Sparrow clip to a rig clip does not flash stale art). For a
    * Sparrow or simple-atlas clip the callback falls through to the normal
    * {@link FlixelSprite#setCurrentFrameForAnimation} path, which is what lets a Sparrow sheet merged
-   * with {@link #addSparrowAtlas(String)} share the same sprite as the rig.
+   * with {@link FlixelAnimationController#addSparrowAtlas(String)} share the same sprite as the rig.
    *
    * @param frame The frame being advanced to by {@link FlixelAnimationController}; ignored while a
    *   rig clip is playing.
@@ -1039,18 +909,6 @@ public class FlixelAnimateSprite extends FlixelSprite {
   @Override
   public void destroy() {
     rig = null;
-    if (secondaryGraphics != null) {
-      // Balance every retain from merged sheets (obtainWrapper()). The primary
-      // graphic is still released by FlixelSprite.destroy() through its own field.
-      for (int i = 0; i < secondaryGraphics.size; i++) {
-        FlixelGraphic g = secondaryGraphics.get(i);
-        if (g != null) {
-          g.release();
-        }
-      }
-      secondaryGraphics.clear();
-      secondaryGraphics = null;
-    }
     super.destroy();
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -226,14 +226,80 @@ public class FlixelAnimationController implements FlixelUpdatable {
   }
 
   /**
+   * Merges a Sparrow XML atlas onto the owning sprite from a single base path, inferring the
+   * conventional {@code .png} and {@code .xml} file names shared by a Sparrow export.
+   *
+   * <p>Unlike {@link #loadSparrowFrames(String)}, which replaces the sprite's atlas and clears its
+   * clips, this <em>appends</em> the sheet's frames to whatever atlas the sprite already has, so one
+   * sprite can carry frames from several sheets. It works on any {@link FlixelSprite}, not just an
+   * Adobe Animate rig sprite: a plain sprite can mix two Sparrow sheets, and a
+   * {@link FlixelAnimateSprite} can carry Sparrow clips alongside its baked rig. Register the merged
+   * clips the usual way after this call, then play one to show the merged art.
+   *
+   * <pre>{@code
+   * FlixelSprite sprite = new FlixelSprite();
+   * sprite.ensureAnimation().addSparrowAtlas("shared/images/characters/Pico_Censored");
+   * sprite.animation.addAnimationByPrefix("swearLeft", "pico swear left", 24, false);
+   * sprite.animation.playAnimation("swearLeft");
+   * }</pre>
+   *
+   * @param path The base path, without a file extension, shared by the PNG and XML pair.
+   * @return The owning sprite for chaining.
+   * @see #addSparrowAtlas(String, String)
+   */
+  @NotNull
+  public FlixelSprite addSparrowAtlas(@NotNull String path) {
+    return addSparrowAtlas(path + ".png", path + ".xml");
+  }
+
+  /**
+   * Overload of {@link #addSparrowAtlas(String)} that accepts the base path as a {@link FileHandle}.
+   *
+   * @param path The base path handle, without a file extension, shared by the PNG and XML pair.
+   * @return The owning sprite for chaining.
+   */
+  @NotNull
+  public FlixelSprite addSparrowAtlas(@NotNull FileHandle path) {
+    return addSparrowAtlas(path.path());
+  }
+
+  /**
+   * Merges a Sparrow XML atlas onto the owning sprite from an explicit texture key and XML path. See
+   * {@link #addSparrowAtlas(String)} for the typical base-path form and the merge contract.
+   *
+   * @param textureKey The asset key of the Sparrow PNG. Must not be {@code null}.
+   * @param xmlPath The path to the Sparrow XML. Must not be {@code null}.
+   * @return The owning sprite for chaining.
+   * @throws IllegalArgumentException If either file is missing or malformed.
+   */
+  @NotNull
+  public FlixelSprite addSparrowAtlas(@NotNull String textureKey, @NotNull String xmlPath) {
+    FileHandle xml = FlixelSpritemapJsonLoader.resolveAssetPath(xmlPath);
+    String text = FlixelSpritemapJsonLoader.readUtf8Text(xml);
+    XmlReader.Element xmlRoot = new XmlReader().parse(new StringReader(text));
+
+    FlixelGraphic g = Flixel.ensureAssets().obtainWrapper(textureKey, FlixelGraphic.class);
+    Texture texture;
+    try {
+      texture = g.requireTexture();
+    } catch (IllegalStateException notLoaded) {
+      texture = g.loadNow();
+    }
+
+    Array<FlixelFrame> parsed = parseSparrowFrames(texture, xmlRoot);
+    owner.mergeSparrowAtlas(g, parsed);
+    return owner;
+  }
+
+  /**
    * Parses Sparrow {@code SubTexture} entries into a fresh frame list without installing them on any
    * sprite.
    *
    * <p>This is the shared parsing core behind {@link #loadSparrowFrames(String, XmlReader.Element)}.
    * Keeping it separate lets callers that need to <em>merge</em> a Sparrow sheet into an existing
-   * atlas (for example {@link FlixelAnimateSprite#addSparrowAtlas(String)}) reuse the exact same
-   * region math without going through {@link FlixelSprite#applySparrowAtlas}, which replaces the
-   * sprite's atlas and clears its clips.
+   * atlas (for example {@link #addSparrowAtlas(String)}) reuse the exact same region math without
+   * going through {@link FlixelSprite#applySparrowAtlas}, which replaces the sprite's atlas and
+   * clears its clips.
    *
    * @param texture The backing texture the regions are cut from.
    * @param xmlRoot The root {@code TextureAtlas} element of a Sparrow XML.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -220,6 +220,28 @@ public class FlixelAnimationController implements FlixelUpdatable {
       texture = g.loadNow();
     }
 
+    Array<FlixelFrame> atlasFrames = parseSparrowFrames(texture, xmlRoot);
+    owner.applySparrowAtlas(g, atlasFrames);
+    return owner;
+  }
+
+  /**
+   * Parses Sparrow {@code SubTexture} entries into a fresh frame list without installing them on any
+   * sprite.
+   *
+   * <p>This is the shared parsing core behind {@link #loadSparrowFrames(String, XmlReader.Element)}.
+   * Keeping it separate lets callers that need to <em>merge</em> a Sparrow sheet into an existing
+   * atlas (for example {@link FlixelAnimateSprite#addSparrowAtlas(String)}) reuse the exact same
+   * region math without going through {@link FlixelSprite#applySparrowAtlas}, which replaces the
+   * sprite's atlas and clears its clips.
+   *
+   * @param texture The backing texture the regions are cut from.
+   * @param xmlRoot The root {@code TextureAtlas} element of a Sparrow XML.
+   * @return A newly allocated list of frames, one per valid {@code SubTexture}.
+   */
+  @NotNull
+  public static Array<FlixelFrame> parseSparrowFrames(
+      @NotNull Texture texture, @NotNull XmlReader.Element xmlRoot) {
     int texW = texture.getWidth();
     int texH = texture.getHeight();
     Array<FlixelFrame> atlasFrames = new Array<>(FlixelFrame[]::new);
@@ -277,8 +299,7 @@ public class FlixelAnimationController implements FlixelUpdatable {
       atlasFrames.add(frame);
     }
 
-    owner.applySparrowAtlas(g, atlasFrames);
-    return owner;
+    return atlasFrames;
   }
 
   /** Clears all clips, per-animation offsets, and resets playback state. */

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimateSpriteRoutingTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimateSpriteRoutingTest.java
@@ -1,0 +1,51 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.animation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the pure decision that routes a clip to the rig draw path versus the standard Sparrow /
+ * atlas frame path on a {@link FlixelAnimateSprite}. The full render path needs a GPU texture, so
+ * this focuses on the texture-free rule: the rig is used only when one is installed and it actually
+ * holds the clip being played.
+ */
+class FlixelAnimateSpriteRoutingTest {
+
+  @Test
+  void rigPathRequiresBothARigAndAMatchingClip() {
+    assertTrue(FlixelAnimateSprite.useRigClip(true, true), "Rig installed and owns the clip.");
+    assertFalse(
+        FlixelAnimateSprite.useRigClip(true, false),
+        "A merged Sparrow clip is not in the rig, so it must use the frame path.");
+    assertFalse(
+        FlixelAnimateSprite.useRigClip(false, false), "No rig means the standard frame path.");
+    assertFalse(
+        FlixelAnimateSprite.useRigClip(false, true),
+        "Without a rig there is nothing to draw the clip from, regardless of the clip flag.");
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ gdxControllersVersion=2.2.4
 miniaudioVersion=0.7
 jansiVersion=2.4.2
 imguiJavaVersion=1.90.0
-projectVersion=0.4.3
+projectVersion=0.4.4-SNAPSHOT
 groupId=org.flixelgdx
 gdxTeaVMVersion=1.5.2
 # Reflection safety profile used by Android and TeaVM build tooling.


### PR DESCRIPTION
## Summary

Makes "merge a Sparrow XML atlas onto a sprite that already has an atlas" a first-class animation-controller feature, reachable on any `FlixelSprite` rather than only an Adobe Animate rig sprite:

```java
FlixelSprite sprite = new FlixelSprite();
sprite.ensureAnimation().addSparrowAtlas("shared/images/characters/Pico_Censored");
sprite.animation.addAnimationByPrefix("swearLeft", "pico swear left", 24, false);
sprite.animation.playAnimation("swearLeft");
```

This started as a rig-only helper on `FlixelAnimateSprite`, but appending a sheet's frames to a sprite's existing atlas is a general capability, so it now lives where the rest of the Sparrow loading lives.

## What changed

- **`FlixelAnimationController.addSparrowAtlas(...)`** (base-path, `FileHandle`, and explicit `textureKey`/`xmlPath` overloads). Unlike `loadSparrowFrames`, which replaces the atlas and clears clips, this *appends* frames so one sprite can carry several sheets. It reuses the existing `parseSparrowFrames` region math.
- **`FlixelSprite.mergeSparrowAtlas(graphic, frames)`** does the append, and the secondary-graphic retention that keeps an appended sheet's texture loaded (`retainSecondaryGraphic`, the `secondaryGraphics` field, and its `destroy()` cleanup) moves down from `FlixelAnimateSprite` to `FlixelSprite`. That retention is a general per-sprite concern the rig loader (`FlixelAnimateRigLoader.append`) already depended on, so it has a natural home on the base class now.
- **`FlixelAnimateSprite`** keeps only its rig-specific routing (rig-vs-frame draw/hitbox/keyframe decisions) and no longer carries the Sparrow merge code or its now-unused imports.

## Behavior

No behavior change for existing rig sprites: a character mixing an Animate rig with Sparrow clips works exactly as before, just by calling `addSparrowAtlas` through the controller. Rig clips still draw from the baked rig; merged Sparrow clips render through the standard frame path.

## Testing

- `flixelgdx-core` compiles clean.
- `FlixelAnimateSpriteRoutingTest` and the rest of `org.flixelgdx.animation.*` pass.
- Verified downstream by building the consuming game (which drives Pico's mixed Animate + Sparrow body) against this branch via a composite build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
