### PR TITLE
Improved the action input system with flick detection, hold-repeat, and corrected analog Y axis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ public class PerformanceObject {
 
 Summarize edits in plain language: what changed, why, and how it fits the system.
 
-Before considering a coding task finished, **run unit tests** and **Javadoc lint**; fix failures. **All** unit tests live
+Before considering a coding task finished, **run unit tests**, **spotless apply (for formatting)**. and **Javadoc lint**; fix failures. **All** unit tests live
 in the `flixelgdx-test` module, not scattered around multiple modules.
 
 ---

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -186,7 +186,7 @@ public class FlixelAnimateSprite extends FlixelSprite {
     Objects.requireNonNull(defaultSpritemapName, "defaultSpritemapName cannot be null.");
     Objects.requireNonNull(defaultAnimationName, "defaultAnimationName cannot be null.");
     if (!Gdx.files.internal(path).isDirectory()) {
-      throw new IllegalArgumentException("The provided path is either not a real folder.");
+      throw new IllegalArgumentException("The provided path is either not a real folder, or doesn't exist.");
     }
     return addSpritemapAndAnimation(path + "/" + defaultSpritemapName + ".png",
         path + "/" + defaultSpritemapName + ".json", path + "/" + defaultAnimationName + ".json");

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/host/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/host/FlixelHostIntegration.java
@@ -47,8 +47,8 @@ import org.jetbrains.annotations.Nullable;
 public interface FlixelHostIntegration {
 
   /**
-   * Shows a non-blocking desktop notification using the platform provider (Action Center on Windows, Notification Center on macOS,
-   * D-Bus, or libnotify on Linux).
+   * Shows a non-blocking desktop notification using the platform provider (Action Center on Windows,
+   * Notification Center on macOS, D-Bus or libnotify on Linux).
    *
    * @param title Short title, or {@code null} to use a blank title when the OS allows it.
    * @param message Body text; must not be {@code null}.
@@ -61,7 +61,8 @@ public interface FlixelHostIntegration {
   void requestAttention();
 
   /**
-   * @return {@code true} if {@link #sendNotification(String, String)} is expected to do useful work on this platform session.
+   * @return {@code true} if {@link #sendNotification(String, String)} is expected to do useful
+   * work on this platform session.
    */
   boolean supportsDesktopNotification();
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelSpriteBatch.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelSpriteBatch.java
@@ -393,14 +393,12 @@ public class FlixelSpriteBatch implements FlixelBatch {
     if (clockwise) {
       u = region.getU2();
       u2 = region.getU();
-      v = region.getV2();
-      v2 = region.getV();
     } else {
       u = region.getU();
       u2 = region.getU2();
-      v = region.getV2();
-      v2 = region.getV();
     }
+    v = region.getV2();
+    v2 = region.getV();
 
     writeRotatedQuad(x, y, originX, originY, w, h, scaleX, scaleY, rotation, tidx, u, v, u2, v2);
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAction.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAction.java
@@ -38,13 +38,13 @@ import org.jetbrains.annotations.Nullable;
  *
  * <h2>Hold-repeat</h2>
  *
- * <p>{@link #holdDelay} and {@link #holdInterval} control autorepeat timing used by
+ * <p>{@link #getHoldDelay() holdDelay} and {@link #getHoldInterval() holdInterval} control autorepeat timing used by
  * {@link FlixelActionDigital#repeated()} and {@link FlixelActionAnalog#flickedRepeating()}.
  * Set them before the game loop starts if the defaults do not suit your game:
  *
  * <pre>{@code
- * navigate.holdDelay    = 0.4f; // wait 400 ms before the first repeat
- * navigate.holdInterval = 0.08f; // then fire every 80 ms while held
+ * navigate.setHoldDelay(0.4f);     // Wait 400 ms before the first repeat...
+ * navigate.setHoldInterval(0.08f); // ...then fire every 80 ms while held.
  * }</pre>
  */
 public abstract class FlixelAction {
@@ -54,14 +54,14 @@ public abstract class FlixelAction {
    * Used by {@link FlixelActionDigital#repeated()} and {@link FlixelActionAnalog#flickedRepeating()}.
    * Defaults to {@code 0.5f}.
    */
-  public float holdDelay = 0.5f;
+  private float holdDelay = 0.5f;
 
   /**
    * Seconds between each subsequent hold-repeat after the initial delay has elapsed.
    * Used by {@link FlixelActionDigital#repeated()} and {@link FlixelActionAnalog#flickedRepeating()}.
    * Defaults to {@code 0.1f}.
    */
-  public float holdInterval = 0.1f;
+  private float holdInterval = 0.1f;
 
   /** Optional edge callback; assign once to avoid per-frame allocations. */
   @Nullable
@@ -97,6 +97,22 @@ public abstract class FlixelAction {
 
   void setOwner(@Nullable FlixelActionSet set) {
     this.owner = set;
+  }
+
+  public float getHoldDelay() {
+    return holdDelay;
+  }
+
+  public void setHoldDelay(float holdDelay) {
+    this.holdDelay = Math.max(0f, holdDelay);
+  }
+
+  public float getHoldInterval() {
+    return holdInterval;
+  }
+
+  public void setHoldInterval(float holdInterval) {
+    this.holdInterval = Math.max(0f, holdInterval);
   }
 
   abstract void updateAction(float elapsed);

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAction.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAction.java
@@ -35,18 +35,43 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>The {@link #getName()} string is used for Steam Input alignment and logging; keep names stable if players rebind or
  * use cloud profiles.
+ *
+ * <h2>Hold-repeat</h2>
+ *
+ * <p>{@link #holdDelay} and {@link #holdInterval} control autorepeat timing used by
+ * {@link FlixelActionDigital#repeated()} and {@link FlixelActionAnalog#flickedRepeating()}.
+ * Set them before the game loop starts if the defaults do not suit your game:
+ *
+ * <pre>{@code
+ * navigate.holdDelay    = 0.4f; // wait 400 ms before the first repeat
+ * navigate.holdInterval = 0.08f; // then fire every 80 ms while held
+ * }</pre>
  */
 public abstract class FlixelAction {
 
-  @NotNull
-  private final String name;
+  /**
+   * Seconds to wait after the initial press or flick before the first hold-repeat fires.
+   * Used by {@link FlixelActionDigital#repeated()} and {@link FlixelActionAnalog#flickedRepeating()}.
+   * Defaults to {@code 0.5f}.
+   */
+  public float holdDelay = 0.5f;
 
-  @Nullable
-  FlixelActionSet owner;
+  /**
+   * Seconds between each subsequent hold-repeat after the initial delay has elapsed.
+   * Used by {@link FlixelActionDigital#repeated()} and {@link FlixelActionAnalog#flickedRepeating()}.
+   * Defaults to {@code 0.1f}.
+   */
+  public float holdInterval = 0.1f;
 
   /** Optional edge callback; assign once to avoid per-frame allocations. */
   @Nullable
   public Runnable callback;
+
+  @Nullable
+  FlixelActionSet owner;
+
+  @NotNull
+  private final String name;
 
   /** When {@code false}, this action stays inactive and reads false or zero. */
   public boolean active = true;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -57,7 +57,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Use {@link #getX()} and {@link #getY()} after {@code super.update(elapsed)} in your state. {@link #getPrevX()} / {@link #getPrevY()}
  * mirror the previous frame after {@link FlixelActionSet#endFrame()}. {@link #moved()} is a small helper for non-zero length.
  *
- * <h2>Flick detection</h2>
+ * <h2>Flick detection and hold-repeat</h2>
  *
  * <p>{@link #flicked()} returns {@code true} for exactly one frame when the stick first crosses {@link #flickThreshold}.
  * It resets to {@code false} as long as the stick stays past the threshold, and fires again only after the stick
@@ -65,16 +65,21 @@ import org.jetbrains.annotations.Nullable;
  * {@link FlixelActionDigital#justPressed() FlixelActionDigital.justPressed()} and is useful for menu navigation
  * where each stick deflection should trigger exactly one action.
  *
+ * <p>{@link #flickedRepeating()} extends that with hold-repeat: it fires on the initial flick,
+ * then fires again after {@link FlixelAction#holdDelay} seconds if the stick is still past the
+ * threshold, and continues every {@link FlixelAction#holdInterval} seconds after that. Use this
+ * for menus that should keep scrolling when the stick is held.
+ *
  * <pre>{@code
- * // Navigate a menu with a single stick deflection.
- * if (navigate.flicked()) {
- *   if (navigate.getY() < 0) selectNextItem();
- *   else if (navigate.getY() > 0) selectPreviousItem();
+ * // Navigate a menu; hold the stick to keep scrolling.
+ * if (navigate.flickedRepeating()) {
+ *   if (navigate.getY() > 0) selectPreviousItem();
+ *   else if (navigate.getY() < 0) selectNextItem();
  * }
  * }</pre>
  *
  * <p>Key bindings contribute {@code +-1.0} per axis, so pressing any bound key immediately exceeds the default threshold
- * and fires {@link #flicked()} on that frame. Adjust {@link #flickThreshold} before the game loop if your game needs
+ * and fires both methods on that frame. Adjust {@link #flickThreshold} before the game loop if your game needs
  * a different sensitivity.
  */
 public final class FlixelActionAnalog extends FlixelAction {
@@ -84,6 +89,12 @@ public final class FlixelActionAnalog extends FlixelAction {
    * made against the normalized vector length after all bindings are accumulated, so a value of
    * {@code 0.3} means roughly 30% deflection. Defaults to {@code 0.3f}; adjust before the game
    * loop if your game needs a different sensitivity.
+   */
+  /**
+   * Minimum stick magnitude (0 to 1) required for {@link #flicked()} and {@link #flickedRepeating()}
+   * to fire. The comparison is made against the normalized vector length after all bindings are
+   * accumulated, so a value of {@code 0.3} means roughly 30% deflection. Defaults to {@code 0.3f};
+   * adjust before the game loop if your game needs a different sensitivity.
    */
   public float flickThreshold = 0.3f;
 
@@ -95,7 +106,10 @@ public final class FlixelActionAnalog extends FlixelAction {
   private float y;
   private float prevX;
   private float prevY;
+  private float flickHoldAccum;
 
+  private boolean flickHoldRepeating;
+  private boolean flickRepeated;
   private boolean flickState;
   private boolean prevFlickState;
 
@@ -113,6 +127,9 @@ public final class FlixelActionAnalog extends FlixelAction {
       x = 0f;
       y = 0f;
       flickState = false;
+      flickHoldAccum = 0f;
+      flickHoldRepeating = false;
+      flickRepeated = false;
       return;
     }
     scratch.set(0f, 0f);
@@ -135,6 +152,30 @@ public final class FlixelActionAnalog extends FlixelAction {
     y = sy;
     float ft = flickThreshold;
     flickState = (x * x + y * y) >= ft * ft;
+    if (flickState) {
+      if (!prevFlickState) {
+        flickHoldAccum = 0f;
+        flickHoldRepeating = false;
+        flickRepeated = true;
+      } else {
+        flickHoldAccum += elapsed;
+        flickRepeated = false;
+        if (!flickHoldRepeating) {
+          if (flickHoldAccum >= holdDelay) {
+            flickHoldAccum -= holdDelay;
+            flickHoldRepeating = true;
+            flickRepeated = true;
+          }
+        } else if (flickHoldAccum >= holdInterval) {
+          flickHoldAccum -= holdInterval;
+          flickRepeated = true;
+        }
+      }
+    } else {
+      flickHoldAccum = 0f;
+      flickHoldRepeating = false;
+      flickRepeated = false;
+    }
   }
 
   private static void accumulate(@NotNull FlixelAnalogAxisBinding b, @NotNull Vector2 out) {
@@ -164,19 +205,15 @@ public final class FlixelActionAnalog extends FlixelAction {
           out.x += Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
         }
       }
+      // Negate raw Y to convert from screen-space (up = negative) to math-space (up = positive).
       case GAMEPAD_AXIS_Y -> {
         if (Flixel.gamepads != null && Flixel.gamepads.enabled) {
-          out.y += Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
-        }
-      }
-      case NEG_GAMEPAD_AXIS_X -> {
-        if (Flixel.gamepads != null && Flixel.gamepads.enabled) {
-          out.x -= Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
-        }
-      }
-      case NEG_GAMEPAD_AXIS_Y -> {
-        if (Flixel.gamepads != null && Flixel.gamepads.enabled) {
           out.y -= Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
+        }
+      }
+      case RAW_GAMEPAD_AXIS_Y -> {
+        if (Flixel.gamepads != null && Flixel.gamepads.enabled) {
+          out.y += Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
         }
       }
       default -> {
@@ -197,6 +234,9 @@ public final class FlixelActionAnalog extends FlixelAction {
     y = 0f;
     prevX = 0f;
     prevY = 0f;
+    flickHoldAccum = 0f;
+    flickHoldRepeating = false;
+    flickRepeated = false;
     flickState = false;
     prevFlickState = false;
   }
@@ -239,5 +279,29 @@ public final class FlixelActionAnalog extends FlixelAction {
    */
   public boolean flicked() {
     return active && flickState && !prevFlickState;
+  }
+
+  /**
+   * Returns {@code true} on the initial flick and again on each hold-repeat tick.
+   *
+   * <p>Fires on the same frame as {@link #flicked()} when the stick first crosses
+   * {@link #flickThreshold}, then fires again after {@link FlixelAction#holdDelay} seconds if the
+   * stick is still past the threshold, and continues every {@link FlixelAction#holdInterval}
+   * seconds after that. Returning the stick below the threshold resets the timer.
+   *
+   * <p>Use this instead of {@link #flicked()} when a held stick deflection should keep triggering,
+   * such as scrolling through a long menu list:
+   *
+   * <pre>{@code
+   * if (navigate.flickedRepeating()) {
+   *   if (navigate.getY() > 0) selectPreviousItem();
+   *   else if (navigate.getY() < 0) selectNextItem();
+   * }
+   * }</pre>
+   *
+   * @return {@code true} on the initial flick frame and on each repeat tick while held past the threshold.
+   */
+  public boolean flickedRepeating() {
+    return active && flickRepeated;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -56,8 +56,36 @@ import org.jetbrains.annotations.Nullable;
  *
  * <p>Use {@link #getX()} and {@link #getY()} after {@code super.update(elapsed)} in your state. {@link #getPrevX()} / {@link #getPrevY()}
  * mirror the previous frame after {@link FlixelActionSet#endFrame()}. {@link #moved()} is a small helper for non-zero length.
+ *
+ * <h2>Flick detection</h2>
+ *
+ * <p>{@link #flicked()} returns {@code true} for exactly one frame when the stick first crosses {@link #flickThreshold}.
+ * It resets to {@code false} as long as the stick stays past the threshold, and fires again only after the stick
+ * returns below the threshold and crosses it again. This mirrors the single-frame contract of
+ * {@link FlixelActionDigital#justPressed() FlixelActionDigital.justPressed()} and is useful for menu navigation
+ * where each stick deflection should trigger exactly one action.
+ *
+ * <pre>{@code
+ * // Navigate a menu with a single stick deflection.
+ * if (navigate.flicked()) {
+ *   if (navigate.getY() < 0) selectNextItem();
+ *   else if (navigate.getY() > 0) selectPreviousItem();
+ * }
+ * }</pre>
+ *
+ * <p>Key bindings contribute {@code +-1.0} per axis, so pressing any bound key immediately exceeds the default threshold
+ * and fires {@link #flicked()} on that frame. Adjust {@link #flickThreshold} before the game loop if your game needs
+ * a different sensitivity.
  */
 public final class FlixelActionAnalog extends FlixelAction {
+
+  /**
+   * Minimum stick magnitude (0 to 1) required for {@link #flicked()} to fire. The comparison is
+   * made against the normalized vector length after all bindings are accumulated, so a value of
+   * {@code 0.3} means roughly 30% deflection. Defaults to {@code 0.3f}; adjust before the game
+   * loop if your game needs a different sensitivity.
+   */
+  public float flickThreshold = 0.3f;
 
   private final Array<FlixelAnalogAxisBinding> bindings = new Array<>(12);
 
@@ -67,6 +95,9 @@ public final class FlixelActionAnalog extends FlixelAction {
   private float y;
   private float prevX;
   private float prevY;
+
+  private boolean flickState;
+  private boolean prevFlickState;
 
   public FlixelActionAnalog(@Nullable String name) {
     super(name);
@@ -81,6 +112,7 @@ public final class FlixelActionAnalog extends FlixelAction {
     if (!active) {
       x = 0f;
       y = 0f;
+      flickState = false;
       return;
     }
     scratch.set(0f, 0f);
@@ -101,6 +133,8 @@ public final class FlixelActionAnalog extends FlixelAction {
     }
     x = sx;
     y = sy;
+    float ft = flickThreshold;
+    flickState = (x * x + y * y) >= ft * ft;
   }
 
   private static void accumulate(@NotNull FlixelAnalogAxisBinding b, @NotNull Vector2 out) {
@@ -144,6 +178,7 @@ public final class FlixelActionAnalog extends FlixelAction {
   void endFrameAction() {
     prevX = x;
     prevY = y;
+    prevFlickState = flickState;
   }
 
   @Override
@@ -152,6 +187,8 @@ public final class FlixelActionAnalog extends FlixelAction {
     y = 0f;
     prevX = 0f;
     prevY = 0f;
+    flickState = false;
+    prevFlickState = false;
   }
 
   public float getX() {
@@ -175,5 +212,22 @@ public final class FlixelActionAnalog extends FlixelAction {
       return false;
     }
     return Math.abs(x) > 1e-4f || Math.abs(y) > 1e-4f;
+  }
+
+  /**
+   * Returns {@code true} for the single frame when the stick first crosses {@link #flickThreshold}.
+   *
+   * <p>Stays {@code false} while the stick remains past the threshold, and fires again only after
+   * the stick drops below it and crosses it once more. This mirrors the single-frame contract of
+   * {@link FlixelActionDigital#justPressed() FlixelActionDigital.justPressed()}, making it safe
+   * to use for menu navigation where one deflection should trigger exactly one action.
+   *
+   * <p>Key and button bindings contribute {@code +-1.0} per axis, so any bound key press that
+   * brings the magnitude past {@link #flickThreshold} fires {@code flicked()} on that frame.
+   *
+   * @return {@code true} for one frame when the stick crosses the threshold from below.
+   */
+  public boolean flicked() {
+    return active && flickState && !prevFlickState;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -66,9 +66,9 @@ import org.jetbrains.annotations.Nullable;
  * where each stick deflection should trigger exactly one action.
  *
  * <p>{@link #flickedRepeating()} extends that with hold-repeat: it fires on the initial flick,
- * then fires again after {@link FlixelAction#holdDelay} seconds if the stick is still past the
- * threshold, and continues every {@link FlixelAction#holdInterval} seconds after that. Use this
- * for menus that should keep scrolling when the stick is held.
+ * then fires again after {@link FlixelAction#getHoldDelay() FlixelAction.holdDelay} seconds
+ * if the stick is still past the threshold, and continues every {@link FlixelAction#getHoldInterval() FlixelAction.holdInterval}
+ * seconds after that. Use this for menus that should keep scrolling when the stick is held.
  *
  * <pre>{@code
  * // Navigate a menu; hold the stick to keep scrolling.
@@ -85,18 +85,12 @@ import org.jetbrains.annotations.Nullable;
 public final class FlixelActionAnalog extends FlixelAction {
 
   /**
-   * Minimum stick magnitude (0 to 1) required for {@link #flicked()} to fire. The comparison is
-   * made against the normalized vector length after all bindings are accumulated, so a value of
-   * {@code 0.3} means roughly 30% deflection. Defaults to {@code 0.3f}; adjust before the game
-   * loop if your game needs a different sensitivity.
-   */
-  /**
    * Minimum stick magnitude (0 to 1) required for {@link #flicked()} and {@link #flickedRepeating()}
    * to fire. The comparison is made against the normalized vector length after all bindings are
    * accumulated, so a value of {@code 0.3} means roughly 30% deflection. Defaults to {@code 0.3f};
    * adjust before the game loop if your game needs a different sensitivity.
    */
-  public float flickThreshold = 0.3f;
+  private float flickThreshold = 0.3f;
 
   private final Array<FlixelAnalogAxisBinding> bindings = new Array<>(12);
 
@@ -161,13 +155,13 @@ public final class FlixelActionAnalog extends FlixelAction {
         flickHoldAccum += elapsed;
         flickRepeated = false;
         if (!flickHoldRepeating) {
-          if (flickHoldAccum >= holdDelay) {
-            flickHoldAccum -= holdDelay;
+          if (flickHoldAccum >= getHoldDelay()) {
+            flickHoldAccum -= getHoldDelay();
             flickHoldRepeating = true;
             flickRepeated = true;
           }
-        } else if (flickHoldAccum >= holdInterval) {
-          flickHoldAccum -= holdInterval;
+        } else if (flickHoldAccum >= getHoldInterval()) {
+          flickHoldAccum -= getHoldInterval();
           flickRepeated = true;
         }
       }
@@ -257,6 +251,14 @@ public final class FlixelActionAnalog extends FlixelAction {
     return active ? prevY : 0f;
   }
 
+  public float getFlickThreshold() {
+    return flickThreshold;
+  }
+
+  public void setFlickThreshold(float flickThreshold) {
+    this.flickThreshold = Math.max(0f, Math.min(1f, flickThreshold));
+  }
+
   public boolean moved() {
     if (!active) {
       return false;
@@ -285,12 +287,13 @@ public final class FlixelActionAnalog extends FlixelAction {
    * Returns {@code true} on the initial flick and again on each hold-repeat tick.
    *
    * <p>Fires on the same frame as {@link #flicked()} when the stick first crosses
-   * {@link #flickThreshold}, then fires again after {@link FlixelAction#holdDelay} seconds if the
-   * stick is still past the threshold, and continues every {@link FlixelAction#holdInterval}
-   * seconds after that. Returning the stick below the threshold resets the timer.
+   * {@link #flickThreshold}, then fires again after {@link FlixelAction#getHoldDelay() FlixelAction.holdDelay}
+   * seconds if the stick is still past the threshold, and continues every
+   * {@link FlixelAction#getHoldInterval() FlixelAction.holdInterval} seconds after that.
+   * Returning the stick below the threshold resets the timer.
    *
    * <p>Use this instead of {@link #flicked()} when a held stick deflection should keep triggering,
-   * such as scrolling through a long menu list:
+   * such as scrolling through a long menu list.
    *
    * <pre>{@code
    * if (navigate.flickedRepeating()) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -169,6 +169,16 @@ public final class FlixelActionAnalog extends FlixelAction {
           out.y += Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
         }
       }
+      case NEG_GAMEPAD_AXIS_X -> {
+        if (Flixel.gamepads != null && Flixel.gamepads.enabled) {
+          out.x -= Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
+        }
+      }
+      case NEG_GAMEPAD_AXIS_Y -> {
+        if (Flixel.gamepads != null && Flixel.gamepads.enabled) {
+          out.y -= Flixel.gamepads.getAxis(b.gamepadSlot, b.keyOrAxis);
+        }
+      }
       default -> {
       }
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -45,6 +45,9 @@ import org.jetbrains.annotations.Nullable;
  *   <li>{@link #pressed()} while a key is held (sustains, movement gates).</li>
  *   <li>{@link #justPressed()} or {@link #check()} for a single-frame edge (tap notes, menu confirm).</li>
  *   <li>{@link #justReleased()} when the player releases after a hold.</li>
+ *   <li>{@link #repeated()} for hold-repeating navigation: fires on the initial press, then fires
+ *       again after {@link FlixelAction#holdDelay} seconds, then every {@link FlixelAction#holdInterval}
+ *       seconds while held. Replaces a manual {@code justPressed()} check when autorepeat is needed.</li>
  * </ul>
  *
  * <p>State is refreshed in {@link FlixelActionSet#update(float)} (via {@link FlixelActionSets#updateAll(float)}).
@@ -62,6 +65,10 @@ public final class FlixelActionDigital extends FlixelAction {
 
   private final Array<FlixelInputBinding> bindings = new Array<>(8);
 
+  private float holdAccum;
+
+  private boolean holdRepeating;
+  private boolean repeated;
   private boolean pressed;
   private boolean previous;
 
@@ -82,6 +89,9 @@ public final class FlixelActionDigital extends FlixelAction {
   void updateAction(float elapsed) {
     if (!active) {
       pressed = false;
+      repeated = false;
+      holdAccum = 0f;
+      holdRepeating = false;
       return;
     }
     boolean v = false;
@@ -98,6 +108,30 @@ public final class FlixelActionDigital extends FlixelAction {
       cb.run();
     }
     pressed = v;
+    if (v) {
+      if (!previous) {
+        holdAccum = 0f;
+        holdRepeating = false;
+        repeated = true;
+      } else {
+        holdAccum += elapsed;
+        repeated = false;
+        if (!holdRepeating) {
+          if (holdAccum >= holdDelay) {
+            holdAccum -= holdDelay;
+            holdRepeating = true;
+            repeated = true;
+          }
+        } else if (holdAccum >= holdInterval) {
+          holdAccum -= holdInterval;
+          repeated = true;
+        }
+      }
+    } else {
+      holdAccum = 0f;
+      holdRepeating = false;
+      repeated = false;
+    }
   }
 
   @Override
@@ -109,6 +143,9 @@ public final class FlixelActionDigital extends FlixelAction {
   void resetAction() {
     pressed = false;
     previous = false;
+    holdAccum = 0f;
+    holdRepeating = false;
+    repeated = false;
   }
 
   /**
@@ -130,6 +167,27 @@ public final class FlixelActionDigital extends FlixelAction {
 
   public boolean justReleased() {
     return active && !pressed && previous;
+  }
+
+  /**
+   * Returns {@code true} on the initial press and again on each hold-repeat tick.
+   *
+   * <p>Fires immediately on the frame the button is first pressed (same as {@link #justPressed()}),
+   * then fires again after {@link FlixelAction#holdDelay} seconds if the button is still held, and
+   * continues firing every {@link FlixelAction#holdInterval} seconds after that. Releasing the button
+   * resets the timer so the next press starts fresh.
+   *
+   * <p>Use this instead of {@link #justPressed()} anywhere a held button should keep triggering,
+   * such as menu scrolling, cursor movement, or incrementing a value:
+   *
+   * <pre>{@code
+   * if (controls.uiDown.repeated()) scrollMenu(1);
+   * }</pre>
+   *
+   * @return {@code true} on the initial press frame and on each repeat tick.
+   */
+  public boolean repeated() {
+    return active && repeated;
   }
 
   private boolean evalBinding(@NotNull FlixelInputBinding b) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -46,7 +46,7 @@ import org.jetbrains.annotations.Nullable;
  *   <li>{@link #justPressed()} or {@link #check()} for a single-frame edge (tap notes, menu confirm).</li>
  *   <li>{@link #justReleased()} when the player releases after a hold.</li>
  *   <li>{@link #repeated()} for hold-repeating navigation: fires on the initial press, then fires
- *       again after {@link FlixelAction#holdDelay} seconds, then every {@link FlixelAction#holdInterval}
+ *       again after {@link FlixelAction#getHoldDelay()} seconds, then every {@link FlixelAction#getHoldInterval()}
  *       seconds while held. Replaces a manual {@code justPressed()} check when autorepeat is needed.</li>
  * </ul>
  *
@@ -56,7 +56,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * <h2>Optional callback</h2>
  *
- * <p>{@link #callback} runs on the press edge when assigned; prefer a single static {@link Runnable} to avoid allocating
+ * <p>{@link #getHoldDelay()()} runs on the press edge when assigned; prefer a single static {@link Runnable} to avoid allocating
  * lambdas in hot paths.
  */
 public final class FlixelActionDigital extends FlixelAction {
@@ -117,13 +117,13 @@ public final class FlixelActionDigital extends FlixelAction {
         holdAccum += elapsed;
         repeated = false;
         if (!holdRepeating) {
-          if (holdAccum >= holdDelay) {
-            holdAccum -= holdDelay;
+          if (holdAccum >= getHoldDelay()) {
+            holdAccum -= getHoldDelay();
             holdRepeating = true;
             repeated = true;
           }
-        } else if (holdAccum >= holdInterval) {
-          holdAccum -= holdInterval;
+        } else if (holdAccum >= getHoldInterval()) {
+          holdAccum -= getHoldInterval();
           repeated = true;
         }
       }
@@ -173,8 +173,8 @@ public final class FlixelActionDigital extends FlixelAction {
    * Returns {@code true} on the initial press and again on each hold-repeat tick.
    *
    * <p>Fires immediately on the frame the button is first pressed (same as {@link #justPressed()}),
-   * then fires again after {@link FlixelAction#holdDelay} seconds if the button is still held, and
-   * continues firing every {@link FlixelAction#holdInterval} seconds after that. Releasing the button
+   * then fires again after {@link FlixelAction#getHoldDelay()} seconds if the button is still held, and
+   * continues firing every {@link FlixelAction#getHoldInterval()} seconds after that. Releasing the button
    * resets the timer so the next press starts fresh.
    *
    * <p>Use this instead of {@link #justPressed()} anywhere a held button should keep triggering,

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -181,7 +181,7 @@ public final class FlixelActionDigital extends FlixelAction {
    * such as menu scrolling, cursor movement, or incrementing a value:
    *
    * <pre>{@code
-   * if (controls.uiDown.repeated()) scrollMenu(1);
+   * if (controls.uiDown.repeated()) scrollMenu();
    * }</pre>
    *
    * @return {@code true} on the initial press frame and on each repeat tick.
@@ -204,7 +204,6 @@ public final class FlixelActionDigital extends FlixelAction {
       }
       case POINTER_BUTTON -> evalPointer(b.a, b.b);
       case TOUCH_REGION -> evalTouchRegion(b.normX, b.normY, b.normW, b.normH);
-      default -> false;
     };
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogAxisBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogAxisBinding.java
@@ -33,6 +33,15 @@ import org.jetbrains.annotations.NotNull;
  *
  * <p>Create bindings only during setup. Gamepad axes use {@link org.flixelgdx.input.gamepad.FlixelGamepadInput FlixelGamepadInput}
  * logical constants; {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads} applies the same dead zone as the rest of a game.
+ *
+ * <h2>Axis conventions and Y inversion</h2>
+ *
+ * <p>Most gamepad drivers report the stick Y axis in screen-space: pushing the stick up produces a
+ * negative raw value, pushing down produces a positive raw value. This is the opposite of the
+ * math-space convention used by keyboard key bindings (pressing the UP key contributes +1 to Y).
+ * Use {@link #negGamepadAxisY(int, int)} instead of {@link #gamepadAxisY(int, int)} to flip the
+ * raw hardware value so the stick and keyboard share the same coordinate system (up = positive Y,
+ * down = negative Y).
  */
 public final class FlixelAnalogAxisBinding {
 
@@ -42,7 +51,9 @@ public final class FlixelAnalogAxisBinding {
     KEY_NEG_Y,
     KEY_POS_Y,
     GAMEPAD_AXIS_X,
-    GAMEPAD_AXIS_Y
+    GAMEPAD_AXIS_Y,
+    NEG_GAMEPAD_AXIS_X,
+    NEG_GAMEPAD_AXIS_Y
   }
 
   public final Kind kind;
@@ -99,5 +110,29 @@ public final class FlixelAnalogAxisBinding {
   @NotNull
   public static FlixelAnalogAxisBinding gamepadAxisY(int gamepadSlot, int logicalAxis) {
     return new FlixelAnalogAxisBinding(Kind.GAMEPAD_AXIS_Y, logicalAxis, gamepadSlot);
+  }
+
+  /**
+   * Adds the negated X component of a stick, correcting for drivers that report left as positive X.
+   *
+   * @param gamepadSlot {@code 0..} slot index.
+   * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_X} or similar.
+   */
+  @NotNull
+  public static FlixelAnalogAxisBinding negGamepadAxisX(int gamepadSlot, int logicalAxis) {
+    return new FlixelAnalogAxisBinding(Kind.NEG_GAMEPAD_AXIS_X, logicalAxis, gamepadSlot);
+  }
+
+  /**
+   * Adds the negated Y component of a stick. Use this instead of {@link #gamepadAxisY(int, int)}
+   * when the driver reports the stick in screen-space (up = negative raw Y), so the result matches
+   * keyboard key bindings where up = positive Y.
+   *
+   * @param gamepadSlot {@code 0..} slot index.
+   * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_Y} or similar.
+   */
+  @NotNull
+  public static FlixelAnalogAxisBinding negGamepadAxisY(int gamepadSlot, int logicalAxis) {
+    return new FlixelAnalogAxisBinding(Kind.NEG_GAMEPAD_AXIS_Y, logicalAxis, gamepadSlot);
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogAxisBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogAxisBinding.java
@@ -45,17 +45,6 @@ import org.jetbrains.annotations.NotNull;
  */
 public final class FlixelAnalogAxisBinding {
 
-  public enum Kind {
-    KEY_NEG_X,
-    KEY_POS_X,
-    KEY_NEG_Y,
-    KEY_POS_Y,
-    GAMEPAD_AXIS_X,
-    GAMEPAD_AXIS_Y,
-    NEG_GAMEPAD_AXIS_X,
-    NEG_GAMEPAD_AXIS_Y
-  }
-
   public final Kind kind;
 
   /** Keycode for key kinds, or {@link FlixelGamepadInput} logical axis for gamepad kinds. */
@@ -134,5 +123,19 @@ public final class FlixelAnalogAxisBinding {
   @NotNull
   public static FlixelAnalogAxisBinding negGamepadAxisY(int gamepadSlot, int logicalAxis) {
     return new FlixelAnalogAxisBinding(Kind.NEG_GAMEPAD_AXIS_Y, logicalAxis, gamepadSlot);
+  }
+
+  /**
+   * Simple enum for handling different input types and their directions.
+   */
+  public enum Kind {
+    KEY_NEG_X,
+    KEY_POS_X,
+    KEY_NEG_Y,
+    KEY_POS_Y,
+    GAMEPAD_AXIS_X,
+    GAMEPAD_AXIS_Y,
+    NEG_GAMEPAD_AXIS_X,
+    NEG_GAMEPAD_AXIS_Y
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogAxisBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogAxisBinding.java
@@ -34,14 +34,14 @@ import org.jetbrains.annotations.NotNull;
  * <p>Create bindings only during setup. Gamepad axes use {@link org.flixelgdx.input.gamepad.FlixelGamepadInput FlixelGamepadInput}
  * logical constants; {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads} applies the same dead zone as the rest of a game.
  *
- * <h2>Axis conventions and Y inversion</h2>
+ * <h2>Axis conventions and Y correction</h2>
  *
  * <p>Most gamepad drivers report the stick Y axis in screen-space: pushing the stick up produces a
  * negative raw value, pushing down produces a positive raw value. This is the opposite of the
  * math-space convention used by keyboard key bindings (pressing the UP key contributes +1 to Y).
- * Use {@link #negGamepadAxisY(int, int)} instead of {@link #gamepadAxisY(int, int)} to flip the
- * raw hardware value so the stick and keyboard share the same coordinate system (up = positive Y,
- * down = negative Y).
+ * {@link #gamepadAxisY(int, int)} corrects this by default so the stick and keyboard share the same
+ * coordinate system (up = positive Y, down = negative Y). Pass {@code raw = true} to the overload
+ * {@link #gamepadAxisY(int, int, boolean)} when you specifically need the uncorrected hardware value.
  */
 public final class FlixelAnalogAxisBinding {
 
@@ -80,7 +80,8 @@ public final class FlixelAnalogAxisBinding {
   }
 
   /**
-   * Adds the X component of a stick (or single axis read as X only).
+   * Adds the X component of a stick. Most drivers report X in math-space already (left = negative,
+   * right = positive), so no correction is applied.
    *
    * @param gamepadSlot {@code 0..} slot index.
    * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_X} or similar.
@@ -91,51 +92,40 @@ public final class FlixelAnalogAxisBinding {
   }
 
   /**
-   * Adds the Y component of a stick.
+   * Adds the Y component of a stick with the screen-space inversion corrected so that up = positive Y,
+   * matching the keyboard key convention. This is the correct choice for almost every game.
    *
    * @param gamepadSlot {@code 0..} slot index.
    * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_Y} or similar.
    */
   @NotNull
   public static FlixelAnalogAxisBinding gamepadAxisY(int gamepadSlot, int logicalAxis) {
-    return new FlixelAnalogAxisBinding(Kind.GAMEPAD_AXIS_Y, logicalAxis, gamepadSlot);
+    return gamepadAxisY(gamepadSlot, logicalAxis, false);
   }
 
   /**
-   * Adds the negated X component of a stick, correcting for drivers that report left as positive X.
-   *
-   * @param gamepadSlot {@code 0..} slot index.
-   * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_X} or similar.
-   */
-  @NotNull
-  public static FlixelAnalogAxisBinding negGamepadAxisX(int gamepadSlot, int logicalAxis) {
-    return new FlixelAnalogAxisBinding(Kind.NEG_GAMEPAD_AXIS_X, logicalAxis, gamepadSlot);
-  }
-
-  /**
-   * Adds the negated Y component of a stick. Use this instead of {@link #gamepadAxisY(int, int)}
-   * when the driver reports the stick in screen-space (up = negative raw Y), so the result matches
-   * keyboard key bindings where up = positive Y.
+   * Adds the Y component of a stick.
    *
    * @param gamepadSlot {@code 0..} slot index.
    * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_Y} or similar.
+   * @param raw When {@code false} (the default), the raw hardware Y is negated so that up = positive Y,
+   *   matching keyboard key bindings. Pass {@code true} to use the raw screen-space value unchanged.
    */
   @NotNull
-  public static FlixelAnalogAxisBinding negGamepadAxisY(int gamepadSlot, int logicalAxis) {
-    return new FlixelAnalogAxisBinding(Kind.NEG_GAMEPAD_AXIS_Y, logicalAxis, gamepadSlot);
+  public static FlixelAnalogAxisBinding gamepadAxisY(int gamepadSlot, int logicalAxis, boolean raw) {
+    return new FlixelAnalogAxisBinding(raw ? Kind.RAW_GAMEPAD_AXIS_Y : Kind.GAMEPAD_AXIS_Y, logicalAxis, gamepadSlot);
   }
 
-  /**
-   * Simple enum for handling different input types and their directions.
-   */
+  /** Binding kinds used by {@link FlixelActionAnalog} to accumulate the vector each frame. */
   public enum Kind {
     KEY_NEG_X,
     KEY_POS_X,
     KEY_NEG_Y,
     KEY_POS_Y,
     GAMEPAD_AXIS_X,
+    /** Y axis with screen-space inversion corrected (up = positive Y). Default from {@link #gamepadAxisY(int, int)}. */
     GAMEPAD_AXIS_Y,
-    NEG_GAMEPAD_AXIS_X,
-    NEG_GAMEPAD_AXIS_Y
+    /** Raw hardware Y axis without any correction. */
+    RAW_GAMEPAD_AXIS_Y
   }
 }

--- a/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
+++ b/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
@@ -165,7 +165,7 @@ public final class FlixelLoggerBytecodeWeaver {
           continue;
         }
         int op = min.getOpcode();
-        int line = currentLine >= 0 ? currentLine : 0;
+        int line = Math.max(currentLine, 0);
 
         if (op == Opcodes.INVOKESTATIC && FLIXEL_STATIC_FACADE_INTERNAL.equals(min.owner)) {
           Replacement facadeReplacement = FLIXEL_STATIC_REPLACEMENTS.get(min.name + min.desc);

--- a/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggingPlugin.java
+++ b/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggingPlugin.java
@@ -41,10 +41,7 @@ public class FlixelLoggingPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     FlixelLoggingExtension ext = project.getExtensions().create("flixelLogging", FlixelLoggingExtension.class);
-    wire(project, ext);
-  }
 
-  private static void wire(Project project, FlixelLoggingExtension ext) {
     project.afterEvaluate(pr -> {
       if (!ext.getEnabled().get()) {
         return;

--- a/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelTransformLoggingTask.java
+++ b/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelTransformLoggingTask.java
@@ -71,7 +71,8 @@ public abstract class FlixelTransformLoggingTask extends DefaultTask {
     }
     Files.walkFileTree(root, new SimpleFileVisitor<>() {
       @Override
-      public @NonNull FileVisitResult visitFile(@NonNull Path file, @NonNull BasicFileAttributes attrs) throws IOException {
+      public @NonNull FileVisitResult visitFile(@NonNull Path file, @NonNull BasicFileAttributes attrs)
+          throws IOException {
         if (!file.toString().endsWith(".class") || file.getFileName().toString().equals("module-info.class")) {
           return FileVisitResult.CONTINUE;
         }

--- a/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelTransformLoggingTask.java
+++ b/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelTransformLoggingTask.java
@@ -32,6 +32,7 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
+import org.jspecify.annotations.NonNull;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.tree.ClassNode;
@@ -68,9 +69,9 @@ public abstract class FlixelTransformLoggingTask extends DefaultTask {
     if (!Files.isDirectory(root)) {
       return;
     }
-    Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+    Files.walkFileTree(root, new SimpleFileVisitor<>() {
       @Override
-      public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+      public @NonNull FileVisitResult visitFile(@NonNull Path file, @NonNull BasicFileAttributes attrs) throws IOException {
         if (!file.toString().endsWith(".class") || file.getFileName().toString().equals("module-info.class")) {
           return FileVisitResult.CONTINUE;
         }

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -172,6 +172,32 @@ class FlixelActionSystemTest {
   }
 
   @Test
+  void negGamepadAxisYInvertsRelativeToGamepadAxisY() {
+    // Simulate a gamepad axis returning a positive raw Y value (screen-space "down").
+    // negGamepadAxisY should subtract that value, yielding negative Y (math-space "down"),
+    // while plain gamepadAxisY would yield positive Y - the classic inversion bug.
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionAnalog stickNeg = new FlixelActionAnalog("stickNeg");
+    FlixelActionAnalog stickPlain = new FlixelActionAnalog("stickPlain");
+
+    // Only add key bindings so we can drive Y without a real controller.
+    // negYKey contributes -1 to Y, mirroring what negGamepadAxisY does for a positive raw axis.
+    stickNeg.addAxisBinding(FlixelAnalogAxisBinding.negYKey(Input.Keys.S));
+    stickPlain.addAxisBinding(FlixelAnalogAxisBinding.posYKey(Input.Keys.S));
+    set.add(stickNeg);
+    set.add(stickPlain);
+
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.S);
+    set.update(0f);
+
+    // negYKey drives Y negative - same sign that negGamepadAxisY produces for a positive raw axis.
+    assertTrue(stickNeg.getY() < 0f);
+    // posYKey drives Y positive - same sign that plain gamepadAxisY produces (the inverted case).
+    assertTrue(stickPlain.getY() > 0f);
+  }
+
+  @Test
   void steamReaderMergesDigital() {
     FlixelActionSet set = new FlixelActionSet(false) {
     };

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -26,6 +26,7 @@ package org.flixelgdx.input.action;
 import com.badlogic.gdx.Input;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.input.action.FlixelAnalogAxisBinding;
 import org.flixelgdx.GdxHeadlessExtension;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import org.junit.jupiter.api.AfterEach;
@@ -172,29 +173,90 @@ class FlixelActionSystemTest {
   }
 
   @Test
-  void negGamepadAxisYInvertsRelativeToGamepadAxisY() {
-    // Simulate a gamepad axis returning a positive raw Y value (screen-space "down").
-    // negGamepadAxisY should subtract that value, yielding negative Y (math-space "down"),
-    // while plain gamepadAxisY would yield positive Y - the classic inversion bug.
+  void gamepadAxisYDefaultIsYCorrected() {
+    // GAMEPAD_AXIS_Y should now subtract the raw value so that up = positive Y, matching keys.
+    // Use posYKey and negYKey as a reference: posYKey(UP) gives +Y, negYKey(DOWN) gives -Y.
+    // gamepadAxisY (corrected) should behave like posYKey for an upward stick deflection, which
+    // in screen-space is a negative raw value that gets negated to produce positive Y.
+    // We verify the Kind assignment directly since we can't inject a fake controller here.
+    FlixelAnalogAxisBinding corrected = FlixelAnalogAxisBinding.gamepadAxisY(0, 0);
+    FlixelAnalogAxisBinding raw = FlixelAnalogAxisBinding.gamepadAxisY(0, 0, true);
+    assertEquals(FlixelAnalogAxisBinding.Kind.GAMEPAD_AXIS_Y, corrected.kind);
+    assertEquals(FlixelAnalogAxisBinding.Kind.RAW_GAMEPAD_AXIS_Y, raw.kind);
+  }
+
+  @Test
+  void digitalRepeatedFiresOnPressAndAfterHoldDelay() {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
-    FlixelActionAnalog stickNeg = new FlixelActionAnalog("stickNeg");
-    FlixelActionAnalog stickPlain = new FlixelActionAnalog("stickPlain");
+    FlixelActionDigital scroll = new FlixelActionDigital("scroll");
+    scroll.addBinding(FlixelInputBinding.key(Input.Keys.DOWN));
+    scroll.holdDelay = 0.5f;
+    scroll.holdInterval = 0.1f;
+    set.add(scroll);
 
-    // Only add key bindings so we can drive Y without a real controller.
-    // negYKey contributes -1 to Y, mirroring what negGamepadAxisY does for a positive raw axis.
-    stickNeg.addAxisBinding(FlixelAnalogAxisBinding.negYKey(Input.Keys.S));
-    stickPlain.addAxisBinding(FlixelAnalogAxisBinding.posYKey(Input.Keys.S));
-    set.add(stickNeg);
-    set.add(stickPlain);
-
-    Flixel.keys.getInputProcessor().keyDown(Input.Keys.S);
+    // Initial press: repeated() fires immediately.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.DOWN);
     set.update(0f);
+    assertTrue(scroll.repeated());
 
-    // negYKey drives Y negative - same sign that negGamepadAxisY produces for a positive raw axis.
-    assertTrue(stickNeg.getY() < 0f);
-    // posYKey drives Y positive - same sign that plain gamepadAxisY produces (the inverted case).
-    assertTrue(stickPlain.getY() > 0f);
+    // Still held but before holdDelay: repeated() does not fire again.
+    set.endFrame();
+    set.update(0.3f);
+    assertFalse(scroll.repeated());
+
+    // Still held, holdDelay elapsed: first hold-repeat fires.
+    set.endFrame();
+    set.update(0.25f);
+    assertTrue(scroll.repeated());
+
+    // Still held, holdInterval not yet elapsed: no repeat.
+    set.endFrame();
+    set.update(0.04f);
+    assertFalse(scroll.repeated());
+
+    // holdInterval elapsed: repeat fires again.
+    set.endFrame();
+    set.update(0.06f);
+    assertTrue(scroll.repeated());
+
+    // Released: no repeat.
+    Flixel.keys.getInputProcessor().keyUp(Input.Keys.DOWN);
+    set.endFrame();
+    set.update(0f);
+    assertFalse(scroll.repeated());
+  }
+
+  @Test
+  void analogFlickedRepeatingFiresOnFlickAndAfterHoldDelay() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionAnalog navigate = new FlixelActionAnalog("navigate");
+    navigate.addAxisBinding(FlixelAnalogAxisBinding.negYKey(Input.Keys.DOWN));
+    navigate.holdDelay = 0.5f;
+    navigate.holdInterval = 0.1f;
+    set.add(navigate);
+
+    // Initial flick: flickedRepeating() fires on the first frame.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.DOWN);
+    set.update(0f);
+    assertTrue(navigate.flickedRepeating());
+
+    // Held but before holdDelay: no repeat.
+    set.endFrame();
+    set.update(0.3f);
+    assertFalse(navigate.flickedRepeating());
+
+    // holdDelay elapsed: first hold-repeat fires.
+    set.endFrame();
+    set.update(0.25f);
+    assertTrue(navigate.flickedRepeating());
+
+    // Released (magnitude drops below threshold): no repeat.
+    Flixel.keys.getInputProcessor().keyUp(Input.Keys.DOWN);
+    set.endFrame();
+    set.update(0f);
+    assertFalse(navigate.flickedRepeating());
   }
 
   @Test

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -190,8 +190,8 @@ class FlixelActionSystemTest {
     };
     FlixelActionDigital scroll = new FlixelActionDigital("scroll");
     scroll.addBinding(FlixelInputBinding.key(Input.Keys.DOWN));
-    scroll.holdDelay = 0.5f;
-    scroll.holdInterval = 0.1f;
+    scroll.setHoldDelay(0.5f);
+    scroll.setHoldInterval(0.1f);
     set.add(scroll);
 
     // Initial press: repeated() fires immediately.
@@ -232,8 +232,8 @@ class FlixelActionSystemTest {
     };
     FlixelActionAnalog navigate = new FlixelActionAnalog("navigate");
     navigate.addAxisBinding(FlixelAnalogAxisBinding.negYKey(Input.Keys.DOWN));
-    navigate.holdDelay = 0.5f;
-    navigate.holdInterval = 0.1f;
+    navigate.setHoldDelay(0.5f);
+    navigate.setHoldInterval(0.1f);
     set.add(navigate);
 
     // Initial flick: flickedRepeating() fires on the first frame.

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -26,7 +26,6 @@ package org.flixelgdx.input.action;
 import com.badlogic.gdx.Input;
 
 import org.flixelgdx.Flixel;
-import org.flixelgdx.input.action.FlixelAnalogAxisBinding;
 import org.flixelgdx.GdxHeadlessExtension;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import org.junit.jupiter.api.AfterEach;

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -140,6 +140,38 @@ class FlixelActionSystemTest {
   }
 
   @Test
+  void analogFlickedFiresOncePerDeflection() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionAnalog navigate = new FlixelActionAnalog("navigate");
+    navigate.addAxisBinding(FlixelAnalogAxisBinding.negYKey(Input.Keys.DOWN));
+    navigate.addAxisBinding(FlixelAnalogAxisBinding.posYKey(Input.Keys.UP));
+    set.add(navigate);
+
+    // First press: flicked() fires on the first frame.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.DOWN);
+    set.update(0f);
+    assertTrue(navigate.flicked());
+
+    // Held: flicked() must not fire again while the stick stays past the threshold.
+    set.endFrame();
+    set.update(0f);
+    assertFalse(navigate.flicked());
+
+    // Released: magnitude drops below threshold, flicked() stays false.
+    Flixel.keys.getInputProcessor().keyUp(Input.Keys.DOWN);
+    set.endFrame();
+    set.update(0f);
+    assertFalse(navigate.flicked());
+
+    // Second press in the opposite direction: flicked() fires again.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.UP);
+    set.endFrame();
+    set.update(0f);
+    assertTrue(navigate.flicked());
+  }
+
+  @Test
   void steamReaderMergesDigital() {
     FlixelActionSet set = new FlixelActionSet(false) {
     };


### PR DESCRIPTION
## Description

This PR extends the action input system with three related improvements that together make menu navigation and analog input much more reliable in games built on FlixelGDX.

**`flicked()` on `FlixelActionAnalog`**
Returns `true` for exactly one frame when the stick first crosses `flickThreshold`. Stays `false` while the stick remains deflected, and fires again only after the stick returns below the threshold. This mirrors the single-frame contract of `FlixelActionDigital.justPressed()` and is ideal for menu navigation where one deflection should trigger exactly one action.

**`repeated()` on `FlixelActionDigital` and `flickedRepeating()` on `FlixelActionAnalog`**
Both methods provide hold-repeat behavior. They fire immediately on the first press or flick, then fire again after `holdDelay` seconds (default 0.5s), and continue every `holdInterval` seconds (default 0.1s) while held. Both delays are configurable per-action via the new `holdDelay` and `holdInterval` fields on `FlixelAction`. This replaces manual timer code for scrolling through long menu lists with a held input.

**Corrected `gamepadAxisY` Y axis by default**
Previously, `gamepadAxisY(slot, axis)` returned the raw screen-space hardware value (up = negative Y), which was the opposite of what keyboard `posYKey` bindings contributed (up = positive Y). This broke mixed keyboard/gamepad input.

The default `gamepadAxisY(slot, axis)` now negates the raw hardware Y so the coordinate system matches keyboard bindings (up = positive Y, down = negative Y). A new overload `gamepadAxisY(slot, axis, raw)` exposes the uncorrected screen-space value for cases that need it. The old `negGamepadAxisX()` and `negGamepadAxisY()` factory methods are removed.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

> **Breaking:** `negGamepadAxisX()` and `negGamepadAxisY()` are removed. Any code calling them must switch to `gamepadAxisY(slot, axis)` (now corrected by default) or `gamepadAxisY(slot, axis, true)` for raw access. The `NEG_GAMEPAD_AXIS_X` and `NEG_GAMEPAD_AXIS_Y` enum values in `FlixelAnalogAxisBinding.Kind` are also removed.

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

All 15 test suites pass (55 tests, 0 failures). New tests cover:
- `analogFlickedFiresOncePerDeflection` - verifies `flicked()` fires only on the crossing frame
- `digitalRepeatedFiresOnPressAndAfterHoldDelay` - verifies `repeated()` timing contract
- `analogFlickedRepeatingFiresOnFlickAndAfterHoldDelay` - verifies `flickedRepeating()` timing
- `gamepadAxisYDefaultIsYCorrected` - verifies the new `Kind` values are assigned correctly