### PR TITLE
Fixed sprite rendering when scale and offsets are combined

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -550,8 +550,11 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
       int insetX = FlixelFrame.regionInsetX(srcW, regW, f.offsetX, isFlippedX);
       int insetY = FlixelFrame.regionInsetY(srcH, regH, f.offsetY, isFlippedY);
 
-      float drawX = wx + offsetX + insetX;
-      float drawY = wy + offsetY + insetY;
+      // When scale != 1 the source box grows proportionally from its center, so the region's draw
+      // position must shift by half the extra width/height so the source box's left/bottom edge
+      // stays anchored at (wx + offsetX, wy + offsetY) rather than drifting with the scale pivot.
+      float drawX = wx + offsetX + insetX + srcW * (Math.abs(scaleX) - 1) * 0.5f;
+      float drawY = wy + offsetY + insetY + srcH * (Math.abs(scaleY) - 1) * 0.5f;
 
       // Rotate/scale around the source box's center, expressed relative to the region's bottom-left
       // corner (the origin that the batch.draw overload below measures from).

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -739,7 +739,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
    * {@link FlixelSprite} draw path.
    *
    * <p>The rig draw composes the sprite's world transform once per frame as
-   * {@code T(wx-offsetX, wy-offsetY) * T(originX, originY) * R(angle) * S(sx, sy) * T(-originX/|sx|, -originY/|sy|)}.
+   * {@code T(wx+offsetX, wy+offsetY) * T(originX, originY) * R(angle) * S(sx, sy) * T(-originX/|sx|, -originY/|sy|)}.
    * The asymmetric origin (scaled-world units before the scale, anchor-local units after the scale) is
    * what makes the rig's visible bounding box exactly coincide with the hitbox after
    * {@link #updateHitbox()} for any non-unit scale, while still pivoting rotations around the visual
@@ -799,8 +799,8 @@ public class FlixelAnimateSprite extends FlixelSprite {
     // but it avoids drawing entirely off-screen rigs. Per-part culling is not done here.
     float rigCullW = getWidth() * Math.abs(scaleX);
     float rigCullH = getHeight() * Math.abs(scaleY);
-    float rigLeft = wx - getOffsetX();
-    float rigBottom = wy - getOffsetY();
+    float rigLeft = wx + getOffsetX();
+    float rigBottom = wy + getOffsetY();
     float rigAngle = getAngle();
     if (rigAngle != 0f) {
       float cos = Math.abs(MathUtils.cosDeg(rigAngle));
@@ -848,7 +848,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
     // +origin_world, then translates to the world position. Identity branches are skipped so the
     // no-rotation/no-scale fast path stays cheap.
     baseAffine.idt();
-    baseAffine.translate(wx - getOffsetX(), wy - getOffsetY());
+    baseAffine.translate(wx + getOffsetX(), wy + getOffsetY());
     if (hasOrigin) {
       baseAffine.translate(ox, oy);
     }


### PR DESCRIPTION
## Description

Fixes two related bugs that caused sprite graphics to drift away from their hitboxes when `scaleX`/`scaleY` was set to anything other than `1`.

**Bug 1 - `FlixelSprite.draw()` (Sparrow / atlas frame path)**

When a trimmed Sparrow frame is drawn at non-unit scale, `batch.draw` scales the region around the center of the source box. The region's raw draw position must therefore include a correction of `srcW * (|scaleX| - 1) * 0.5` so the source box's left/bottom edge stays anchored at `(wx + offsetX, wy + offsetY)` rather than drifting with the scale pivot. Without this correction the graphic leaked outside the hitbox by up to `srcW/2 * (scale - 1)` pixels on the left, which was visible in screenshots where the character extended past the red hitbox outline.

**Bug 2 - `FlixelAnimateSprite.draw()` (Animate rig path)**

The rig path still used `wx - getOffsetX()` / `wy - getOffsetY()` for both the culling rectangle and the `baseAffine` world translate. This sign was correct under the old subtract convention but was missed when `e9ecada` changed `FlixelSprite.draw()` to add the offset. Both locations now use `wx + getOffsetX()` / `wy + getOffsetY()`, matching the convention everywhere else and making per-animation offsets shift the rig in the expected direction.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Verified visually with the pico-test project at `scaleX = 2`. Before the fix: the rig atlas left animation extended outside the hitbox on the left; Sparrow offsets shifted the sprite in the wrong direction at scale. After the fix: both align correctly.