### PR TITLE
Bundle native .so extraction into flixelgdx-android

### DIFF
--- a/flixelgdx-android/build.gradle
+++ b/flixelgdx-android/build.gradle
@@ -42,6 +42,29 @@ ${keepRules}
   }
 }
 
+// Native artifact coordinates shared between the "api" configuration (Java/Kotlin classpath)
+// and the "natives" configuration (raw .so extraction below). libGDX's native platform jars
+// store .so files at the jar root rather than under jni/<abi>/, so AGP's automatic AAR
+// packaging cannot find them there. copyAndroidNatives unpacks them into this module's own
+// jniLibs source set so they end up in the AAR's standard jni/<abi>/ layout, letting consumers
+// depend on flixelgdx-android alone instead of re-declaring every native artifact themselves.
+def androidNativeCoordinates = [
+  "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-armeabi-v7a",
+  "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-arm64-v8a",
+  "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-x86",
+  "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-x86_64",
+  "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-arm64-v8a",
+  "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi-v7a",
+  "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86",
+  "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86_64",
+  "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-arm64-v8a",
+  "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a",
+  "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86",
+  "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86_64"
+]
+
+def nativesOutputDir = layout.buildDirectory.dir("jniLibs")
+
 android {
   namespace "org.flixelgdx"
   compileSdk 36
@@ -64,6 +87,11 @@ android {
     sourceCompatibility JavaVersion.VERSION_17
     targetCompatibility JavaVersion.VERSION_17
   }
+  sourceSets {
+    main {
+      jniLibs.srcDirs = [nativesOutputDir.get().asFile.path]
+    }
+  }
 }
 
 tasks.matching { it.name == "preBuild" }.configureEach {
@@ -77,6 +105,7 @@ repositories {
 
 configurations {
   coreLibraryDesugaring
+  natives
 }
 
 dependencies {
@@ -84,20 +113,51 @@ dependencies {
 
   api project(':flixelgdx-core')
   api "androidx.multidex:multidex:2.0.1"
-  api "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-armeabi-v7a"
-  api "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-arm64-v8a"
-  api "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-x86"
-  api "games.rednblack.miniaudio:gdx-miniaudio-platform:$miniaudioVersion:natives-x86_64"
-  api "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-arm64-v8a"
-  api "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-armeabi-v7a"
-  api "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86"
-  api "com.badlogicgames.gdx:gdx-freetype-platform:$gdxVersion:natives-x86_64"
-  api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-arm64-v8a"
-  api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a"
-  api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86"
-  api "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-x86_64"
+  androidNativeCoordinates.each { coordinates ->
+    add("api", coordinates)
+    add("natives", coordinates)
+  }
   api "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
   api "com.badlogicgames.gdx-controllers:gdx-controllers-android:$gdxControllersVersion"
+}
+
+// Unpacks the .so files bundled at the root of libGDX's native platform jars into this
+// module's own jniLibs source set (see androidNativeCoordinates above for why).
+def copyAndroidNatives = tasks.register("copyAndroidNatives") {
+  inputs.files(configurations.natives)
+  outputs.dir(nativesOutputDir)
+
+  doFirst {
+    def abiMap = [
+      'armeabi-v7a': 'natives-armeabi-v7a',
+      'arm64-v8a'  : 'natives-arm64-v8a',
+      'x86'        : 'natives-x86',
+      'x86_64'     : 'natives-x86_64'
+    ]
+    configurations.natives.copy().files.each { jar ->
+      def destAbi = abiMap.find { _, suffix -> jar.name.endsWith("${suffix}.jar") }?.key
+      if (destAbi != null) {
+        def destDir = nativesOutputDir.get().dir(destAbi).asFile
+        destDir.mkdirs()
+        copy {
+          from zipTree(jar)
+          into destDir
+          include "*.so"
+        }
+      }
+    }
+  }
+}
+
+afterEvaluate {
+  android.libraryVariants.all { variant ->
+    def capitalized = variant.name.capitalize()
+    def mergeJniTask = tasks.findByName("merge${capitalized}JniLibFolders")
+    if (mergeJniTask != null) {
+      mergeJniTask.dependsOn(copyAndroidNatives)
+    }
+    variant.assembleProvider.get().dependsOn(copyAndroidNatives)
+  }
 }
 
 apply plugin: 'maven-publish'


### PR DESCRIPTION
## Description

Follow-up to #244. Bundles the framework's own Android native `.so` dependencies (miniaudio, freetype, gdx core) directly into `flixelgdx-android`'s AAR at build time, mirroring how `flixelgdx-lwjgl3` already auto-injects its native dependencies. Consumers no longer need to hand-roll native extraction in their own `android/build.gradle`.

Verified on a physical device via the `funkin` test project (composite build): natives loaded correctly, app launched with no crashes.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **platform/android** branch (follow-up to #244, not a develop-facing change).
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Verified via `unzip -l flixelgdx-android-debug.aar | grep .so` showing `jni/<abi>/lib{gdx,gdx-freetype,gdx-miniaudio}.so` for all 4 ABIs, and a real install/launch on a connected Android device.