### PR TITLE
Fixed FlixelAnimateSprite folder path loading not working when compiled to a JAR

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -185,11 +185,16 @@ public class FlixelAnimateSprite extends FlixelSprite {
   public FlixelAnimateSprite addSpritemapAndAnimation(String path) {
     Objects.requireNonNull(defaultSpritemapName, "defaultSpritemapName cannot be null.");
     Objects.requireNonNull(defaultAnimationName, "defaultAnimationName cannot be null.");
-    if (!Gdx.files.internal(path).isDirectory()) {
-      throw new IllegalArgumentException("The provided path is either not a real folder, or doesn't exist.");
+    String pngPath = path + "/" + defaultSpritemapName + ".png";
+    String spritemapJsonPath = path + "/" + defaultSpritemapName + ".json";
+    String animationJsonPath = path + "/" + defaultAnimationName + ".json";
+    if (!Gdx.files.internal(pngPath).exists()
+        || !Gdx.files.internal(spritemapJsonPath).exists()
+        || !Gdx.files.internal(animationJsonPath).exists()) {
+      throw new IllegalArgumentException(
+          "The provided path is either not a real folder, one of the required files is missing, or doesn't exist.");
     }
-    return addSpritemapAndAnimation(path + "/" + defaultSpritemapName + ".png",
-        path + "/" + defaultSpritemapName + ".json", path + "/" + defaultAnimationName + ".json");
+    return addSpritemapAndAnimation(pngPath, spritemapJsonPath, animationJsonPath);
   }
 
   /**


### PR DESCRIPTION
## Description

`FlixelAnimateSprite.addSpritemapAndAnimation(String path)` threw an `IllegalArgumentException` at line 189 when the game was compiled to a JAR, even with a valid asset path. The root cause was that the validation used `Gdx.files.internal(path).isDirectory()`, which internally calls `File.isDirectory()` on the real filesystem. When assets are bundled inside a JAR, they only exist as classpath entries — there is no actual directory on disk — so `isDirectory()` always returned `false` and the exception fired before any loading happened.

The fix replaces the directory check with existence checks on each of the three individual expected files (`spritemap1.png`, `spritemap1.json`, `Animation.json`). `FileHandle.exists()` resolves through the classpath and works correctly both during development (files on disk) and at runtime inside a JAR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Stack trace from the test project when compiled to a JAR:

```
Exception: java.lang.IllegalArgumentException: The provided path is either not a real folder, or doesn't exist.
Location: FILE=FlixelAnimateSprite.java, CLASS=org.flixelgdx.animation.FlixelAnimateSprite, METHOD=addSpritemapAndAnimation(), LINE=189
```