### PR TITLE
Reworked the gamepad system to be disabled by default, now requiring developers to explicitly opt in for controller support

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -535,6 +535,13 @@ public final class Flixel {
   /**
    * The gamepad and controller input manager.
    *
+   * <p>The gamepad system is <strong>disabled by default</strong>. Set {@link FlixelGamepadManager#enabled} to
+   * {@code true} before the game loop starts if your game needs controller support:
+   *
+   * <pre>{@code
+   * Flixel.gamepads.enabled = true;
+   * }</pre>
+   *
    * <p>FlixelGDX's gamepad system is built on the gdx-controllers extension. It abstracts physical
    * controllers (Xbox, PlayStation, generic USB) behind a set of logical button and axis codes
    * defined in {@link org.flixelgdx.input.gamepad.FlixelGamepadInput FlixelGamepadInput}, so the same game code works
@@ -548,6 +555,9 @@ public final class Flixel {
    *
    * <p>Example:
    * <pre>{@code
+   * // Opt in to controller support before the game loop starts.
+   * Flixel.gamepads.enabled = true;
+   *
    * // Check if player 1 pressed the A button this frame.
    * if (Flixel.gamepads.justPressed(0, FlixelGamepadInput.A)) {
    *   player.jump();
@@ -784,7 +794,6 @@ public final class Flixel {
     save = new FlixelSave();
     mouse = new FlixelMouseManager();
     gamepads = new FlixelGamepadManager();
-    gamepads.attach();
     log = new FlixelLogger(FlixelLogMode.SIMPLE);
     if (assets == null) {
       assets = new FlixelDefaultAssetManager();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadManager.java
@@ -40,6 +40,13 @@ import java.util.Arrays;
  * Global gamepad manager backed by gdx-controllers. Polls controllers each frame and mirrors the
  * keyboard and mouse frame contract from {@link org.flixelgdx.FlixelGame FlixelGame}.
  *
+ * <p>The gamepad system is <strong>disabled by default</strong>. Set {@link #enabled} to {@code true} before the game
+ * loop starts to opt in:
+ *
+ * <pre>{@code
+ * Flixel.gamepads.enabled = true;
+ * }</pre>
+ *
  * <p>Use logical button and axis constants from {@link FlixelGamepadInput} (for example {@link FlixelGamepadInput#A})
  * with {@link #pressed(int, int)}; each {@link Controller#getMapping()} supplies native indices.
  * {@link FlixelGamepadDevice} is optional; call {@link #ensureDevice(int)} once per slot you want a facade for.
@@ -82,8 +89,11 @@ public final class FlixelGamepadManager implements FlixelInputManager, Controlle
   @Nullable
   private final FlixelGamepadDevice[] ensuredDevices = new FlixelGamepadDevice[MAX_GAMEPADS];
 
-  /** When {@code false}, all queries return inactive state. */
-  public boolean enabled = true;
+  /**
+   * Whether the gamepad system is active. When {@code false}, all queries return inactive state and no hardware is
+   * polled. Defaults to {@code false}; set to {@code true} to opt in before the game loop starts.
+   */
+  public boolean enabled = false;
 
   private boolean listenerAttached;
 


### PR DESCRIPTION
## Description

The gamepad system previously started enabled, meaning every game automatically registered a controller listener and polled hardware each frame -- even games that have no controller support at all. This change makes the system opt-in by defaulting `FlixelGamepadManager.enabled` to `false`.

Developers who want controller support now set `Flixel.gamepads.enabled = true` once before the game loop starts. When disabled, all queries return `false` or `0`, no hardware is polled, and no gdx-controllers listener is registered. The lazy `attach()` in `update()` handles listener registration on the first enabled frame, so there is no behavior difference beyond the new default.

The eager `gamepads.attach()` call that was in `Flixel.initialize()` has been removed since it is redundant with the lazy attach already inside `update()`.

Both the `FlixelGamepadManager` class Javadoc and the `Flixel.gamepads` field Javadoc have been updated with opt-in instructions and an example.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).