### PR TITLE
Added browser tab close support when Gdx.app.exit() is called on the web backend

### DIFF
--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -36,6 +36,7 @@ import org.flixelgdx.backend.teavm.logging.FlixelTeaVMLogConsole;
 import org.flixelgdx.backend.teavm.logging.TeaVMStackTraceProvider;
 import org.flixelgdx.logging.FlixelLogger;
 import org.jetbrains.annotations.Nullable;
+import org.teavm.jso.JSBody;
 
 import java.util.function.Consumer;
 
@@ -80,6 +81,11 @@ import java.util.function.Consumer;
  * The {@link org.flixelgdx.logging.FlixelLogFileHandler FlixelLogFileHandler} is not registered, so {@link FlixelLogger#startFileLogging()} is a safe no-op.
  * Console output uses {@link Flixel#setLogConsoleSink} with a styled {@code console} writer so log lines appear with readable colors
  * in the browser; ANSI {@code System.out} is not used on web.
+ *
+ * <p>When {@code Gdx.app.exit()} is called, the launcher overrides {@code exit()} to invoke the browser's
+ * {@code window.close()}. Browsers only close the tab when it was opened programmatically via {@code window.open()};
+ * for tabs the user opened directly, the browser silently ignores the request. This is a browser security
+ * restriction and cannot be bypassed from JavaScript.
  *
  * @see FlixelGame
  * @see WebApplicationConfiguration
@@ -205,8 +211,25 @@ public class FlixelTeaVMLauncher {
         super.init();
         Flixel.mouse.setMouseIconManager(new FlixelTeaVMMouseIconManager(configuration.canvasID));
       }
+
+      @Override
+      public void exit() {
+        super.exit();
+        closeWindow();
+      }
     };
   }
+
+  /**
+   * Calls the browser's {@code window.close()} to close the current tab.
+   *
+   * <p>Browsers only honor this call when the tab was opened programmatically via
+   * {@code window.open()}. For tabs the user opened directly, the browser silently
+   * ignores the request; this is an intentional browser security restriction and
+   * cannot be bypassed.
+   */
+  @JSBody(script = "window.close();")
+  private static native void closeWindow();
 
   /**
    * Default TeaVM entry point. Games should use their own launcher class


### PR DESCRIPTION
## Description

When `Gdx.app.exit()` is called in a game running on the TeaVM (web) backend, the browser tab now attempts to close itself via `window.close()`. Previously, the call was forwarded to the gdx-teavm `WebApplication.exit()` implementation with no browser-level effect.

The implementation adds an `exit()` override in the anonymous `WebApplication` subclass inside `FlixelTeaVMLauncher.launch(...)`. It calls `super.exit()` first (so the gdx-teavm loop tears down correctly), then invokes a `@JSBody` native method that emits `window.close()` into the compiled JavaScript - the same interop pattern already used by `FlixelTeaVMAlerter`.

**Important browser caveat:** `window.close()` only succeeds when the tab was opened programmatically via `window.open()`. For tabs the user opened directly, browsers silently ignore the call - this is an intentional security restriction that cannot be bypassed from JavaScript. This behavior is documented in the class-level Javadoc and in the `closeWindow()` method Javadoc.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

> No automated test was added - the behavior requires a live browser environment and cannot be exercised from the headless `flixelgdx-test` suite.

## Screenshots / Evidence (if applicable)

N/A - browser tab close behavior requires manual verification in a deployed web build.