### PR TITLE
Added a global overlay system for persistent HUD-style rendering over all game states

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,7 @@ hs_err_pid*
 .attach_pid*
 
 ## Android:
-/android/libs/armeabi-v7a/
-/android/libs/arm64-v8a/
-/android/libs/x86/
-/android/libs/x86_64/
+/android/libs/
 /android/gen/
 /android/out/
 local.properties
@@ -34,20 +31,6 @@ com_crashlytics_export_strings.xml
 /ios/IOSLauncher.app
 /ios/IOSLauncher.app.dSYM
 
-## GWT:
-/html/war/
-/html/gwt-unitCache/
-.apt_generated/
-/html/war/WEB-INF/deploy/
-/html/war/WEB-INF/classes/
-.gwt/
-gwt-unitCache/
-www-test/
-.gwt-tmp/
-
-## TeaVM:
-# Not sure yet...
-
 ## IntelliJ, Android Studio:
 .cursorj
 .idea/
@@ -58,19 +41,7 @@ www-test/
 ## Eclipse:
 .classpath
 .project
-.metadata/
-/android/bin/
-/core/bin/
-flixelgdx-*/bin/
-/lwjgl2/bin/
-/lwjgl3/bin/
-/html/bin/
-/teavm/bin/
-/ios/bin/
-/ios-moe/bin/
-/headless/bin/
-/server/bin/
-/shared/bin/
+**/bin/
 *.tmp
 *.bak
 *.swp

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -38,11 +38,14 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ScreenUtils;
 
 import org.flixelgdx.debug.FlixelDebugOverlay;
+import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.functional.FlixelUpdatable;
+import org.flixelgdx.functional.IFlixelBasic;
 import org.flixelgdx.graphics.FlixelBatch;
 import org.flixelgdx.graphics.FlixelSpriteBatch;
+import org.flixelgdx.group.FlixelBasicGroup;
 import org.flixelgdx.input.FlixelInputProcessorManager;
 import org.flixelgdx.input.action.FlixelActionSets;
 import org.flixelgdx.text.FlixelFontRegistry;
@@ -132,6 +135,14 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   /** Convenience reference to the global {@link Flixel#cameras} list (the single source of truth). */
   protected final Array<FlixelCamera> cameras = Flixel.cameras;
 
+  /** The camera used to render the global overlay. Not registered in {@link Flixel#cameras}. */
+  @Nullable
+  private FlixelCamera overlayCamera;
+
+  /** The member group for the global overlay. Updated and drawn when the overlay is enabled. */
+  @Nullable
+  private FlixelBasicGroup<IFlixelBasic> overlayGroup;
+
   /**
    * Total render calls issued by the framework {@link FlixelBatch} during the most recently
    * completed draw pass, summed across all camera loops. Derived from the delta of
@@ -203,6 +214,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
   /** When true, skips gameplay/state/camera follow updates (debug pause). */
   private boolean gamePaused = false;
+
+  /** When true, the global overlay group is updated and drawn on top of all game cameras each frame. */
+  private boolean overlayEnabled;
 
   /** When true, calls {@link #destroy()} and {@link #create()}, which resets the game. */
   protected volatile boolean resetRequested = false;
@@ -335,6 +349,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     batch = new FlixelSpriteBatch();
     cameras.clear();
     cameras.add(new FlixelCamera((int) viewSize.x, (int) viewSize.y));
+    overlayCamera = new FlixelCamera((int) viewSize.x, (int) viewSize.y);
+    overlayGroup = new FlixelBasicGroup<>(IFlixelBasic[]::new) {
+    };
 
     Pixmap pixmap = new Pixmap(1, 1, Pixmap.Format.RGBA8888);
     pixmap.setColor(Color.WHITE);
@@ -384,6 +401,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
     for (FlixelCamera camera : cameras) {
       camera.update(width, height, camera.centerCameraOnResize);
+    }
+    if (overlayCamera != null && overlayEnabled) {
+      overlayCamera.update(width, height, overlayCamera.centerCameraOnResize);
     }
 
     FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
@@ -441,6 +461,13 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       for (FlixelCamera camera : cameras) {
         camera.update(elapsed);
       }
+
+      if (overlayGroup != null && overlayEnabled) {
+        overlayGroup.update(elapsed);
+        if (overlayCamera != null) {
+          overlayCamera.update(elapsed);
+        }
+      }
     }
 
     FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
@@ -497,6 +524,22 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
         camera.drawFX(batch, bgTexture);
 
+        batch.end();
+      } finally {
+        Flixel.setDrawCamera(null);
+      }
+    }
+
+    if (overlayCamera != null && overlayGroup != null && overlayEnabled) {
+      Flixel.setDrawCamera(overlayCamera);
+      try {
+        if (gamePaused) {
+          overlayCamera.applyLibCameraTransform();
+        }
+        overlayCamera.getViewport().apply();
+        batch.setProjectionMatrix(overlayCamera.getCamera().combined);
+        batch.begin();
+        overlayGroup.draw(batch);
         batch.end();
       } finally {
         Flixel.setDrawCamera(null);
@@ -837,6 +880,15 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       camera.destroy();
     }
     cameras.clear();
+    if (overlayGroup != null) {
+      overlayGroup.destroy();
+      overlayGroup = null;
+    }
+    if (overlayCamera != null) {
+      overlayCamera.destroy();
+      overlayCamera = null;
+    }
+    overlayEnabled = false;
     debugPauseCameraScroll = null;
     debugPauseCameraZoom = null;
     gamePaused = false;
@@ -905,6 +957,62 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     if (desktopTransparencyActive) {
       applyDesktopTransparencyBackdropOnly();
     }
+  }
+
+  /**
+   * Adds a member to the global overlay group so it is updated and drawn on top of all game cameras while the overlay
+   * is enabled.
+   *
+   * <p>The overlay must be enabled via {@link #enableGlobalOverlay(boolean)} or {@link #toggleGlobalOverlay()} for
+   * added members to actually appear. This is safe to call even when the overlay is disabled.
+   *
+   * <p>Example usage:
+   * <pre>{@code
+   * fpsCounter = new FlixelText();
+   * add(fpsCounter);
+   * enableGlobalOverlay(true);
+   * }</pre>
+   *
+   * @param basic The object to add to the overlay group.
+   */
+  public void add(@NotNull IFlixelBasic basic) {
+    if (overlayGroup != null) {
+      overlayGroup.add(basic);
+      if (basic instanceof FlixelAntialiasable b && Flixel.applyAntialiasingOnStateAdd) {
+        b.setAntialiasing(Flixel.isAntialiasing());
+      }
+    }
+  }
+
+  /**
+   * Removes a member from the global overlay group.
+   *
+   * @param basic The object to remove from the overlay group.
+   */
+  public void remove(@NotNull IFlixelBasic basic) {
+    if (overlayGroup != null) {
+      overlayGroup.remove(basic);
+    }
+  }
+
+  /**
+   * Enables or disables the global overlay. When disabled, the overlay group is neither updated nor drawn, making it
+   * zero-cost on the frame budget.
+   *
+   * @param enabled Whether the overlay should be active.
+   */
+  public void enableGlobalOverlay(boolean enabled) {
+    overlayEnabled = enabled;
+  }
+
+  /**
+   * Toggles the global overlay on if it is currently off, and off if it is currently on.
+   *
+   * @return The new enabled state after toggling.
+   */
+  public boolean toggleGlobalOverlay() {
+    overlayEnabled = !overlayEnabled;
+    return overlayEnabled;
   }
 
   public String getTitle() {
@@ -1154,5 +1262,34 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   public void setWindowSize(Vector2 newSize) {
     viewSize = newSize;
     Gdx.graphics.setWindowedMode((int) newSize.x, (int) newSize.y);
+  }
+
+  public boolean isGlobalOverlayEnabled() {
+    return overlayEnabled;
+  }
+
+  /**
+   * Returns the private {@link FlixelCamera} used to render the global overlay.
+   *
+   * <p>This camera is never registered in {@link Flixel#cameras}, so it is not affected by state
+   * code or camera resets. Its scroll is always zero, which means overlay members placed at
+   * position {@code (x, y)} always appear at those same design-resolution coordinates regardless
+   * of what the active game camera is doing.
+   *
+   * @return The overlay camera, or {@code null} if {@link #create()} has not yet run.
+   */
+  @Nullable
+  public FlixelCamera getOverlayCamera() {
+    return overlayCamera;
+  }
+
+  /**
+   * Returns the {@link FlixelBasicGroup} that holds all members added via {@link #add(IFlixelBasic)}.
+   *
+   * @return The overlay group, or {@code null} if {@link #create()} has not yet run.
+   */
+  @Nullable
+  public FlixelBasicGroup<IFlixelBasic> getOverlayGroup() {
+    return overlayGroup;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelAssetMode.java
@@ -23,6 +23,8 @@
  */
 package org.flixelgdx.asset;
 
+import org.flixelgdx.Flixel;
+
 /**
  * Controls when the asset manager reclaims memory for non-persistent assets.
  *
@@ -77,10 +79,10 @@ public enum FlixelAssetMode {
    * <ul>
    *   <li>{@link FlixelAsset#release()} must be called on the GL/render thread. Calling it from
    *     a background thread while libGDX may be uploading or disposing GPU resources is not safe
-   *     in AGGRESSIVE mode (it is fine in LAZY and STANDARD since those only unload at state
-   *     switch boundaries, which is always on the GL thread).</li>
+   *     in AGGRESSIVE mode. It is fine in LAZY and STANDARD since those only unload at state
+   *     switch boundaries, which is always on the GL thread.</li>
    *   <li>After an aggressive eviction, the underlying libGDX asset is disposed. Any code that
-   *     still holds a raw reference to the same {@link com.badlogic.gdx.graphics.Texture} (or
+   *     still holds a raw reference to the same {@link com.badlogic.gdx.graphics.Texture Texture} (or
    *     other resource) object will encounter a disposed object. The automated sprite pipeline
    *     ({@code loadGraphic} and {@code destroy}) handles this correctly; direct raw-asset usage
    *     outside that pipeline must ensure no other references remain before releasing.</li>
@@ -88,7 +90,7 @@ public enum FlixelAssetMode {
    *     {@link FlixelAssetManager#load(String)} again and awaiting the async load cycle.</li>
    * </ul>
    *
-   * <p>{@link org.flixelgdx.Flixel#switchState Flixel.switchState} still calls {@link FlixelAssetManager#clearNonPersist()}
+   * <p>{@link Flixel#switchState Flixel.switchState} still calls {@link FlixelAssetManager#clearNonPersist()}
    * as a safety net for assets that were loaded but never retained.
    */
   AGGRESSIVE

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ gdxControllersVersion=2.2.4
 miniaudioVersion=0.7
 jansiVersion=2.4.2
 imguiJavaVersion=1.90.0
-projectVersion=0.4.4-SNAPSHOT
+projectVersion=0.4.4
 groupId=org.flixelgdx
 gdxTeaVMVersion=1.5.2
 # Reflection safety profile used by Android and TeaVM build tooling.


### PR DESCRIPTION
## Description

Adds a global overlay system to `FlixelGame` that lets game code display sprites, text, and other `IFlixelBasic` members on top of every state and camera, regardless of what is currently active. The canonical use case is an FPS/heap counter, but any persistent HUD element works.

The overlay is **off by default** and zero-cost when disabled (the group is neither updated nor drawn).

### API

```java
// In your FlixelGame subclass:
fpsDisplay = new FlixelText();
add(fpsDisplay);          // add to overlay group
enableGlobalOverlay(true); // opt in
toggleGlobalOverlay();     // flip on/off
getOverlayCamera();        // access the private camera
getOverlayGroup();         // access the member group directly
```

### Implementation details

- A dedicated `FlixelCamera` (`overlayCamera`) is created in `create()` and updated in `resize()`, but is **never registered in `Flixel.cameras`** — it is completely invisible to state code and camera resets.
- A `FlixelBasicGroup<IFlixelBasic>` (`overlayGroup`) holds all members added via `add()`.
- The overlay pass runs **after all main camera passes** in `draw()`, before the debug overlay, so it always appears on top.
- The overlay camera always has `scrollX = 0 / scrollY = 0`, so members placed at design-resolution coordinates stay pinned to the screen regardless of what the game cameras are doing.
- `FlixelGame.add()` mirrors the antialiasing logic from `FlixelState.add()` so that `FlixelText` and other `FlixelAntialiasable` members respect `Flixel.applyAntialiasingOnStateAdd`, preventing the chunky/pixelated text rendering that would otherwise occur.
- Overlay group and camera are properly destroyed in `destroy()`.

Also includes a minor Javadoc formatting fix in `FlixelAssetMode` applied by the formatter.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).