### PR TITLE
Fixed logging plugin not weaving Kotlin projects, resolving unknown:0 in TeaVM web builds

### DIFF
--- a/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
+++ b/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggerBytecodeWeaver.java
@@ -149,7 +149,7 @@ public final class FlixelLoggerBytecodeWeaver {
       return false;
     }
     boolean changed = false;
-    String sourceFile = classNode.sourceFile != null ? classNode.sourceFile : "UnknownFile.java";
+    String sourceFile = classNode.sourceFile != null ? classNode.sourceFile : "UnknownFile";
     String classNameDots = classNode.name.replace('/', '.');
     for (MethodNode method : classNode.methods) {
       if (method.instructions == null || method.instructions.size() == 0) {

--- a/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggingPlugin.java
+++ b/flixelgdx-logging-plugin/src/main/java/org/flixelgdx/gradle/logging/FlixelLoggingPlugin.java
@@ -25,6 +25,7 @@ package org.flixelgdx.gradle.logging;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.tasks.compile.AbstractCompile;
 
 import java.io.IOException;
@@ -32,9 +33,12 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 
 /**
- * Registers a finalize step after each {@link AbstractCompile} task (covers both
- * {@code compileJava} and {@code compileKotlin}) that rewrites {@code FlixelLogger}
+ * Registers a finalize step after each compile task that rewrites {@code FlixelLogger}
  * invocations to {@code *WithSite} overloads so stack traces carry accurate file/line info.
+ *
+ * <p>Both {@link AbstractCompile} tasks (Java) and Kotlin compile tasks are covered. Kotlin
+ * compile tasks stopped extending {@link AbstractCompile} in KGP 2.x, so they are detected
+ * by walking the class hierarchy and matched by name to avoid a compile-time KGP dependency.
  */
 public class FlixelLoggingPlugin implements Plugin<Project> {
 
@@ -46,6 +50,7 @@ public class FlixelLoggingPlugin implements Plugin<Project> {
       if (!ext.getEnabled().get()) {
         return;
       }
+
       pr.getTasks().withType(AbstractCompile.class).configureEach(compile -> compile.doLast(task -> {
         Path root = compile.getDestinationDirectory().get().getAsFile().toPath();
         try {
@@ -54,6 +59,39 @@ public class FlixelLoggingPlugin implements Plugin<Project> {
           throw new UncheckedIOException(e);
         }
       }));
+
+      // KGP 2.x KotlinCompile doesn't extend AbstractCompile, so we hook it separately.
+      // Skip tasks already covered by the AbstractCompile hook above to avoid double-weaving.
+      pr.getTasks().configureEach(task -> {
+        if (task instanceof AbstractCompile || !isKotlinCompileTask(task.getClass())) {
+          return;
+        }
+        task.doLast(t -> {
+          try {
+            DirectoryProperty destDir = (DirectoryProperty) task.getClass()
+                .getMethod("getDestinationDirectory")
+                .invoke(task);
+            Path root = destDir.get().getAsFile().toPath();
+            FlixelTransformLoggingTask.weaveDirectory(root, ext.getVerbose().get(), t.getLogger());
+          } catch (ReflectiveOperationException e) {
+            task.getLogger().warn("Flixel logging: could not get destination directory for '{}'", task.getName(), e);
+          } catch (IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+      });
     });
+  }
+
+  private static boolean isKotlinCompileTask(Class<?> cls) {
+    while (cls != null && !Object.class.equals(cls)) {
+      String name = cls.getName();
+      if (name.equals("org.jetbrains.kotlin.gradle.tasks.KotlinCompile")
+          || name.equals("org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon")) {
+        return true;
+      }
+      cls = cls.getSuperclass();
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Description

The logging plugin hook used `withType(AbstractCompile.class)` to intercept compile output and run the bytecode weaver. In KGP 2.x, `KotlinCompile` was reparented away from `AbstractCompile`, so Kotlin projects silently produced no weaving at all. This was most visible in TeaVM web builds where every log showed `unknown:0` in the JavaScript console, since TeaVM has no stack walking and depends entirely on the baked-in site metadata.

Changes:
- `FlixelLoggingPlugin`: adds a second `configureEach` block that detects Kotlin compile tasks by walking the class hierarchy and matching `org.jetbrains.kotlin.gradle.tasks.KotlinCompile` / `KotlinCompileCommon` by name. This avoids adding KGP as a compile-time dependency on the plugin. An `instanceof AbstractCompile` guard prevents double-weaving on older KGP versions where `KotlinCompile` still extended `AbstractCompile`.
- `FlixelLoggerBytecodeWeaver`: changed the missing-`SourceFile` fallback from `"UnknownFile.java"` to `"UnknownFile"`, since Kotlin source files are `.kt`, not `.java`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - the bug manifests at runtime in a separate test project consuming the plugin. The fix is verified by code review and successful compilation/Javadoc checks.