### PR TITLE
Added a new video extension to allow video playback in games for things like cutscenes

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -29,7 +29,7 @@ jobs:
         shell: bash
 
   test:
-    name: Unit tests (JVM)
+    name: Unit tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -10,26 +10,13 @@ The project is split into several modules, each serving a specific purpose:
 - **`flixelgdx-common`**: Shared code that multiple JVM-family backends can use without pulling in LWJGL3 or TeaVM. This includes the MiniAudio-based sound handler used by desktop, Android, and iOS launchers.
 - **`flixelgdx-lwjgl3`**: The primary desktop backend using the third release of the **[Lightweight Java Game Library](https://www.lwjgl.org/)**. When you create a desktop launcher with FlixelGDX, this is the module that provides the actual `Lwjgl3Application`.
 - **`flixelgdx-android`**: The backend for Android devices. This integrates FlixelGDX with libGDX's Android launcher and lifecycle.
-- **`flixelgdx-ios`**: The backend for iOS using [MobiVM](https://github.com/MobiVM/robovm) (a maintained fork of RoboVM).
-- **`flixelgdx-teavm`**: The backend for the web using TeaVM to transpile Java bytecode to JavaScript.
-- **`flixelgdx-teavm-plugin`**: A custom plugin to automate the workflow for web games.
-- **`flixelgdx-logging-plugin`**: Optional Gradle plugin that runs after `compileJava` and rewrites `FlixelLogger` and **`Flixel`** static `info(...)` / `warn(...)` / `error(...)` calls to injected hooks / `*WithSite` overloads so logs show accurate file and line without relying on stack walking (essential on TeaVM and helpful on the JVM).
+- **`flixelgdx-ios`**: The backend for iOS using [MobiVM](https://github.com/MobiVM/robovm) (a maintained fork of RoboVM). Not supported yet.
+- **`flixelgdx-teavm`**: The backend for the web using TeaVM to transpile Java bytecode to JavaScript, allowing games to run seamlessly in a browser.
+- **`flixelgdx-basisu-plugin`**: Compression plugin that automatically downloads a Basis Universal binary for the current OS and applies `.ktx2` compression for every `.png` asset.
+- **`flixelgdx-teavm-plugin`**: Plugin that automates the workflow for web games. This includes copying assets, creating the HTML index file, extracting native scripts, and more.
+- **`flixelgdx-logging-plugin`**: Plugin that runs after `compileJava` and rewrites `FlixelLogger` and **`Flixel`** static `info(...)` / `warn(...)` / `error(...)` calls to injected hooks / `*WithSite` overloads so logs show accurate file and line without relying on stack walking (essential on TeaVM and helpful on the JVM).
 - **`flixelgdx-jvm`**: JVM-only helpers that are not suitable for TeaVM or other non-JVM targets (stack traces, optional log files, etc.). It depends on **`flixelgdx-common`** for shared native-friendly pieces such as MiniAudio.
 - **`flixelgdx-test`**: **Test-only** module. Holds JUnit tests for `flixelgdx-core` (tweens, utilities, signals, etc.). It is not published to Maven; run `./gradlew :flixelgdx-test:test` locally and in CI.
-
-### Which module should my game depend on?
-
-When you use FlixelGDX **as a library inside another libGDX project**, you almost always:
-
-- add a dependency on **`org.flixelgdx:flixelgdx-core`** to your own `core` module, and
-- keep using your existing platform launchers (desktop, Android, etc.).
-
-When you are building a project that is structured like FlixelGDX itself (multi-module with shared `core` and distinct backends), you can:
-
-- depend on `flixelgdx-core` from your game logic,
-- depend on the appropriate backend modules (`flixelgdx-lwjgl3`, `flixelgdx-android`, `flixelgdx-ios`, `flixelgdx-teavm`) in your platform-specific launchers.
-
-For more info on how to wire FlixelGDX into a new libGDX project, see the [COMPILING.md](COMPILING.md) document.
 
 ## Build System
 
@@ -47,11 +34,11 @@ Dependencies are managed in the `build.gradle` file of each module. We use `api`
 
 For example, the `flixelgdx-core` module uses `api` for libGDX, which means any project using FlixelGDX will also have access to the underlying libGDX classes.
 
-When you publish FlixelGDX to your local Maven repository (see `TESTING.md`), other projects can simply add:
+When you publish FlixelGDX to your local Maven repository (see [`COMPILING.md`](./COMPILING.md)), other projects can simply add:
 
 ```gradle
 dependencies {
-    implementation "org.flixelgdx:core:<version>"
+  implementation "org.flixelgdx:core:<version>"
 }
 ```
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -16,6 +16,10 @@ The project is split into several modules, each serving a specific purpose:
 - **`flixelgdx-teavm-plugin`**: Plugin that automates the workflow for web games. This includes copying assets, creating the HTML index file, extracting native scripts, and more.
 - **`flixelgdx-logging-plugin`**: Plugin that runs after `compileJava` and rewrites `FlixelLogger` and **`Flixel`** static `info(...)` / `warn(...)` / `error(...)` calls to injected hooks / `*WithSite` overloads so logs show accurate file and line without relying on stack walking (essential on TeaVM and helpful on the JVM).
 - **`flixelgdx-jvm`**: JVM-only helpers that are not suitable for TeaVM or other non-JVM targets (stack traces, optional log files, etc.). It depends on **`flixelgdx-common`** for shared native-friendly pieces such as MiniAudio.
+- **`flixelgdx-video/`**: Optional video playback extension (for cutscenes, animated backgrounds, and so on), split into per-platform modules so games only ship the decoder they need:
+  - **`flixelgdx-video-core`**: The platform-agnostic API (`FlixelVideo`, `FlixelVideos`, `FlixelBaseVideo`, `FlixelVideoBackend`). TeaVM-safe; depends only on `flixelgdx-core`.
+  - **`flixelgdx-video-lwjgl3`**: Desktop backend that decodes through [libvlc](https://www.videolan.org/vlc/libvlc.html) in-memory callbacks and streams frames to the GPU with double-buffered PBOs. Bundles the VLC natives for Windows/macOS/Linux into the jar by default (build with `-PskipVlcNatives=true` for a slim jar) and falls back to a game-shipped `vlc/` folder or a system VLC install. If no working VLC is found, videos degrade to a never-ready state with a logged error instead of crashing the game.
+  - **`flixelgdx-video-teavm`**: Web backend built on a hidden HTML video element; the browser decodes and each frame is transferred GPU-to-GPU with `texImage2D`.
 - **`flixelgdx-test`**: **Test-only** module. Holds JUnit tests for `flixelgdx-core` (tweens, utilities, signals, etc.). It is not published to Maven; run `./gradlew :flixelgdx-test:test` locally and in CI.
 
 ## Build System

--- a/flixelgdx-video/flixelgdx-video-core/build.gradle
+++ b/flixelgdx-video/flixelgdx-video-core/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'java-library'
+}
+
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+eclipse.project.name = appName + '-video-core'
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
+// This module must stay platform neutral and TeaVM safe: no JVM-only helpers,
+// no LWJGL, no JNA. Platform backends live in the sibling video modules.
+dependencies {
+  api project(':flixelgdx-core')
+  implementation 'org.jetbrains:annotations:26.1.0'
+}

--- a/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelBaseVideo.java
+++ b/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelBaseVideo.java
@@ -1,0 +1,386 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.video;
+
+import com.badlogic.gdx.graphics.Texture;
+
+import org.flixelgdx.Flixel;
+import org.flixelgdx.FlixelBasic;
+import org.flixelgdx.FlixelCamera;
+import org.flixelgdx.graphics.FlixelBatch;
+import org.flixelgdx.util.signal.FlixelSignal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Default {@link FlixelVideo} implementation that wraps a platform
+ * {@link FlixelVideoBackend}.
+ *
+ * <p>This is the class {@link FlixelVideos#create(String)} returns on every platform.
+ * It extends {@link FlixelBasic} for the standard lifecycle flags and pooling support,
+ * pumps the backend once per frame from {@link #update(float)}, and draws the frame
+ * texture through the regular batch with camera awareness and culling.
+ *
+ * <p>Games normally interact with the {@link FlixelVideo} interface; subclassing this
+ * type is only needed when a custom draw or update behavior is wanted on top of an
+ * existing backend.
+ */
+public class FlixelBaseVideo extends FlixelBasic implements FlixelVideo {
+
+  /** Signal dispatched once when a non-looping video reaches its end. */
+  @NotNull
+  public final FlixelSignal<Void> onComplete = new FlixelSignal<>();
+
+  @NotNull
+  private final FlixelVideoBackend video;
+
+  @NotNull
+  private FlixelVideoQuality quality = FlixelVideoQuality.FULL;
+
+  /** World X position of the top-left corner in view coordinates. */
+  public float x;
+
+  /** World Y position of the video in view coordinates. */
+  public float y;
+
+  /** Drawn width in pixels. {@code 0} (the default) draws at the decoded frame width. */
+  public float width;
+
+  /** Drawn height in pixels. {@code 0} (the default) draws at the decoded frame height. */
+  public float height;
+
+  /** Horizontal parallax factor, same contract as sprites ({@code 1} = follows the camera). */
+  public float scrollX = 1f;
+
+  /** Vertical parallax factor, same contract as sprites ({@code 1} = follows the camera). */
+  public float scrollY = 1f;
+
+  /** When true, {@link #destroy()} is called automatically when playback completes. */
+  private boolean autoDestroy;
+
+  /** Guards {@link #onComplete} so the end of a video is only announced once. */
+  private boolean completed;
+
+  /**
+   * Creates a video wrapping the given backend. Prefer {@link FlixelVideos#create(String)};
+   * this exists for tests and advanced embedding.
+   *
+   * @param video The platform-specific video backend to wrap (must not be null).
+   */
+  public FlixelBaseVideo(@NotNull FlixelVideoBackend video) {
+    super();
+    this.video = video;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo play() {
+    return play(true, 0f);
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo play(boolean forceRestart) {
+    return play(forceRestart, 0f);
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo play(boolean forceRestart, float startTimeMs) {
+    completed = false;
+    video.play();
+    if (forceRestart) {
+      video.setTime(startTimeMs);
+    }
+    return this;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo pause() {
+    video.pause();
+    return this;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo resume() {
+    video.resume();
+    return this;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo stop() {
+    completed = false;
+    video.stop();
+    return this;
+  }
+
+  @Override
+  public boolean isPlaying() {
+    return video.isPlaying();
+  }
+
+  @Override
+  public boolean isReady() {
+    return video.isReady();
+  }
+
+  @Override
+  public void update(float elapsed) {
+    if (!active || !exists) {
+      return;
+    }
+
+    video.update();
+
+    if (!completed && video.isEnd() && !video.isLooping()) {
+      completed = true;
+      onComplete.dispatch();
+      if (autoDestroy) {
+        destroy();
+      }
+    }
+  }
+
+  @Override
+  public void draw(@NotNull FlixelBatch batch) {
+    if (!visible || !exists) {
+      return;
+    }
+    if (!isOnDrawCamera()) {
+      return;
+    }
+    Texture texture = video.getTexture();
+    if (texture == null) {
+      return;
+    }
+
+    int videoW = video.getVideoWidth();
+    int videoH = video.getVideoHeight();
+    float drawW = width > 0f ? width : videoW;
+    float drawH = height > 0f ? height : videoH;
+    if (drawW <= 0f || drawH <= 0f || videoW <= 0 || videoH <= 0) {
+      return;
+    }
+
+    FlixelCamera cam = Flixel.getDrawCamera() != null ? Flixel.getDrawCamera() : Flixel.cameras.first();
+    float wx = cam.worldToViewX(x, scrollX);
+    float wy = cam.worldToViewY(y, scrollY);
+    if (!cam.isInView(wx, wy, drawW, drawH)) {
+      return;
+    }
+
+    // Source rectangle crop: decoders often pad the texture below the visible picture
+    // (codec row alignment), so only the top-left videoW x videoH region is drawn.
+    batch.draw(texture, wx, wy, drawW, drawH, 0, 0, videoW, videoH, false, false);
+  }
+
+  @Override
+  public void destroy() {
+    super.destroy();
+    onComplete.clear();
+    video.dispose();
+    quality = FlixelVideoQuality.FULL;
+    x = 0f;
+    y = 0f;
+    width = 0f;
+    height = 0f;
+    scrollX = 1f;
+    scrollY = 1f;
+    autoDestroy = false;
+    completed = false;
+  }
+
+  /**
+   * Returns the underlying video backend for advanced use. Prefer the
+   * {@link FlixelVideo} API when possible.
+   *
+   * @return The wrapped backend instance.
+   */
+  @NotNull
+  public FlixelVideoBackend getBackend() {
+    return video;
+  }
+
+  @Nullable
+  @Override
+  public Texture getTexture() {
+    return video.getTexture();
+  }
+
+  @NotNull
+  @Override
+  public FlixelSignal<Void> getOnComplete() {
+    return onComplete;
+  }
+
+  @Override
+  public float getTime() {
+    return video.getTime();
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setTime(float timeMs) {
+    completed = false;
+    video.setTime(timeMs);
+    return this;
+  }
+
+  @Override
+  public float getLength() {
+    return video.getLength();
+  }
+
+  @Override
+  public float getRate() {
+    return video.getRate();
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setRate(float rate) {
+    video.setRate(rate);
+    return this;
+  }
+
+  @Override
+  public boolean isLooped() {
+    return video.isLooping();
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setLooped(boolean looped) {
+    video.setLooping(looped);
+    return this;
+  }
+
+  @Override
+  public float getVolume() {
+    return video.getVolume();
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setVolume(float volume) {
+    video.setVolume(volume);
+    return this;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideoQuality getQuality() {
+    return quality;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setQuality(@NotNull FlixelVideoQuality quality) {
+    if (quality == null) {
+      throw new IllegalArgumentException("Video quality cannot be null.");
+    }
+    this.quality = quality;
+    video.setQuality(quality);
+    return this;
+  }
+
+  @Override
+  public int getVideoWidth() {
+    return video.getVideoWidth();
+  }
+
+  @Override
+  public int getVideoHeight() {
+    return video.getVideoHeight();
+  }
+
+  @Override
+  public boolean isAutoDestroy() {
+    return autoDestroy;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setAutoDestroy(boolean autoDestroy) {
+    this.autoDestroy = autoDestroy;
+    return this;
+  }
+
+  @Override
+  public float getX() {
+    return x;
+  }
+
+  @Override
+  public float getY() {
+    return y;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setPosition(float x, float y) {
+    this.x = x;
+    this.y = y;
+    return this;
+  }
+
+  @Override
+  public float getWidth() {
+    return width;
+  }
+
+  @Override
+  public float getHeight() {
+    return height;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setSize(float width, float height) {
+    this.width = width;
+    this.height = height;
+    return this;
+  }
+
+  @Override
+  public float getScrollX() {
+    return scrollX;
+  }
+
+  @Override
+  public float getScrollY() {
+    return scrollY;
+  }
+
+  @NotNull
+  @Override
+  public FlixelVideo setScrollFactor(float scrollX, float scrollY) {
+    this.scrollX = scrollX;
+    this.scrollY = scrollY;
+    return this;
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelUnavailableVideo.java
+++ b/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelUnavailableVideo.java
@@ -1,0 +1,136 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.video;
+
+import com.badlogic.gdx.graphics.Texture;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A do-nothing {@link FlixelVideoBackend} used when video playback is unavailable.
+ *
+ * <p>Platform factories return this backend when their native decoder cannot be set
+ * up (for example, no working VLC installation on desktop). The game keeps running,
+ * the video simply never becomes ready and never provides a texture, and every
+ * control call is a safe no-op. Games that must react to a missing decoder can check
+ * {@link FlixelVideo#isReady()} staying {@code false}.
+ */
+public final class FlixelUnavailableVideo implements FlixelVideoBackend {
+
+  /** The shared instance; the backend is stateless, so one is enough for all videos. */
+  @NotNull
+  public static final FlixelUnavailableVideo INSTANCE = new FlixelUnavailableVideo();
+
+  private FlixelUnavailableVideo() {}
+
+  @Override
+  public void play() {}
+
+  @Override
+  public void pause() {}
+
+  @Override
+  public void resume() {}
+
+  @Override
+  public void stop() {}
+
+  @Override
+  public boolean isPlaying() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnd() {
+    return false;
+  }
+
+  @Override
+  public boolean isReady() {
+    return false;
+  }
+
+  @Override
+  public float getTime() {
+    return 0f;
+  }
+
+  @Override
+  public void setTime(float timeMs) {}
+
+  @Override
+  public float getLength() {
+    return 0f;
+  }
+
+  @Override
+  public float getRate() {
+    return 1f;
+  }
+
+  @Override
+  public void setRate(float rate) {}
+
+  @Override
+  public boolean isLooping() {
+    return false;
+  }
+
+  @Override
+  public void setLooping(boolean looping) {}
+
+  @Override
+  public float getVolume() {
+    return 1f;
+  }
+
+  @Override
+  public void setVolume(float volume) {}
+
+  @Override
+  public void setQuality(@NotNull FlixelVideoQuality quality) {}
+
+  @Override
+  public int getVideoWidth() {
+    return 0;
+  }
+
+  @Override
+  public int getVideoHeight() {
+    return 0;
+  }
+
+  @Override
+  public void update() {}
+
+  @Override
+  @Nullable
+  public Texture getTexture() {
+    return null;
+  }
+
+  @Override
+  public void dispose() {}
+}

--- a/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideo.java
+++ b/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideo.java
@@ -1,0 +1,349 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.video;
+
+import com.badlogic.gdx.graphics.Texture;
+
+import org.flixelgdx.functional.IFlixelBasic;
+import org.flixelgdx.util.signal.FlixelSignal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * A video that plays inside your game, drawn like any other object in a state.
+ *
+ * <p>{@code FlixelVideo} extends {@link IFlixelBasic}, so every implementation carries
+ * the normal lifecycle flags, can be pooled, and can be added straight to a
+ * {@link org.flixelgdx.FlixelState FlixelState}. Draw order follows state member order:
+ * a sprite added after the video renders on top of it, exactly as with two sprites.
+ *
+ * <p>Create instances through {@link FlixelVideos#create(String)}, which picks the
+ * platform backend registered by your launcher (libvlc on desktop, the browser's
+ * decoder on the web):
+ *
+ * <pre>{@code
+ * FlixelVideo cutscene = FlixelVideos.create("videos/intro.mp4");
+ * cutscene.setSize(Flixel.getGame().getViewWidth(), Flixel.getGame().getViewHeight());
+ * cutscene.setLooped(false);
+ * cutscene.getOnComplete().add(v -> Flixel.switchState(new MenuState()));
+ * add(cutscene);
+ * cutscene.play();
+ * }</pre>
+ *
+ * <p>All positions are in milliseconds, matching {@link org.flixelgdx.audio.FlixelSound
+ * FlixelSound}. Call {@link #destroy()} when the video leaves the game for good; that
+ * releases the decoder and the frame texture.
+ *
+ * @see FlixelVideos
+ * @see FlixelVideoBackend
+ */
+public interface FlixelVideo extends IFlixelBasic {
+
+  /**
+   * Plays the video from the beginning.
+   *
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo play();
+
+  /**
+   * Plays the video.
+   *
+   * @param forceRestart Should the video restart from the beginning if it is already playing?
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo play(boolean forceRestart);
+
+  /**
+   * Plays the video.
+   *
+   * @param forceRestart Whether to restart if the video is already playing.
+   * @param startTimeMs The time to start playback at, in milliseconds.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo play(boolean forceRestart, float startTimeMs);
+
+  /**
+   * Pauses the video at its current position.
+   *
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo pause();
+
+  /**
+   * Resumes from the current position after a pause.
+   *
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo resume();
+
+  /**
+   * Stops the video and resets the position to the beginning.
+   *
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo stop();
+
+  /**
+   * Returns whether the video is currently playing.
+   *
+   * @return {@code true} if the video is actively playing.
+   */
+  boolean isPlaying();
+
+  /**
+   * Returns whether the video has finished decoding its metadata and produced a frame.
+   *
+   * <p>Width, height, and length are {@code 0} until this returns {@code true}, which
+   * happens shortly after the first {@link #play()}.
+   *
+   * @return {@code true} once the video is ready to display.
+   */
+  boolean isReady();
+
+  /**
+   * Returns the current playback position in milliseconds.
+   *
+   * @return Playback position in milliseconds.
+   */
+  float getTime();
+
+  /**
+   * Sets the playback position in milliseconds.
+   *
+   * @param timeMs The time to seek to, in milliseconds.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setTime(float timeMs);
+
+  /**
+   * Returns the total length of the video in milliseconds.
+   *
+   * @return Duration in milliseconds, or {@code 0} if not yet known.
+   */
+  float getLength();
+
+  /**
+   * Returns the playback speed multiplier.
+   *
+   * @return Speed multiplier; {@code 1} is normal speed.
+   */
+  float getRate();
+
+  /**
+   * Sets the playback speed multiplier.
+   *
+   * @param rate Speed multiplier; must be greater than {@code 0}. {@code 1} is normal,
+   *     {@code 2} is double speed, {@code 0.5} is half speed.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setRate(float rate);
+
+  /**
+   * Returns whether this video is set to loop.
+   *
+   * @return {@code true} if looping is enabled.
+   */
+  boolean isLooped();
+
+  /**
+   * Enables or disables looping.
+   *
+   * @param looped {@code true} to loop, {@code false} to play once.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setLooped(boolean looped);
+
+  /**
+   * Returns the audio volume of this video.
+   *
+   * @return Volume in {@code [0, 1]}.
+   */
+  float getVolume();
+
+  /**
+   * Sets the audio volume of this video.
+   *
+   * @param volume Volume in {@code [0, 1]}; values outside the range are clamped.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setVolume(float volume);
+
+  /**
+   * Returns the current decode quality preset.
+   *
+   * @return The active quality preset.
+   */
+  @NotNull
+  FlixelVideoQuality getQuality();
+
+  /**
+   * Sets the decode quality preset.
+   *
+   * <p>On the web the change applies immediately. On desktop the decoder pipeline is
+   * rebuilt, so the change takes effect when playback starts or restarts; the desktop
+   * backend restarts a playing video automatically and seeks back to where it was.
+   *
+   * @param quality The preset to apply (must not be {@code null}).
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setQuality(@NotNull FlixelVideoQuality quality);
+
+  /**
+   * Returns the width of the decoded video frame in pixels.
+   *
+   * @return Decoded frame width, or {@code 0} while the video is not yet ready.
+   */
+  int getVideoWidth();
+
+  /**
+   * Returns the height of the decoded video frame in pixels.
+   *
+   * @return Decoded frame height, or {@code 0} while the video is not yet ready.
+   */
+  int getVideoHeight();
+
+  /**
+   * Returns the texture that holds the current video frame.
+   *
+   * <p>Useful when you want to feed the video into your own drawing code instead of
+   * relying on the default draw. The backend owns this texture; do not dispose it
+   * yourself.
+   *
+   * @return The frame texture, or {@code null} before the first frame arrives.
+   */
+  @Nullable
+  Texture getTexture();
+
+  /**
+   * Returns the signal dispatched once when a non-looping video reaches its end.
+   *
+   * @return The completion signal.
+   */
+  @NotNull
+  FlixelSignal<Void> getOnComplete();
+
+  /**
+   * Returns whether this video auto-destroys when playback completes.
+   *
+   * @return {@code true} if auto-destroy is enabled.
+   */
+  boolean isAutoDestroy();
+
+  /**
+   * Sets whether this video auto-destroys when playback completes.
+   *
+   * @param autoDestroy {@code true} to destroy this video when it finishes.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setAutoDestroy(boolean autoDestroy);
+
+  /**
+   * Returns the world X position of the video's top-left corner.
+   *
+   * @return World X position.
+   */
+  float getX();
+
+  /**
+   * Returns the world Y position of the video.
+   *
+   * @return World Y position.
+   */
+  float getY();
+
+  /**
+   * Positions the video in world coordinates.
+   *
+   * @param x World X of the top-left corner.
+   * @param y World Y of the video.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setPosition(float x, float y);
+
+  /**
+   * Returns the drawn width in pixels ({@code 0} means the decoded frame width is used).
+   *
+   * @return Drawn width in pixels.
+   */
+  float getWidth();
+
+  /**
+   * Returns the drawn height in pixels ({@code 0} means the decoded frame height is used).
+   *
+   * @return Drawn height in pixels.
+   */
+  float getHeight();
+
+  /**
+   * Sets how large the video is drawn on screen, in pixels.
+   *
+   * <p>This is independent of the decode {@link #setQuality(FlixelVideoQuality) quality}:
+   * a HALF-quality video stretched to full screen simply looks softer.
+   *
+   * @param width Drawn width in pixels ({@code 0} = decoded frame width).
+   * @param height Drawn height in pixels ({@code 0} = decoded frame height).
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setSize(float width, float height);
+
+  /**
+   * Returns the horizontal parallax factor ({@code 1} = follows the camera fully).
+   *
+   * @return Horizontal scroll factor.
+   */
+  float getScrollX();
+
+  /**
+   * Returns the vertical parallax factor ({@code 1} = follows the camera fully).
+   *
+   * @return Vertical scroll factor.
+   */
+  float getScrollY();
+
+  /**
+   * Sets the parallax factors, same contract as sprites. Use {@code 0, 0} to pin the
+   * video to the screen regardless of camera scroll (typical for cutscenes).
+   *
+   * @param scrollX Horizontal scroll factor.
+   * @param scrollY Vertical scroll factor.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  FlixelVideo setScrollFactor(float scrollX, float scrollY);
+}

--- a/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideoBackend.java
+++ b/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideoBackend.java
@@ -1,0 +1,231 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.video;
+
+import com.badlogic.gdx.graphics.Texture;
+
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Platform-agnostic abstraction over a single video player instance.
+ *
+ * <p>On desktop the implementation wraps libvlc through in-memory frame callbacks;
+ * on the web it wraps a hidden HTML video element; on Android it wraps MediaCodec.
+ * The decoder never owns a window or a DOM layer: every backend delivers frames
+ * into a plain {@link Texture} so {@link FlixelVideo} can draw them through the
+ * regular batch, respecting state draw order like any other object.
+ *
+ * <p>Texture orientation contract: row {@code 0} of the texture holds the top row
+ * of the video image, the same orientation libGDX uses when uploading a
+ * {@code Pixmap}. Drawing through the plain
+ * {@code Batch.draw(Texture, x, y, width, height)} overload therefore shows the
+ * frame upright.
+ *
+ * <p>Visible region contract: the texture may be taller or wider than the actual
+ * picture because hardware decoders pad frame buffers for row alignment (a 1080p
+ * H.264 stream typically decodes into a 1088 row buffer). The real picture always
+ * occupies the top-left {@link #getVideoWidth()} x {@link #getVideoHeight()} region
+ * of the texture; draw code must crop to it.
+ *
+ * <p>Obtain instances through {@link Factory#createVideo}, which is normally done
+ * for you by {@link FlixelVideos#create(String)}.
+ *
+ * @see Factory
+ * @see FlixelVideo
+ */
+public interface FlixelVideoBackend {
+
+  /** Starts playback from the current position, or from the start on first call. */
+  void play();
+
+  /** Pauses playback at the current position. */
+  void pause();
+
+  /** Resumes playback after {@link #pause()}. */
+  void resume();
+
+  /** Stops playback and resets the position to the beginning. */
+  void stop();
+
+  /**
+   * Returns whether the video is actively playing.
+   *
+   * @return {@code true} while playing, {@code false} when paused, stopped, or ended.
+   */
+  boolean isPlaying();
+
+  /**
+   * Returns whether playback reached the end of the stream.
+   *
+   * <p>Looping videos never report {@code true} here; they wrap around instead.
+   *
+   * @return {@code true} once a non-looping video finished.
+   */
+  boolean isEnd();
+
+  /**
+   * Returns whether the video is ready to produce frames.
+   *
+   * <p>Until the decoder has parsed the stream, {@link #getVideoWidth()} and
+   * {@link #getVideoHeight()} return {@code 0} and {@link #getTexture()} returns
+   * {@code null}. Readiness is reached shortly after the first {@link #play()}.
+   *
+   * @return {@code true} once stream metadata and the first frame are available.
+   */
+  boolean isReady();
+
+  /**
+   * Returns the current playback position.
+   *
+   * @return Position in milliseconds.
+   */
+  float getTime();
+
+  /**
+   * Seeks to the given playback position.
+   *
+   * @param timeMs Target position in milliseconds.
+   */
+  void setTime(float timeMs);
+
+  /**
+   * Returns the total length of the video.
+   *
+   * @return Duration in milliseconds, or {@code 0} if not yet known.
+   */
+  float getLength();
+
+  /**
+   * Returns the playback speed multiplier.
+   *
+   * @return Speed multiplier; {@code 1} is normal speed.
+   */
+  float getRate();
+
+  /**
+   * Sets the playback speed multiplier.
+   *
+   * @param rate Speed multiplier; must be greater than {@code 0}. {@code 1} is normal speed.
+   */
+  void setRate(float rate);
+
+  /**
+   * Returns whether the video restarts automatically when it reaches the end.
+   *
+   * @return {@code true} if looping is enabled.
+   */
+  boolean isLooping();
+
+  /**
+   * Enables or disables looping.
+   *
+   * @param looping {@code true} to loop, {@code false} to play once.
+   */
+  void setLooping(boolean looping);
+
+  /**
+   * Returns the audio volume of this video.
+   *
+   * @return Volume in {@code [0, 1]}.
+   */
+  float getVolume();
+
+  /**
+   * Sets the audio volume of this video.
+   *
+   * @param volume Volume in {@code [0, 1]}; values outside the range are clamped.
+   */
+  void setVolume(float volume);
+
+  /**
+   * Applies a decode quality preset.
+   *
+   * <p>Depending on the platform this may only take effect when playback (re)starts;
+   * see {@link FlixelVideo#setQuality(FlixelVideoQuality)} for the user-facing
+   * contract.
+   *
+   * @param quality The preset to apply (never {@code null}).
+   */
+  void setQuality(FlixelVideoQuality quality);
+
+  /**
+   * Returns the width of the decoded video in pixels.
+   *
+   * @return Decoded frame width, or {@code 0} while not {@link #isReady() ready}.
+   */
+  int getVideoWidth();
+
+  /**
+   * Returns the height of the decoded video in pixels.
+   *
+   * @return Decoded frame height, or {@code 0} while not {@link #isReady() ready}.
+   */
+  int getVideoHeight();
+
+  /**
+   * Per-frame pump that must run on the render thread.
+   *
+   * <p>This is where pending decoded frames are uploaded into the {@link Texture}
+   * (asynchronously where the platform allows it), and where deferred state such
+   * as loop restarts is applied. {@link FlixelBaseVideo#update(float)} calls this
+   * automatically when the video is part of a {@link org.flixelgdx.FlixelState FlixelState}.
+   */
+  void update();
+
+  /**
+   * Returns the texture holding the most recent decoded frame.
+   *
+   * <p>The same texture instance is reused for the lifetime of the stream; only its
+   * pixel contents change as new frames arrive. Do not dispose it yourself; the
+   * backend owns it and releases it in {@link #dispose()}.
+   *
+   * @return The frame texture, or {@code null} before the first frame is available.
+   */
+  @Nullable
+  Texture getTexture();
+
+  /** Releases the decoder, the frame texture, and any native resources. */
+  void dispose();
+
+  /**
+   * Platform-specific factory for creating video backends.
+   *
+   * <p>One instance is registered through
+   * {@link FlixelVideos#setBackendFactory(FlixelVideoBackend.Factory)} by the
+   * platform launcher (for example {@code FlixelVlcVideoHandler.install()} on
+   * desktop) before any {@link FlixelVideo} is created.
+   */
+  interface Factory {
+
+    /**
+     * Creates a new video backend for the given path.
+     *
+     * @param path Resolved path to the video file. For internal assets this is an
+     *     absolute filesystem path on JVM platforms and a URL path on the web.
+     * @param external {@code true} if the path points outside the game's assets.
+     * @return A new backend instance.
+     */
+    FlixelVideoBackend createVideo(String path, boolean external);
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideoQuality.java
+++ b/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideoQuality.java
@@ -1,0 +1,67 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.video;
+
+/**
+ * Decode quality presets for a {@link FlixelVideo}.
+ *
+ * <p>Lower presets decode into a smaller pixel buffer, which reduces CPU decode cost,
+ * upload bandwidth, and memory. The drawn size on screen never changes; only the
+ * source resolution the frames are produced at does, so lower presets look softer.
+ *
+ * <p>How each platform applies the preset:
+ *
+ * <ul>
+ *   <li>Desktop (libvlc): the decode target is scaled before frames are handed to the
+ *       framework, so the savings apply to the whole pipeline.</li>
+ *   <li>Web: {@link #FULL} uploads the video element directly to WebGL (usually a
+ *       GPU-to-GPU copy). Lower presets route through a downscaled canvas first.</li>
+ * </ul>
+ */
+public enum FlixelVideoQuality {
+
+  /** Decode at the source resolution of the video file. */
+  FULL(1f),
+
+  /** Decode at half the source width and height (a quarter of the pixels). */
+  HALF(0.5f),
+
+  /** Decode at a quarter of the source width and height. */
+  QUARTER(0.25f);
+
+  private final float scale;
+
+  FlixelVideoQuality(float scale) {
+    this.scale = scale;
+  }
+
+  /**
+   * Returns the multiplier applied to the source width and height when decoding.
+   *
+   * @return Scale factor in {@code (0, 1]}.
+   */
+  public float getScale() {
+    return scale;
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideos.java
+++ b/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideos.java
@@ -1,0 +1,136 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.video;
+
+import com.badlogic.gdx.Files;
+import com.badlogic.gdx.files.FileHandle;
+
+import org.flixelgdx.Flixel;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Static helper that creates {@link FlixelVideo} instances from the platform backend
+ * registered by your launcher.
+ *
+ * <p>Each platform module ships an installer that wires itself in here once, before
+ * the game starts:
+ *
+ * <pre>{@code
+ * public static void main(String[] args) {
+ *   FlixelVlcVideoHandler.install();
+ *   FlixelLwjgl3Launcher.launch(new MyGame());
+ * }
+ * }</pre>
+ *
+ * <p>After that, creating a video anywhere in the game needs no further setup:
+ *
+ * <pre>{@code
+ * FlixelVideo cutscene = FlixelVideos.create("videos/intro.mp4");
+ * add(cutscene);
+ * cutscene.play();
+ * }</pre>
+ *
+ * @see FlixelVideo
+ * @see FlixelVideoBackend.Factory
+ */
+public final class FlixelVideos {
+
+  @Nullable
+  private static FlixelVideoBackend.Factory backendFactory;
+
+  private FlixelVideos() {}
+
+  /**
+   * Creates a new video for an internal asset path using the current platform backend.
+   *
+   * @param path The path to the video file inside your assets, e.g. {@code "videos/intro.mp4"}.
+   * @return A new video instance.
+   * @throws IllegalStateException If no platform backend factory has been registered.
+   */
+  @NotNull
+  public static FlixelVideo create(@NotNull String path) {
+    return new FlixelBaseVideo(createBackend(path, false));
+  }
+
+  /**
+   * Creates a new video from a libGDX file handle using the current platform backend.
+   *
+   * <p>Internal and classpath handles resolve through the asset manager (so packaged
+   * JAR assets work); absolute, external, and local handles are opened directly.
+   *
+   * @param file The video file handle.
+   * @return A new video instance.
+   * @throws IllegalStateException If no platform backend factory has been registered.
+   */
+  @NotNull
+  public static FlixelVideo create(@NotNull FileHandle file) {
+    boolean internal = file.type() == Files.FileType.Internal
+        || file.type() == Files.FileType.Classpath;
+    if (internal) {
+      return create(file.path());
+    }
+    return new FlixelBaseVideo(createBackend(file.file().getAbsolutePath(), true));
+  }
+
+  /**
+   * Registers the platform video backend factory.
+   *
+   * <p>Called once by the platform installer (for example
+   * {@code FlixelVlcVideoHandler.install()} on desktop or
+   * {@code FlixelTeaVMVideoHandler.install()} on the web) before any video is created.
+   *
+   * @param factory The backend factory to use (must not be {@code null}).
+   * @throws IllegalArgumentException If {@code factory} is {@code null}.
+   */
+  public static void setBackendFactory(@NotNull FlixelVideoBackend.Factory factory) {
+    if (factory == null) {
+      throw new IllegalArgumentException("Video backend factory cannot be null.");
+    }
+    backendFactory = factory;
+  }
+
+  /**
+   * Returns the registered platform video backend factory.
+   *
+   * @return The factory, or {@code null} if no platform installer has run yet.
+   */
+  @Nullable
+  public static FlixelVideoBackend.Factory getBackendFactory() {
+    return backendFactory;
+  }
+
+  @NotNull
+  private static FlixelVideoBackend createBackend(@NotNull String path, boolean external) {
+    FlixelVideoBackend.Factory factory = backendFactory;
+    if (factory == null) {
+      throw new IllegalStateException(
+          "No video backend factory registered. Call the platform installer first, e.g. "
+              + "FlixelVlcVideoHandler.install() in your desktop launcher or "
+              + "FlixelTeaVMVideoHandler.install() in your web launcher.");
+    }
+    String resolved = external ? path : Flixel.ensureAssets().extractAssetPath(path);
+    return factory.createVideo(resolved, external);
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/package-info.java
+++ b/flixelgdx-video/flixelgdx-video-core/src/main/java/org/flixelgdx/video/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Platform-neutral video playback API for FlixelGDX.
+ *
+ * <p>{@link org.flixelgdx.video.FlixelVideo} is the interface games interact with, and
+ * {@link org.flixelgdx.video.FlixelVideos} creates instances backed by the platform
+ * backend registered once per launcher. The backend contract lives in
+ * {@link org.flixelgdx.video.FlixelVideoBackend}, and the desktop, web, and Android
+ * implementations ship in the sibling {@code flixelgdx-video-lwjgl3},
+ * {@code flixelgdx-video-teavm}, and {@code flixelgdx-video-android} modules.
+ */
+package org.flixelgdx.video;

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/.gitignore
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/.gitignore
@@ -1,0 +1,2 @@
+# Populated by the downloadVlcNatives task; libvlc binaries never live in git.
+/natives/

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/build.gradle
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/build.gradle
@@ -1,0 +1,313 @@
+// Desktop backend for the FlixelGDX video extension. Bridges libvlc into the
+// framework through JNA-registered JNI bindings and packages (optionally) the
+// libvlc native libraries that downloadVlcNatives fetches from upstream.
+
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    // Pure-JVM extraction of the upstream archives: 7z (Windows SDK .lib files)
+    // and Debian .deb (ar + tar.xz) so the natives task needs no external tools
+    // for Windows and Linux. Only the macOS .dmg needs 7z or hdiutil on PATH.
+    classpath 'org.apache.commons:commons-compress:1.27.1'
+    classpath 'org.tukaani:xz:1.10'
+  }
+}
+
+plugins {
+  id 'java-library'
+}
+
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+eclipse.project.name = appName + '-video-lwjgl3'
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+  api project(':flixelgdx-video-core')
+  api "net.java.dev.jna:jna:$jnaVersion"
+  implementation "com.badlogicgames.gdx:gdx-backend-lwjgl3:$gdxVersion"
+  implementation 'org.jetbrains:annotations:26.1.0'
+
+  // Provides the Feature interface and RuntimeJNIAccess used by FlixelVideoGraalFeature.
+  // Compile-only: the class runs inside native-image at build time, not in user runtimes.
+  compileOnly 'org.graalvm.sdk:nativeimage:24.2.0'
+}
+
+/*
+ * libvlc natives pipeline.
+ *
+ * Every artifact below is the same upstream release (vlcVersion in
+ * gradle.properties) so the .dll, .dylib and .so files always match:
+ *   - Windows x64: official VideoLAN zip (runtime .dll + plugins) and 7z (SDK .lib import libraries).
+ *   - macOS universal (arm64 + x86_64): official VideoLAN dmg.
+ *   - Linux x64: Debian bookworm builds of the same release (VideoLAN publishes no Linux binaries).
+ *
+ * Binaries are never committed to git; downloadVlcNatives populates natives/ once on the
+ * machine that builds the framework. From there the libraries are embedded into this
+ * module's jar automatically (see processResources below), so games that depend on
+ * flixelgdx-video-lwjgl3 get working desktop video with no extra downloads or setup.
+ */
+def vlcDownloads = [
+  [
+    name: "vlc-${vlcVersion}-win64.zip",
+    url : "https://download.videolan.org/pub/videolan/vlc/${vlcVersion}/win64/vlc-${vlcVersion}-win64.zip",
+    sha256: '992d19dbd0b8a7cde9167d2f7780b1ef6f92acc8a71acfa736101a21f35181e1'
+  ],
+  [
+    name: "vlc-${vlcVersion}-win64.7z",
+    url : "https://download.videolan.org/pub/videolan/vlc/${vlcVersion}/win64/vlc-${vlcVersion}-win64.7z",
+    sha256: 'eb4fd8a28291da73608c733786a09610fea865fbe94113bcb60b91c1ebb8404a'
+  ],
+  [
+    name: "vlc-${vlcVersion}-universal.dmg",
+    url : "https://download.videolan.org/pub/videolan/vlc/${vlcVersion}/macosx/vlc-${vlcVersion}-universal.dmg",
+    sha256: '56ee657c3aaf5c71b4ab7d6e4f4a77f6eca54633e0bf42a93b8116eb1d1f6ec9'
+  ],
+  [
+    name: "libvlc5_${vlcVersion}-0+deb12u1_amd64.deb",
+    url : "https://deb.debian.org/debian/pool/main/v/vlc/libvlc5_${vlcVersion}-0%2Bdeb12u1_amd64.deb",
+    sha256: '07ad5c61dc41acf29c485224accf457b7632e68a910eee21badf30213e6ab359'
+  ],
+  [
+    name: "libvlccore9_${vlcVersion}-0+deb12u1_amd64.deb",
+    url : "https://deb.debian.org/debian/pool/main/v/vlc/libvlccore9_${vlcVersion}-0%2Bdeb12u1_amd64.deb",
+    sha256: 'a3114b86450777e4cbbd4620419b74d189367e5f5026286cc74c39c9e759bfa7'
+  ],
+  [
+    name: "vlc-plugin-base_${vlcVersion}-0+deb12u1_amd64.deb",
+    url : "https://deb.debian.org/debian/pool/main/v/vlc/vlc-plugin-base_${vlcVersion}-0%2Bdeb12u1_amd64.deb",
+    sha256: '38b953a2a6355c5ba75e3e5d2015100d793fbf5a00211aaa78b2d705a9547cb1'
+  ],
+  [
+    name: "vlc-plugin-video-output_${vlcVersion}-0+deb12u1_amd64.deb",
+    url : "https://deb.debian.org/debian/pool/main/v/vlc/vlc-plugin-video-output_${vlcVersion}-0%2Bdeb12u1_amd64.deb",
+    sha256: 'de1d62487161efc62305b6e84cd364e71f109125d601401ee824d3291813e6e2'
+  ]
+]
+
+// Plugin categories no game playback path needs (interface, scripting, streaming out,
+// discovery). Dropping them roughly halves the Windows natives payload.
+def vlcPluginBlocklist = [
+  'gui', 'lua', 'control', 'services_discovery', 'visualization',
+  'mux', 'stream_out', 'access_output', 'meta_engine', 'keystore', 'logger'
+]
+
+def vlcDownloadDir = layout.buildDirectory.dir('vlc-downloads')
+def vlcNativesDir = layout.projectDirectory.dir('natives')
+
+def sha256Of = { File f ->
+  def digest = java.security.MessageDigest.getInstance('SHA-256')
+  f.withInputStream { is ->
+    byte[] buf = new byte[65536]
+    int n
+    while ((n = is.read(buf)) > 0) {
+      digest.update(buf, 0, n)
+    }
+  }
+  digest.digest().collect { String.format('%02x', it) }.join()
+}
+
+def fetchVlcArtifact = { Map spec, File dir ->
+  def target = new File(dir, spec.name as String)
+  if (target.exists() && sha256Of(target) == spec.sha256) {
+    return target
+  }
+  dir.mkdirs()
+  logger.lifecycle("Downloading ${spec.url}")
+  new URI(spec.url as String).toURL().withInputStream { is ->
+    target.withOutputStream { os -> os << is }
+  }
+  def actual = sha256Of(target)
+  if (actual != spec.sha256) {
+    target.delete()
+    throw new GradleException("Checksum mismatch for ${spec.name}: expected ${spec.sha256}, got ${actual}")
+  }
+  return target
+}
+
+// Extracts a Debian package's data.tar.* into destDir using commons-compress only.
+def extractDeb = { File deb, File destDir ->
+  deb.withInputStream { fis ->
+    def ar = new org.apache.commons.compress.archivers.ar.ArArchiveInputStream(fis)
+    def entry
+    while ((entry = ar.nextEntry) != null) {
+      if (!entry.name.startsWith('data.tar')) {
+        continue
+      }
+      def dataStream = entry.name.endsWith('.xz')
+        ? new org.tukaani.xz.XZInputStream(ar)
+        : (entry.name.endsWith('.gz') ? new java.util.zip.GZIPInputStream(ar) : ar)
+      def tar = new org.apache.commons.compress.archivers.tar.TarArchiveInputStream(dataStream)
+      def tarEntry
+      while ((tarEntry = tar.nextEntry) != null) {
+        if (!tarEntry.file) {
+          continue
+        }
+        def out = new File(destDir, tarEntry.name)
+        out.parentFile.mkdirs()
+        out.withOutputStream { os -> os << tar }
+      }
+    }
+  }
+}
+
+def extractLibsFrom7z = { File sevenZip, String pathPrefix, File destDir ->
+  // Constructor form on purpose: Gradle's own (older) commons-compress wins on the
+  // buildscript classpath and does not have the newer builder() API.
+  def sz = new org.apache.commons.compress.archivers.sevenz.SevenZFile(sevenZip)
+  try {
+    def entry
+    while ((entry = sz.nextEntry) != null) {
+      if (entry.directory || !entry.name.replace('\\', '/').startsWith(pathPrefix)) {
+        continue
+      }
+      def out = new File(destDir, entry.name.replace('\\', '/').substring(pathPrefix.length()))
+      out.parentFile.mkdirs()
+      byte[] content = new byte[(int) entry.size]
+      int off = 0
+      while (off < content.length) {
+        off += sz.read(content, off, content.length - off)
+      }
+      out.bytes = content
+    }
+  } finally {
+    sz.close()
+  }
+}
+
+tasks.register('downloadVlcNatives') {
+  group = 'flixelgdx'
+  description = "Downloads libvlc ${vlcVersion} natives (Windows, macOS, Linux) into natives/."
+  outputs.dir(vlcNativesDir)
+
+  doLast {
+    def dlDir = vlcDownloadDir.get().asFile
+    def outRoot = vlcNativesDir.asFile
+    def files = [:]
+    vlcDownloads.each { spec -> files[spec.name] = fetchVlcArtifact(spec, dlDir) }
+
+    // Windows x64: runtime DLLs and plugins from the zip, SDK import libraries from the 7z.
+    def winDir = new File(outRoot, 'windows-amd64')
+    if (!new File(winDir, 'libvlc.dll').exists()) {
+      logger.lifecycle('Extracting Windows natives...')
+      def zipRoot = "vlc-${vlcVersion}/"
+      copy {
+        from(zipTree(files["vlc-${vlcVersion}-win64.zip" as String])) {
+          include "${zipRoot}libvlc.dll", "${zipRoot}libvlccore.dll", "${zipRoot}plugins/**"
+          vlcPluginBlocklist.each { exclude "${zipRoot}plugins/${it}/**" }
+          eachFile { it.path = it.path.substring(zipRoot.length()) }
+          includeEmptyDirs = false
+        }
+        into winDir
+      }
+    }
+    if (!new File(winDir, 'sdk/libvlc.lib').exists()) {
+      logger.lifecycle('Extracting Windows SDK import libraries...')
+      extractLibsFrom7z(files["vlc-${vlcVersion}-win64.7z" as String], "vlc-${vlcVersion}/sdk/lib/", new File(winDir, 'sdk'))
+    }
+
+    // Linux x64: Debian builds of the same upstream release.
+    def linuxDir = new File(outRoot, 'linux-amd64')
+    if (!new File(linuxDir, 'libvlc.so.5').exists()) {
+      logger.lifecycle('Extracting Linux natives...')
+      def debStage = new File(dlDir, 'deb-stage')
+      delete debStage
+      vlcDownloads.findAll { it.name.endsWith('.deb') }.each { spec ->
+        extractDeb(files[spec.name as String], debStage)
+      }
+      def usrLib = new File(debStage, 'usr/lib/x86_64-linux-gnu')
+      copy {
+        from(usrLib) {
+          include 'libvlc.so*', 'libvlccore.so*', 'vlc/plugins/**', 'vlc/libvlc_*.so'
+          vlcPluginBlocklist.each { exclude "vlc/plugins/${it}/**" }
+          includeEmptyDirs = false
+        }
+        into linuxDir
+      }
+      // The .deb data tar carries libvlc.so.5 as a symlink; materialize real files for jar packaging.
+      ['libvlc.so.5': 'libvlc.so.5.6.1', 'libvlccore.so.9': 'libvlccore.so.9.0.1'].each { link, real ->
+        def linkFile = new File(linuxDir, link)
+        def realFile = new File(linuxDir, real)
+        if (realFile.exists() && (!linkFile.exists() || linkFile.length() == 0)) {
+          linkFile.delete()
+          linkFile.bytes = realFile.bytes
+        }
+      }
+    }
+
+    // macOS universal: needs a dmg-capable extractor (7z on any OS, hdiutil on macOS).
+    def macDir = new File(outRoot, 'macos-universal')
+    if (!new File(macDir, 'lib/libvlc.dylib').exists()) {
+      def dmg = files["vlc-${vlcVersion}-universal.dmg" as String]
+      def sevenZip = ['7z', '7za'].find { tool ->
+        try {
+          def p = [tool].execute()
+          p.waitFor()
+          return true
+        } catch (Exception ignored) {
+          return false
+        }
+      }
+      if (sevenZip != null) {
+        logger.lifecycle('Extracting macOS natives with 7z...')
+        def dmgStage = new File(dlDir, 'dmg-stage')
+        delete dmgStage
+        dmgStage.mkdirs()
+        def appPath = 'VLC media player/VLC.app/Contents/MacOS'
+        def proc = [sevenZip, 'x', '-y', "-o${dmgStage.absolutePath}", dmg.absolutePath,
+                    "${appPath}/lib/*", "${appPath}/plugins/*"].execute()
+        proc.consumeProcessOutput(new StringBuffer(), new StringBuffer())
+        proc.waitFor()
+        def macSrc = new File(dmgStage, appPath)
+        if (new File(macSrc, 'lib').exists()) {
+          copy {
+            from(macSrc) {
+              include 'lib/**', 'plugins/**'
+            }
+            into macDir
+          }
+        } else {
+          logger.warn('7z could not read the dmg layout; macOS natives were skipped.')
+        }
+      } else if (System.getProperty('os.name', '').toLowerCase(java.util.Locale.ROOT).contains('mac')) {
+        logger.lifecycle('Extracting macOS natives with hdiutil...')
+        def mountPoint = new File(dlDir, 'dmg-mount')
+        mountPoint.mkdirs()
+        ['hdiutil', 'attach', dmg.absolutePath, '-nobrowse', '-readonly', '-mountpoint', mountPoint.absolutePath].execute().waitFor()
+        try {
+          copy {
+            from(new File(mountPoint, 'VLC.app/Contents/MacOS')) {
+              include 'lib/**', 'plugins/**'
+            }
+            into macDir
+          }
+        } finally {
+          ['hdiutil', 'detach', mountPoint.absolutePath].execute().waitFor()
+        }
+      } else {
+        logger.warn('No 7z/hdiutil found; macOS natives were skipped. Install p7zip to extract the dmg.')
+      }
+    }
+
+    logger.lifecycle("libvlc ${vlcVersion} natives ready under ${outRoot}")
+  }
+}
+
+// The libvlc libraries are included in this module's jar automatically, so desktop
+// games work out of the box; FlixelVlcDiscovery extracts them to a per-user cache at
+// runtime. Pass -PskipVlcNatives=true for a slim jar that relies on a system VLC
+// instead (useful for CI runs that never execute video code).
+if ((findProperty('skipVlcNatives') ?: 'false') != 'true') {
+  processResources {
+    dependsOn 'downloadVlcNatives'
+    from(vlcNativesDir) {
+      into 'org/flixelgdx/video/natives'
+      exclude '**/sdk/**'
+    }
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcDiscovery.java
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcDiscovery.java
@@ -1,0 +1,455 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.lwjgl3.video;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
+import com.sun.jna.Pointer;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Locates a working libvlc installation and prepares the process so libvlc can find
+ * its plugin directory.
+ *
+ * <p>Candidates are tried in order, and each one is verified with a real
+ * {@code libvlc_new} probe before it is accepted. A libvlc that loads but cannot
+ * initialize (for example a distribution package with the plugin set missing) is
+ * skipped instead of crashing the game, and the search falls through to the next
+ * candidate.
+ *
+ * <p>Search order:
+ *
+ * <ol>
+ *   <li>The {@code flixel.video.vlc.path} system property: a directory that contains
+ *       the libvlc shared library and its {@code plugins} folder.</li>
+ *   <li>A {@code vlc/} directory next to the game's working directory (for games that
+ *       ship VLC alongside the executable).</li>
+ *   <li>The natives bundled inside the {@code flixelgdx-video-lwjgl3} JAR under
+ *       {@code org/flixelgdx/video/natives/}, extracted once to a per-user cache. On
+ *       Windows and macOS these are the official self-contained VideoLAN builds and
+ *       are preferred over a system install.</li>
+ *   <li>A system-installed VLC (Program Files on Windows, {@code /Applications/VLC.app}
+ *       on macOS, the system linker path on Linux). On Linux this is tried before the
+ *       bundled copy, because distribution VLC plugins link against distribution codec
+ *       libraries and the local install is the configuration that is guaranteed to
+ *       match them.</li>
+ * </ol>
+ */
+final class FlixelVlcDiscovery {
+
+  /** System property naming a directory that contains libvlc and its plugins folder. */
+  static final String PATH_PROPERTY = "flixel.video.vlc.path";
+
+  private static final String RESOURCE_ROOT = "org/flixelgdx/video/natives/";
+
+  private FlixelVlcDiscovery() {}
+
+  /**
+   * Finds a working libvlc, sets {@code VLC_PLUGIN_PATH} when needed, and loads it.
+   *
+   * @return The loaded libvlc native library, ready for {@link LibVlc#register}.
+   * @throws IllegalStateException If no usable VLC installation could be found.
+   */
+  @NotNull
+  static NativeLibrary load() {
+    List<String> attempts = new ArrayList<>();
+
+    String explicit = System.getProperty(PATH_PROPERTY);
+    if (explicit != null && !explicit.isBlank()) {
+      NativeLibrary lib = tryDirectory(new File(explicit), attempts);
+      if (lib != null) {
+        return lib;
+      }
+      throw new IllegalStateException(
+          "No usable libvlc found in " + PATH_PROPERTY + "=" + explicit
+              + " (attempts: " + String.join("; ", attempts) + ")");
+    }
+
+    NativeLibrary lib = tryDirectory(new File("vlc"), attempts);
+    if (lib != null) {
+      return lib;
+    }
+
+    boolean linux = isLinux();
+    if (!linux) {
+      lib = tryBundled(attempts);
+      if (lib != null) {
+        return lib;
+      }
+    }
+    lib = trySystem(attempts);
+    if (lib == null && linux) {
+      lib = tryBundled(attempts);
+    }
+    if (lib != null) {
+      return lib;
+    }
+
+    throw new IllegalStateException(
+        "FlixelGDX video could not find a working libvlc. Attempts: ["
+            + String.join("; ", attempts) + "]. Fixes: install VLC from "
+            + "https://www.videolan.org (on Linux also install your distribution's VLC "
+            + "plugin packages, e.g. vlc-plugin-base), ship a 'vlc' folder next to the "
+            + "game, or point -D" + PATH_PROPERTY + " at a VLC directory.");
+  }
+
+  /**
+   * Attempts to load and probe libvlc from one directory.
+   *
+   * @param dir Directory expected to contain the shared libraries and a plugins folder.
+   * @param attempts Human-readable log of what was tried, for the final error message.
+   * @return The loaded library, or {@code null} if this directory does not work.
+   */
+  @Nullable
+  private static NativeLibrary tryDirectory(@NotNull File dir, @NotNull List<String> attempts) {
+    if (!dir.isDirectory()) {
+      return null;
+    }
+    File lib = findLibrary(dir, "libvlc");
+    File core = findLibrary(dir, "libvlccore");
+    if (lib == null && isMac()) {
+      File macLib = new File(dir, "lib");
+      if (macLib.isDirectory()) {
+        lib = findLibrary(macLib, "libvlc");
+        core = findLibrary(macLib, "libvlccore");
+      }
+    }
+    if (lib == null) {
+      attempts.add(dir.getAbsolutePath() + " (no libvlc library found)");
+      return null;
+    }
+
+    File pluginDir = new File(dir, "plugins");
+    if (!pluginDir.isDirectory()) {
+      // Linux layouts keep plugins under vlc/plugins next to the libraries.
+      File nested = new File(dir, "vlc/plugins");
+      pluginDir = nested.isDirectory() ? nested : null;
+    }
+    setPluginPathEnv(pluginDir != null ? pluginDir.getAbsolutePath() : null);
+
+    try {
+      if (core != null) {
+        // Loading libvlccore first lets the dynamic linker satisfy libvlc's dependency
+        // even though the directory is not on the system library path.
+        NativeLibrary.getInstance(core.getAbsolutePath());
+      }
+      NativeLibrary loaded = NativeLibrary.getInstance(lib.getAbsolutePath());
+      if (!probe(lib.getAbsolutePath())) {
+        attempts.add(lib.getAbsolutePath()
+            + " (loaded, but libvlc_new failed; plugins missing or broken)");
+        return null;
+      }
+      if (!codecPluginLoads(pluginDir)) {
+        // libvlc_new succeeds even when individual plugins cannot load their own
+        // dependencies; it just skips them and later fails to decode anything, which
+        // shows up as a silent black video. Checking the main codec plugin up front
+        // rejects such an installation so the search can fall through to a working one.
+        attempts.add(lib.getAbsolutePath()
+            + " (initialized, but the avcodec plugin cannot load; its codec libraries "
+            + "are missing or from a different distribution)");
+        return null;
+      }
+      return loaded;
+    } catch (UnsatisfiedLinkError error) {
+      attempts.add(lib.getAbsolutePath() + " (failed to load: " + error.getMessage() + ")");
+      return null;
+    }
+  }
+
+  /** Extracts classpath-bundled natives (if present) to a per-user cache and probes them. */
+  @Nullable
+  private static NativeLibrary tryBundled(@NotNull List<String> attempts) {
+    String platform = platformDirectory();
+    String root = RESOURCE_ROOT + platform + "/";
+    URL marker = FlixelVlcDiscovery.class.getClassLoader().getResource(root);
+    if (marker == null) {
+      attempts.add("bundled natives (none on classpath)");
+      return null;
+    }
+    try {
+      File cacheDir = cacheDirectory(platform);
+      // The marker alone is not trusted: if the user (or a cleaner tool) removed the
+      // extracted libraries but the marker survived, everything is extracted again.
+      if (!new File(cacheDir, ".complete").exists() || findLibrary(cacheDir, "libvlc") == null) {
+        extractResources(marker, root, cacheDir.toPath());
+        Files.writeString(new File(cacheDir, ".complete").toPath(), "ok");
+      }
+      return tryDirectory(cacheDir, attempts);
+    } catch (IOException e) {
+      attempts.add("bundled natives (extraction failed: " + e.getMessage() + ")");
+      return null;
+    }
+  }
+
+  /** Tries well-known system installation locations for the current OS. */
+  @Nullable
+  private static NativeLibrary trySystem(@NotNull List<String> attempts) {
+    if (isWindows()) {
+      String[] roots = {
+          System.getenv("ProgramFiles"),
+          System.getenv("ProgramFiles(x86)")
+      };
+      for (String rootPath : roots) {
+        if (rootPath == null) {
+          continue;
+        }
+        NativeLibrary lib = tryDirectory(new File(rootPath, "VideoLAN/VLC"), attempts);
+        if (lib != null) {
+          return lib;
+        }
+      }
+      return null;
+    }
+    if (isMac()) {
+      return tryDirectory(new File("/Applications/VLC.app/Contents/MacOS"), attempts);
+    }
+    try {
+      // A system-wide libvlc knows its own plugin directory, but a plugin path set by
+      // an earlier candidate must not leak into this attempt.
+      setPluginPathEnv(null);
+      NativeLibrary loaded = NativeLibrary.getInstance("vlc");
+      if (probe("vlc")) {
+        return loaded;
+      }
+      attempts.add("system libvlc (loaded, but libvlc_new failed; install vlc-plugin-base)");
+      return null;
+    } catch (UnsatisfiedLinkError error) {
+      attempts.add("system libvlc (not found on linker path)");
+      return null;
+    }
+  }
+
+  /**
+   * Verifies that the candidate's avcodec plugin (the decoder used by virtually every
+   * video format) can be loaded by the dynamic linker.
+   *
+   * <p>This catches plugin sets built against codec libraries the current system does
+   * not have, for example Debian-built plugins that need a libavcodec version another
+   * distribution no longer ships. When the plugin directory is unknown or has an
+   * unexpected layout, the candidate is given the benefit of the doubt because the
+   * {@code libvlc_new} probe already passed.
+   */
+  private static boolean codecPluginLoads(@Nullable File pluginDir) {
+    if (pluginDir == null) {
+      return true;
+    }
+    File plugin = findLibrary(new File(pluginDir, "codec"), "libavcodec_plugin");
+    if (plugin == null) {
+      return true;
+    }
+    try {
+      NativeLibrary.getInstance(plugin.getAbsolutePath());
+      return true;
+    } catch (UnsatisfiedLinkError error) {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies a candidate by creating and immediately releasing a throwaway libvlc
+   * instance. This is the only reliable test that the plugin set is actually usable.
+   */
+  private static boolean probe(@NotNull String libraryPathOrName) {
+    try {
+      ProbeLibrary probeLib = Native.load(libraryPathOrName, ProbeLibrary.class);
+      Pointer instance = probeLib.libvlc_new(0, null);
+      if (instance == null) {
+        return false;
+      }
+      probeLib.libvlc_release(instance);
+      return true;
+    } catch (UnsatisfiedLinkError error) {
+      return false;
+    }
+  }
+
+  @Nullable
+  private static File findLibrary(@NotNull File dir, @NotNull String baseName) {
+    String[] candidates;
+    if (isWindows()) {
+      candidates = new String[] { baseName + ".dll", baseName.substring(3) + ".dll" };
+    } else if (isMac()) {
+      candidates = new String[] { baseName + ".dylib", baseName + ".5.dylib", baseName + ".9.dylib" };
+    } else {
+      candidates = new String[] {
+          baseName + ".so", baseName + ".so.5", baseName + ".so.9",
+          baseName + ".so.5.6.1", baseName + ".so.9.0.1"
+      };
+    }
+    for (String name : candidates) {
+      File f = new File(dir, name);
+      if (f.isFile()) {
+        return f;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Publishes {@code VLC_PLUGIN_PATH} into the C runtime environment so libvlccore's
+   * module loader (which reads it with {@code getenv}) can see it. Plain
+   * {@code System.setProperty} cannot do this, hence the tiny libc binding. Passing
+   * {@code null} clears the variable so a value set for an earlier candidate cannot
+   * poison a later one.
+   */
+  private static void setPluginPathEnv(@Nullable String pluginPath) {
+    try {
+      if (isWindows()) {
+        WindowsCRuntime.INSTANCE._putenv_s("VLC_PLUGIN_PATH", pluginPath != null ? pluginPath : "");
+      } else if (pluginPath != null) {
+        PosixCRuntime.INSTANCE.setenv("VLC_PLUGIN_PATH", pluginPath, 1);
+      } else {
+        PosixCRuntime.INSTANCE.unsetenv("VLC_PLUGIN_PATH");
+      }
+    } catch (LinkageError error) {
+      // Without the environment variable libvlc falls back to its built-in search,
+      // which still succeeds for system installations.
+    }
+  }
+
+  private static void extractResources(@NotNull URL rootUrl, @NotNull String root,
+      @NotNull Path targetDir) throws IOException {
+    Files.createDirectories(targetDir);
+    if ("jar".equals(rootUrl.getProtocol())) {
+      JarURLConnection connection = (JarURLConnection) rootUrl.openConnection();
+      connection.setUseCaches(false);
+      try (JarFile jar = connection.getJarFile()) {
+        Enumeration<JarEntry> entries = jar.entries();
+        while (entries.hasMoreElements()) {
+          JarEntry entry = entries.nextElement();
+          if (entry.isDirectory() || !entry.getName().startsWith(root)) {
+            continue;
+          }
+          Path out = targetDir.resolve(entry.getName().substring(root.length()));
+          Files.createDirectories(out.getParent());
+          try (InputStream in = jar.getInputStream(entry)) {
+            Files.copy(in, out, StandardCopyOption.REPLACE_EXISTING);
+          }
+        }
+      }
+    } else if ("file".equals(rootUrl.getProtocol())) {
+      Path source = new File(rootUrl.getPath()).toPath();
+      try (var stream = Files.walk(source)) {
+        for (Path path : (Iterable<Path>) stream::iterator) {
+          if (Files.isDirectory(path)) {
+            continue;
+          }
+          Path out = targetDir.resolve(source.relativize(path).toString());
+          Files.createDirectories(out.getParent());
+          Files.copy(path, out, StandardCopyOption.REPLACE_EXISTING);
+        }
+      }
+    }
+  }
+
+  @NotNull
+  private static File cacheDirectory(@NotNull String platform) throws IOException {
+    String home = System.getProperty("user.home", ".");
+    File base;
+    if (isWindows()) {
+      String localAppData = System.getenv("LOCALAPPDATA");
+      base = localAppData != null ? new File(localAppData) : new File(home, "AppData/Local");
+    } else if (isMac()) {
+      base = new File(home, "Library/Caches");
+    } else {
+      String xdg = System.getenv("XDG_CACHE_HOME");
+      base = xdg != null ? new File(xdg) : new File(home, ".cache");
+    }
+    File dir = new File(base, "flixelgdx/vlc/" + platform);
+    Files.createDirectories(dir.toPath());
+    return dir;
+  }
+
+  @NotNull
+  private static String platformDirectory() {
+    if (isWindows()) {
+      return "windows-amd64";
+    }
+    if (isMac()) {
+      return "macos-universal";
+    }
+    return "linux-amd64";
+  }
+
+  private static boolean isWindows() {
+    return osName().contains("windows");
+  }
+
+  private static boolean isMac() {
+    return osName().contains("mac");
+  }
+
+  private static boolean isLinux() {
+    return osName().contains("linux");
+  }
+
+  @NotNull
+  private static String osName() {
+    return System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+  }
+
+  /** Minimal interface-mapped binding used only to probe candidates before committing. */
+  private interface ProbeLibrary extends Library {
+
+    Pointer libvlc_new(int argc, Pointer argv);
+
+    void libvlc_release(Pointer instance);
+  }
+
+  /** Binding for POSIX setenv so VLC_PLUGIN_PATH reaches libvlccore's getenv. */
+  private interface PosixCRuntime extends Library {
+
+    PosixCRuntime INSTANCE = Native.load("c", PosixCRuntime.class);
+
+    int setenv(String name, String value, int overwrite);
+
+    int unsetenv(String name);
+  }
+
+  /** Binding for the Windows C runtime equivalent of setenv. */
+  private interface WindowsCRuntime extends Library {
+
+    WindowsCRuntime INSTANCE = Native.load("msvcrt", WindowsCRuntime.class);
+
+    int _putenv_s(String name, String value);
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcVideo.java
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcVideo.java
@@ -1,0 +1,620 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.lwjgl3.video;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.glutils.GLOnlyTextureData;
+import com.sun.jna.Memory;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.PointerByReference;
+
+import org.flixelgdx.video.FlixelVideoBackend;
+import org.flixelgdx.video.FlixelVideoQuality;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.lwjgl.opengl.GL11C;
+import org.lwjgl.opengl.GL15C;
+import org.lwjgl.opengl.GL21C;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Desktop {@link FlixelVideoBackend} that decodes through libvlc's in-memory video
+ * callbacks.
+ *
+ * <p>libvlc never owns a window here. The format callback negotiates an RGBA buffer
+ * (optionally downscaled for {@link FlixelVideoQuality}), the lock callback hands
+ * libvlc one of two pre-allocated native pixel buffers to decode into, and the display
+ * callback flips a dirty flag. Audio decoding and output stay entirely inside libvlc.
+ *
+ * <p>On the render thread, {@link #update()} streams the latest completed frame into a
+ * reusable {@link Texture} through two ping-ponged pixel buffer objects: each frame the
+ * pixels are written into one PBO (orphaned first so the driver never blocks on the
+ * previous transfer) while the texture upload reads from it via DMA, and the next frame
+ * uses the other PBO. All buffers, textures, and PBOs are allocated once per format and
+ * reused; the per-frame path allocates nothing.
+ *
+ * <p>Threading contract: every public method must be called on the render thread. The
+ * inner callbacks run on libvlc decoder threads and only touch the shared frame buffers
+ * under {@code bufferLock} plus a handful of volatile flags.
+ */
+final class FlixelVlcVideo implements FlixelVideoBackend {
+
+  /** Protects the frame buffer swap between the libvlc thread and the render thread. */
+  private final Object bufferLock = new Object();
+
+  /** Native pixel buffers libvlc decodes into; index flipped on every displayed frame. */
+  private final Memory[] frameBuffers = new Memory[2];
+
+  /** Direct views over {@link #frameBuffers}, reused for the PBO copies. */
+  private final ByteBuffer[] frameViews = new ByteBuffer[2];
+
+  /** Ping-ponged pixel buffer object handles for asynchronous texture uploads. */
+  private final int[] pbos = new int[2];
+
+  /** Reused out-parameters for libvlc_video_get_size (avoids per-frame allocation). */
+  private final IntByReference sizeWidthRef = new IntByReference();
+  private final IntByReference sizeHeightRef = new IntByReference();
+
+  private Pointer mediaPlayer;
+  private Pointer eventManager;
+
+  @Nullable
+  private Texture texture;
+
+  @NotNull
+  private volatile FlixelVideoQuality quality = FlixelVideoQuality.FULL;
+
+  // Strong references keep the JNA callback trampolines alive while libvlc holds them.
+  private final LibVlc.LockCallback lockCallback;
+  private final LibVlc.UnlockCallback unlockCallback;
+  private final LibVlc.DisplayCallback displayCallback;
+  private final LibVlc.FormatCallback formatCallback;
+  private final LibVlc.CleanupCallback cleanupCallback;
+  private final LibVlc.EventCallback eventCallback;
+
+  /** Decoded frame width in pixels, written by the format callback. */
+  private volatile int frameWidth;
+
+  /** Decoded frame height in pixels, written by the format callback. */
+  private volatile int frameHeight;
+
+  /** Buffer dimensions libvlc originally proposed, before quality scaling. */
+  private volatile int setupSourceWidth;
+  private volatile int setupSourceHeight;
+
+  /**
+   * Codec buffers carry alignment padding rows below the visible picture (a 1080p
+   * H.264 stream decodes into a 1088 or 1090 row buffer). These are the dimensions of
+   * the real picture inside the texture, derived from libvlc_video_get_size(...).
+   * Render thread only.
+   */
+  private int visibleWidth;
+  private int visibleHeight;
+
+  /** Frame dimensions the visible size was computed for, to detect format changes. */
+  private int visibleBasisWidth;
+  private int visibleBasisHeight;
+
+  /** Which frame buffer libvlc writes into next. Guarded by {@link #bufferLock}. */
+  private int writeIndex;
+
+  /** Which frame buffer holds the latest displayed frame. Guarded by {@link #bufferLock}. */
+  private int readyIndex = -1;
+
+  /** Which PBO receives the next upload. Render thread only. */
+  private int pboIndex;
+
+  /** Size in bytes of the current frame buffers. */
+  private int frameBytes;
+
+  /** Width/height the GPU objects were created for. Render thread only. */
+  private int textureWidth;
+  private int textureHeight;
+
+  private float desiredVolume = 1f;
+  private float desiredRate = 1f;
+
+  /** Seek queued until the player actually reaches a seekable state. -1 = none. */
+  private float pendingSeekMs = -1f;
+
+  /** Set by the display callback when a new frame is ready for upload. */
+  private volatile boolean frameDirty;
+
+  /** Set by the end-reached event; consumed on the render thread. */
+  private volatile boolean endReached;
+
+  /** Set by the error event. */
+  private volatile boolean playbackError;
+
+  /** Sticky end state reported by {@link #isEnd()} for non-looping playback. */
+  private boolean ended;
+
+  private boolean looping;
+
+  /** The playback rate is re-pushed once per (re)start when the player is live. */
+  private boolean settingsApplied;
+
+  private boolean ready;
+
+  private boolean disposed;
+
+  /**
+   * Creates a media player for the given file and wires all libvlc callbacks.
+   *
+   * @param instance The shared libvlc instance.
+   * @param path Absolute path of the video file to open.
+   * @throws IllegalStateException If libvlc cannot open the media.
+   */
+  FlixelVlcVideo(@NotNull Pointer instance, @NotNull String path) {
+    Pointer media = LibVlc.libvlc_media_new_path(instance, path);
+    if (media == null) {
+      throw new IllegalStateException("libvlc could not open media: " + path);
+    }
+    mediaPlayer = LibVlc.libvlc_media_player_new_from_media(media);
+    LibVlc.libvlc_media_release(media);
+    if (mediaPlayer == null) {
+      throw new IllegalStateException("libvlc could not create a media player for: " + path);
+    }
+
+    lockCallback = this::onLock;
+    unlockCallback = (opaque, picture, planes) -> {
+    };
+    displayCallback = this::onDisplay;
+    formatCallback = this::onFormat;
+    cleanupCallback = opaque -> {
+    };
+    eventCallback = this::onEvent;
+
+    LibVlc.libvlc_video_set_format_callbacks(mediaPlayer, formatCallback, cleanupCallback);
+    LibVlc.libvlc_video_set_callbacks(mediaPlayer, lockCallback, unlockCallback, displayCallback, null);
+
+    eventManager = LibVlc.libvlc_media_player_event_manager(mediaPlayer);
+    LibVlc.libvlc_event_attach(eventManager, LibVlc.EVENT_END_REACHED, eventCallback, null);
+    LibVlc.libvlc_event_attach(eventManager, LibVlc.EVENT_ENCOUNTERED_ERROR, eventCallback, null);
+  }
+
+  @Override
+  public void play() {
+    if (disposed) {
+      return;
+    }
+    if (LibVlc.libvlc_media_player_get_state(mediaPlayer) == LibVlc.STATE_ENDED) {
+      // libvlc 3 refuses to replay from the Ended state until the player is stopped.
+      LibVlc.libvlc_media_player_stop(mediaPlayer);
+    }
+    ended = false;
+    endReached = false;
+    settingsApplied = false;
+    LibVlc.libvlc_media_player_play(mediaPlayer);
+  }
+
+  @Override
+  public void pause() {
+    if (disposed) {
+      return;
+    }
+    LibVlc.libvlc_media_player_set_pause(mediaPlayer, 1);
+  }
+
+  @Override
+  public void resume() {
+    if (disposed) {
+      return;
+    }
+    LibVlc.libvlc_media_player_set_pause(mediaPlayer, 0);
+  }
+
+  @Override
+  public void stop() {
+    if (disposed) {
+      return;
+    }
+    ended = false;
+    endReached = false;
+    pendingSeekMs = -1f;
+    LibVlc.libvlc_media_player_stop(mediaPlayer);
+  }
+
+  @Override
+  public boolean isPlaying() {
+    return !disposed && LibVlc.libvlc_media_player_get_state(mediaPlayer) == LibVlc.STATE_PLAYING;
+  }
+
+  @Override
+  public boolean isEnd() {
+    if (disposed) {
+      return false;
+    }
+    return ended || LibVlc.libvlc_media_player_get_state(mediaPlayer) == LibVlc.STATE_ENDED;
+  }
+
+  @Override
+  public boolean isReady() {
+    return ready;
+  }
+
+  @Override
+  public float getTime() {
+    if (disposed) {
+      return 0f;
+    }
+    if (pendingSeekMs >= 0f) {
+      return pendingSeekMs;
+    }
+    long time = LibVlc.libvlc_media_player_get_time(mediaPlayer);
+    return time < 0 ? 0f : time;
+  }
+
+  @Override
+  public void setTime(float timeMs) {
+    if (disposed) {
+      return;
+    }
+    float target = Math.max(0f, timeMs);
+    int state = LibVlc.libvlc_media_player_get_state(mediaPlayer);
+    if (state == LibVlc.STATE_PLAYING || state == LibVlc.STATE_PAUSED) {
+      LibVlc.libvlc_media_player_set_time(mediaPlayer, (long) target);
+      pendingSeekMs = -1f;
+    } else {
+      // The player is still opening (or stopped); apply once it is actually running.
+      pendingSeekMs = target;
+    }
+    ended = false;
+    endReached = false;
+  }
+
+  @Override
+  public float getLength() {
+    if (disposed) {
+      return 0f;
+    }
+    long length = LibVlc.libvlc_media_player_get_length(mediaPlayer);
+    return length < 0 ? 0f : length;
+  }
+
+  @Override
+  public float getRate() {
+    return desiredRate;
+  }
+
+  @Override
+  public void setRate(float rate) {
+    if (disposed || rate <= 0f) {
+      return;
+    }
+    desiredRate = rate;
+    LibVlc.libvlc_media_player_set_rate(mediaPlayer, rate);
+  }
+
+  @Override
+  public boolean isLooping() {
+    return looping;
+  }
+
+  @Override
+  public void setLooping(boolean looping) {
+    this.looping = looping;
+  }
+
+  @Override
+  public float getVolume() {
+    return desiredVolume;
+  }
+
+  @Override
+  public void setVolume(float volume) {
+    desiredVolume = Math.max(0f, Math.min(1f, volume));
+    if (!disposed) {
+      LibVlc.libvlc_audio_set_volume(mediaPlayer, (int) (desiredVolume * 100f));
+    }
+  }
+
+  @Override
+  public void setQuality(@NotNull FlixelVideoQuality quality) {
+    if (disposed || this.quality == quality) {
+      return;
+    }
+    this.quality = quality;
+    int state = LibVlc.libvlc_media_player_get_state(mediaPlayer);
+    if (state == LibVlc.STATE_PLAYING || state == LibVlc.STATE_PAUSED) {
+      // The vmem format is negotiated at playback start, so rebuild the pipeline in
+      // place: remember where we were, restart, and seek back.
+      float resumeAt = getTime();
+      boolean wasPaused = state == LibVlc.STATE_PAUSED;
+      LibVlc.libvlc_media_player_stop(mediaPlayer);
+      play();
+      pendingSeekMs = resumeAt;
+      if (wasPaused) {
+        // Let the pipeline restart and produce the frame, then re-pause on the next pump.
+        LibVlc.libvlc_media_player_set_pause(mediaPlayer, 1);
+      }
+    }
+  }
+
+  @Override
+  public int getVideoWidth() {
+    return visibleWidth > 0 ? visibleWidth : frameWidth;
+  }
+
+  @Override
+  public int getVideoHeight() {
+    return visibleHeight > 0 ? visibleHeight : frameHeight;
+  }
+
+  @Override
+  public void update() {
+    if (disposed) {
+      return;
+    }
+
+    if (playbackError) {
+      playbackError = false;
+      Gdx.app.error("FlixelVideo", "libvlc reported a playback error; the video was stopped.");
+    }
+
+    if (endReached) {
+      endReached = false;
+      if (looping) {
+        // libvlc 3 parks the player in the Ended state; restart from the render thread
+        // (never from the event thread, which libvlc forbids re-entering).
+        LibVlc.libvlc_media_player_stop(mediaPlayer);
+        play();
+      } else {
+        ended = true;
+      }
+    }
+
+    int state = LibVlc.libvlc_media_player_get_state(mediaPlayer);
+    if (state == LibVlc.STATE_PLAYING) {
+      if (pendingSeekMs >= 0f) {
+        LibVlc.libvlc_media_player_set_time(mediaPlayer, (long) pendingSeekMs);
+        pendingSeekMs = -1f;
+      }
+      // The volume is reconciled every frame instead of being pushed once per start.
+      // Audio outputs can silently override a player's volume after the stream is
+      // created; PulseAudio in particular restores the volume of the application's
+      // most recent stream, so a looping video that restarts right after another
+      // video ends would otherwise inherit that other video's volume.
+      int wantVolume = (int) (desiredVolume * 100f);
+      if (LibVlc.libvlc_audio_get_volume(mediaPlayer) != wantVolume) {
+        LibVlc.libvlc_audio_set_volume(mediaPlayer, wantVolume);
+      }
+      if (!settingsApplied) {
+        settingsApplied = true;
+        if (desiredRate != 1f) {
+          LibVlc.libvlc_media_player_set_rate(mediaPlayer, desiredRate);
+        }
+      }
+    }
+
+    if (frameDirty) {
+      uploadLatestFrame();
+    }
+  }
+
+  @Override
+  @Nullable
+  public Texture getTexture() {
+    return ready ? texture : null;
+  }
+
+  @Override
+  public void dispose() {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    LibVlc.libvlc_event_detach(eventManager, LibVlc.EVENT_END_REACHED, eventCallback, null);
+    LibVlc.libvlc_event_detach(eventManager, LibVlc.EVENT_ENCOUNTERED_ERROR, eventCallback, null);
+    LibVlc.libvlc_media_player_stop(mediaPlayer);
+    LibVlc.libvlc_media_player_release(mediaPlayer);
+    mediaPlayer = null;
+    eventManager = null;
+    if (texture != null) {
+      texture.dispose();
+      texture = null;
+    }
+    if (pbos[0] != 0) {
+      GL15C.glDeleteBuffers(pbos);
+      pbos[0] = 0;
+      pbos[1] = 0;
+    }
+    synchronized (bufferLock) {
+      frameBuffers[0] = null;
+      frameBuffers[1] = null;
+      frameViews[0] = null;
+      frameViews[1] = null;
+      readyIndex = -1;
+    }
+    ready = false;
+  }
+
+  /**
+   * Streams the most recent completed frame into the texture through the PBO pair.
+   *
+   * <p>The write PBO is orphaned before the copy so the driver can hand back fresh
+   * storage instead of stalling on an in-flight transfer, and the texture upload reads
+   * from the PBO (a GPU-side DMA), not from client memory. Alternating PBOs each frame
+   * keeps the copy of frame N independent from the upload of frame N-1.
+   */
+  private void uploadLatestFrame() {
+    // The whole upload runs under bufferLock so the dimensions, byte count, and frame
+    // contents stay consistent even if libvlc renegotiates the format mid-play. The
+    // lock is only held for the PBO copy (about a millisecond); if libvlc wants to
+    // swap buffers meanwhile it briefly waits, which beats showing a torn frame.
+    synchronized (bufferLock) {
+      int width = frameWidth;
+      int height = frameHeight;
+      if (width <= 0 || height <= 0 || readyIndex < 0) {
+        return;
+      }
+      ensureGpuObjects(width, height);
+      Texture target = texture;
+      if (target == null) {
+        return;
+      }
+
+      int pbo = pbos[pboIndex];
+      pboIndex ^= 1;
+
+      GL15C.glBindBuffer(GL21C.GL_PIXEL_UNPACK_BUFFER, pbo);
+      GL15C.glBufferData(GL21C.GL_PIXEL_UNPACK_BUFFER, frameBytes, GL15C.GL_STREAM_DRAW);
+      ByteBuffer frame = frameViews[readyIndex];
+      frame.clear();
+      GL15C.glBufferSubData(GL21C.GL_PIXEL_UNPACK_BUFFER, 0, frame);
+      frameDirty = false;
+
+      target.bind();
+      GL11C.glTexSubImage2D(GL11C.GL_TEXTURE_2D, 0, 0, 0, width, height,
+          GL11C.GL_RGBA, GL11C.GL_UNSIGNED_BYTE, 0L);
+      GL15C.glBindBuffer(GL21C.GL_PIXEL_UNPACK_BUFFER, 0);
+      ready = true;
+    }
+    updateVisibleSize();
+  }
+
+  /**
+   * Derives the visible picture size inside the (padding-aligned) frame buffer.
+   *
+   * <p>libvlc reports the true display resolution through libvlc_video_get_size(...);
+   * scaling it by the ratio between our decode buffer and the source buffer maps it
+   * into texture pixels, so draw code can crop away the codec padding rows.
+   */
+  private void updateVisibleSize() {
+    int width = frameWidth;
+    int height = frameHeight;
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+    if (visibleWidth > 0 && width == visibleBasisWidth && height == visibleBasisHeight) {
+      return;
+    }
+    if (LibVlc.libvlc_video_get_size(mediaPlayer, 0, sizeWidthRef, sizeHeightRef) != 0) {
+      return;
+    }
+    int displayWidth = sizeWidthRef.getValue();
+    int displayHeight = sizeHeightRef.getValue();
+    int sourceWidth = setupSourceWidth;
+    int sourceHeight = setupSourceHeight;
+    if (displayWidth <= 0 || displayHeight <= 0 || sourceWidth <= 0 || sourceHeight <= 0) {
+      return;
+    }
+    visibleWidth = Math.min(width, Math.round(width * (displayWidth / (float) sourceWidth)));
+    visibleHeight = Math.min(height, Math.round(height * (displayHeight / (float) sourceHeight)));
+    visibleBasisWidth = width;
+    visibleBasisHeight = height;
+  }
+
+  /** (Re)creates the texture and PBO pair when the decoded frame size changes. */
+  private void ensureGpuObjects(int width, int height) {
+    if (texture != null && width == textureWidth && height == textureHeight) {
+      return;
+    }
+    if (texture != null) {
+      texture.dispose();
+    }
+    texture = new Texture(new GLOnlyTextureData(width, height, 0,
+        GL20.GL_RGBA, GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE));
+    texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+    texture.setWrap(Texture.TextureWrap.ClampToEdge, Texture.TextureWrap.ClampToEdge);
+    textureWidth = width;
+    textureHeight = height;
+    if (pbos[0] == 0) {
+      GL15C.glGenBuffers(pbos);
+    }
+    pboIndex = 0;
+    ready = false;
+  }
+
+  /** libvlc format negotiation; runs on a libvlc thread. */
+  private int onFormat(PointerByReference opaque, Pointer chroma, IntByReference width,
+      IntByReference height, Pointer pitches, Pointer lines) {
+    int sourceWidth = width.getValue();
+    int sourceHeight = height.getValue();
+    setupSourceWidth = sourceWidth;
+    setupSourceHeight = sourceHeight;
+    float scale = quality.getScale();
+    // Even dimensions keep chroma subsampled sources (which is nearly all of them) happy.
+    int decodeWidth = Math.max(2, ((int) (sourceWidth * scale)) & ~1);
+    int decodeHeight = Math.max(2, ((int) (sourceHeight * scale)) & ~1);
+
+    chroma.setByte(0, (byte) 'R');
+    chroma.setByte(1, (byte) 'G');
+    chroma.setByte(2, (byte) 'B');
+    chroma.setByte(3, (byte) 'A');
+    width.setValue(decodeWidth);
+    height.setValue(decodeHeight);
+    pitches.setInt(0, decodeWidth * 4);
+    lines.setInt(0, decodeHeight);
+
+    int bytes = decodeWidth * 4 * decodeHeight;
+    synchronized (bufferLock) {
+      if (frameBuffers[0] == null || frameBytes != bytes) {
+        frameBuffers[0] = new Memory(bytes);
+        frameBuffers[1] = new Memory(bytes);
+        frameViews[0] = frameBuffers[0].getByteBuffer(0, bytes);
+        frameViews[1] = frameBuffers[1].getByteBuffer(0, bytes);
+        frameBytes = bytes;
+        writeIndex = 0;
+        readyIndex = -1;
+      }
+      frameWidth = decodeWidth;
+      frameHeight = decodeHeight;
+    }
+    return 1;
+  }
+
+  /** libvlc asks for the buffer to decode the next frame into; runs on a libvlc thread. */
+  private Pointer onLock(Pointer opaque, Pointer planes) {
+    synchronized (bufferLock) {
+      Memory buffer = frameBuffers[writeIndex];
+      planes.setPointer(0, buffer);
+    }
+    return null;
+  }
+
+  /** A decoded frame is ready to be shown; runs on a libvlc thread. */
+  private void onDisplay(Pointer opaque, Pointer picture) {
+    synchronized (bufferLock) {
+      readyIndex = writeIndex;
+      writeIndex ^= 1;
+      frameDirty = true;
+    }
+  }
+
+  /** Player events; runs on the libvlc event thread, so it only flips flags. */
+  private void onEvent(Pointer event, Pointer userData) {
+    int type = event.getInt(0);
+    if (type == LibVlc.EVENT_END_REACHED) {
+      endReached = true;
+    } else if (type == LibVlc.EVENT_ENCOUNTERED_ERROR) {
+      playbackError = true;
+      endReached = true;
+    }
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcVideoHandler.java
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcVideoHandler.java
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.lwjgl3.video;
+
+import com.badlogic.gdx.Gdx;
+import com.sun.jna.Pointer;
+import com.sun.jna.StringArray;
+
+import org.flixelgdx.video.FlixelUnavailableVideo;
+import org.flixelgdx.video.FlixelVideoBackend;
+import org.flixelgdx.video.FlixelVideos;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Desktop video backend factory powered by libvlc.
+ *
+ * <p>Install it once in your desktop launcher, before the game starts:
+ *
+ * <pre>{@code
+ * public static void main(String[] args) {
+ *   FlixelVlcVideoHandler.install();
+ *   FlixelLwjgl3Launcher.launch(new MyGame());
+ * }
+ * }</pre>
+ *
+ * <p>Installation is cheap: no native library is touched until the first
+ * {@link org.flixelgdx.video.FlixelVideo FlixelVideo} is created, at which point
+ * {@link FlixelVlcDiscovery} locates libvlc (bundled natives, a game-shipped
+ * {@code vlc/} folder, or a system installation) and a single shared libvlc instance
+ * is created for the whole game.
+ *
+ * <p>When no working VLC can be found at all, videos are still created; they just
+ * stay in a never-ready state (see
+ * {@link org.flixelgdx.video.FlixelUnavailableVideo FlixelUnavailableVideo}) and the
+ * reason is logged, so a missing decoder degrades the game instead of crashing it.
+ */
+public final class FlixelVlcVideoHandler implements FlixelVideoBackend.Factory {
+
+  private static Pointer instance;
+
+  /** Set after discovery fails once, so every later video degrades without re-probing. */
+  private static boolean unavailable;
+
+  /**
+   * Registers this handler as the video backend factory for {@link FlixelVideos}.
+   * Safe to call multiple times.
+   */
+  public static void install() {
+    FlixelVideos.setBackendFactory(new FlixelVlcVideoHandler());
+  }
+
+  /**
+   * Returns the libvlc runtime version string, loading libvlc if needed.
+   *
+   * <p>Useful for diagnostics screens; most games never need this.
+   *
+   * @return The libvlc version, e.g. {@code "3.0.23 Vetinari"}.
+   */
+  @NotNull
+  public static String getLibVlcVersion() {
+    ensureInstance();
+    return LibVlc.libvlc_get_version();
+  }
+
+  private static synchronized void ensureInstance() {
+    if (instance != null) {
+      return;
+    }
+    LibVlc.register(FlixelVlcDiscovery.load());
+    // Headless flags: no interface, no X11 requirement, no console spam. Video output
+    // is negotiated per player through the vmem callbacks, so libvlc never opens a window.
+    String[] args = { "--intf=dummy", "--quiet", "--no-xlib" };
+    Pointer created = LibVlc.libvlc_new(args.length, new StringArray(args));
+    if (created == null) {
+      throw new IllegalStateException(
+          "libvlc_new failed. The located VLC installation may be incomplete (missing plugins).");
+    }
+    instance = created;
+  }
+
+  @Override
+  public FlixelVideoBackend createVideo(String path, boolean external) {
+    // A broken or missing VLC installation must not crash the game: the video
+    // degrades to a backend that is never ready, and the reason is logged loudly so
+    // the problem is diagnosable.
+    if (unavailable) {
+      return FlixelUnavailableVideo.INSTANCE;
+    }
+    try {
+      ensureInstance();
+    } catch (IllegalStateException | LinkageError error) {
+      unavailable = true;
+      Gdx.app.error("FlixelVideo",
+          "Video playback is disabled for this session: " + error.getMessage());
+      return FlixelUnavailableVideo.INSTANCE;
+    }
+    try {
+      return new FlixelVlcVideo(instance, path);
+    } catch (IllegalStateException error) {
+      Gdx.app.error("FlixelVideo", error.getMessage());
+      return FlixelUnavailableVideo.INSTANCE;
+    }
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/LibVlc.java
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/LibVlc.java
@@ -1,0 +1,184 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.lwjgl3.video;
+
+import com.sun.jna.Callback;
+import com.sun.jna.Native;
+import com.sun.jna.NativeLibrary;
+import com.sun.jna.Pointer;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.PointerByReference;
+
+/**
+ * Minimal libvlc 3.x binding used by the desktop video backend.
+ *
+ * <p>The methods are registered against the discovered libvlc shared library through
+ * JNA's direct mapping, which binds each declaration below to the exported C symbol of
+ * the same name via JNI. Only the functions the video pipeline needs are mapped; this
+ * is intentionally not a general-purpose libvlc wrapper.
+ *
+ * <p>All callback interfaces are invoked from libvlc's own decoder threads, never from
+ * the render thread. Implementations must therefore stay allocation-free and hand data
+ * over through fields that the render thread polls (see {@code FlixelVlcVideo}).
+ */
+final class LibVlc {
+
+  /** libvlc_state_t: media player is actively playing. */
+  static final int STATE_PLAYING = 3;
+
+  /** libvlc_state_t: media player is paused. */
+  static final int STATE_PAUSED = 4;
+
+  /** libvlc_state_t: media player reached the end of the media. */
+  static final int STATE_ENDED = 6;
+
+  /** libvlc_state_t: media player hit an unrecoverable error. */
+  static final int STATE_ERROR = 7;
+
+  /** libvlc_event_e: playback reached the end of the stream. */
+  static final int EVENT_END_REACHED = 265;
+
+  /** libvlc_event_e: playback stopped due to an error. */
+  static final int EVENT_ENCOUNTERED_ERROR = 266;
+
+  private static boolean registered;
+
+  private LibVlc() {}
+
+  /**
+   * Binds the native methods of this class to the given libvlc library. Safe to call
+   * more than once; only the first call registers.
+   *
+   * @param library The loaded libvlc native library.
+   */
+  static synchronized void register(NativeLibrary library) {
+    if (registered) {
+      return;
+    }
+    Native.register(LibVlc.class, library);
+    registered = true;
+  }
+
+  static native Pointer libvlc_new(int argc, Pointer argv);
+
+  static native void libvlc_release(Pointer instance);
+
+  static native String libvlc_get_version();
+
+  static native Pointer libvlc_media_new_path(Pointer instance, String path);
+
+  static native void libvlc_media_release(Pointer media);
+
+  static native Pointer libvlc_media_player_new_from_media(Pointer media);
+
+  static native void libvlc_media_player_release(Pointer mediaPlayer);
+
+  static native int libvlc_media_player_play(Pointer mediaPlayer);
+
+  static native void libvlc_media_player_set_pause(Pointer mediaPlayer, int doPause);
+
+  static native void libvlc_media_player_stop(Pointer mediaPlayer);
+
+  static native int libvlc_media_player_get_state(Pointer mediaPlayer);
+
+  static native long libvlc_media_player_get_time(Pointer mediaPlayer);
+
+  static native void libvlc_media_player_set_time(Pointer mediaPlayer, long timeMs);
+
+  static native long libvlc_media_player_get_length(Pointer mediaPlayer);
+
+  static native float libvlc_media_player_get_rate(Pointer mediaPlayer);
+
+  static native int libvlc_media_player_set_rate(Pointer mediaPlayer, float rate);
+
+  static native int libvlc_audio_get_volume(Pointer mediaPlayer);
+
+  static native int libvlc_audio_set_volume(Pointer mediaPlayer, int volume);
+
+  static native int libvlc_video_get_size(Pointer mediaPlayer, int num, IntByReference width,
+      IntByReference height);
+
+  static native void libvlc_video_set_callbacks(Pointer mediaPlayer, LockCallback lock,
+      UnlockCallback unlock, DisplayCallback display, Pointer opaque);
+
+  static native void libvlc_video_set_format_callbacks(Pointer mediaPlayer, FormatCallback setup,
+      CleanupCallback cleanup);
+
+  static native Pointer libvlc_media_player_event_manager(Pointer mediaPlayer);
+
+  static native int libvlc_event_attach(Pointer eventManager, int eventType, EventCallback callback,
+      Pointer userData);
+
+  static native void libvlc_event_detach(Pointer eventManager, int eventType, EventCallback callback,
+      Pointer userData);
+
+  /**
+   * libvlc_video_lock_cb: libvlc asks where to decode the next frame into.
+   *
+   * <p>The implementation writes the address of a pre-allocated pixel buffer into
+   * {@code planes[0]} and returns an opaque picture handle (unused here, so {@code null}).
+   */
+  interface LockCallback extends Callback {
+    Pointer invoke(Pointer opaque, Pointer planes);
+  }
+
+  /** libvlc_video_unlock_cb: libvlc finished writing the frame started in lock. */
+  interface UnlockCallback extends Callback {
+    void invoke(Pointer opaque, Pointer picture, Pointer planes);
+  }
+
+  /** libvlc_video_display_cb: the frame written in lock/unlock is ready to show. */
+  interface DisplayCallback extends Callback {
+    void invoke(Pointer opaque, Pointer picture);
+  }
+
+  /**
+   * libvlc_video_format_cb: negotiate the in-memory pixel format.
+   *
+   * <p>The implementation reads the source dimensions, writes the desired chroma fourcc
+   * into {@code chroma}, may shrink {@code width}/{@code height} (decode quality), and
+   * fills {@code pitches}/{@code lines} for plane 0. Returns the number of pixel
+   * buffers to allocate, or {@code 0} on error.
+   */
+  interface FormatCallback extends Callback {
+    int invoke(PointerByReference opaque, Pointer chroma, IntByReference width,
+        IntByReference height, Pointer pitches, Pointer lines);
+  }
+
+  /** libvlc_video_cleanup_cb: the format negotiated in setup is being torn down. */
+  interface CleanupCallback extends Callback {
+    void invoke(Pointer opaque);
+  }
+
+  /**
+   * libvlc_callback_t: generic event notification.
+   *
+   * <p>The event struct starts with the {@code int} event type at offset 0, which is all
+   * this backend reads. Never call back into libvlc from inside this callback; libvlc
+   * documents that re-entering the player from its event thread can deadlock.
+   */
+  interface EventCallback extends Callback {
+    void invoke(Pointer event, Pointer userData);
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/graal/FlixelVideoGraalFeature.java
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/graal/FlixelVideoGraalFeature.java
@@ -1,0 +1,111 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.lwjgl3.video.graal;
+
+import com.sun.jna.Callback;
+import com.sun.jna.CallbackReference;
+import com.sun.jna.Native;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.ptr.PointerByReference;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeJNIAccess;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+/**
+ * GraalVM native image Feature that registers the JNA entry points the video
+ * extension's libvlc bindings need at run time.
+ *
+ * <p>Activated automatically when the {@code flixelgdx-video-lwjgl3} JAR is on the
+ * native-image classpath, via
+ * {@code META-INF/native-image/org.flixelgdx.video/native-image.properties}. Game
+ * projects do not need to configure anything; JNA itself additionally ships its own
+ * reachability metadata on Maven Central, which the GraalVM Gradle plugin picks up.
+ *
+ * <p>JNA's dispatcher calls back into the JVM through JNI when libvlc invokes the
+ * video callbacks, so every callback interface (and JNA's core plumbing) must remain
+ * visible to JNI in the closed world of a native image.
+ */
+public class FlixelVideoGraalFeature implements Feature {
+
+  @Override
+  public void beforeAnalysis(BeforeAnalysisAccess access) {
+    try {
+      registerJnaCore();
+      registerVideoCallbacks(access);
+    } catch (NoSuchMethodException | NoSuchFieldException e) {
+      // A missing entry means a JNA version change renamed internals. The build does
+      // not fail here, but the resulting binary may crash when a callback first fires.
+      System.err.println("[FlixelGDX] Warning: video native image JNI registration failed: " + e);
+      System.err.println("[FlixelGDX] Re-run the tracing agent and update FlixelVideoGraalFeature.");
+    }
+  }
+
+  /**
+   * Registers the JNA dispatch types our bindings touch from native code. JNA ships
+   * its own reachability metadata for the rest of its internals; this list only covers
+   * the types the libvlc stubs and callbacks exchange directly.
+   */
+  private void registerJnaCore() throws NoSuchMethodException, NoSuchFieldException {
+    RuntimeJNIAccess.register(Native.class);
+    RuntimeJNIAccess.register(Callback.class);
+    RuntimeJNIAccess.register(CallbackReference.class);
+    RuntimeJNIAccess.register(Pointer.class);
+    RuntimeJNIAccess.register(Pointer.class.getDeclaredConstructor(long.class));
+    RuntimeJNIAccess.register(Pointer.class.getDeclaredField("peer"));
+    RuntimeJNIAccess.register(IntByReference.class);
+    RuntimeJNIAccess.register(PointerByReference.class);
+    RuntimeReflection.register(Structure.class);
+  }
+
+  /**
+   * Registers the libvlc callback interfaces so JNA can build their JNI trampolines.
+   * The callbacks are looked up reflectively by JNA, hence both reflection and JNI
+   * registration of each interface method.
+   */
+  private void registerVideoCallbacks(BeforeAnalysisAccess access) {
+    String[] callbackTypes = {
+        "org.flixelgdx.backend.lwjgl3.video.LibVlc$LockCallback",
+        "org.flixelgdx.backend.lwjgl3.video.LibVlc$UnlockCallback",
+        "org.flixelgdx.backend.lwjgl3.video.LibVlc$DisplayCallback",
+        "org.flixelgdx.backend.lwjgl3.video.LibVlc$FormatCallback",
+        "org.flixelgdx.backend.lwjgl3.video.LibVlc$CleanupCallback",
+        "org.flixelgdx.backend.lwjgl3.video.LibVlc$EventCallback"
+    };
+    for (String typeName : callbackTypes) {
+      Class<?> type = access.findClassByName(typeName);
+      if (type == null) {
+        continue;
+      }
+      RuntimeReflection.register(type);
+      RuntimeJNIAccess.register(type);
+      for (var method : type.getDeclaredMethods()) {
+        RuntimeReflection.register(method);
+        RuntimeJNIAccess.register(method);
+      }
+    }
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/package-info.java
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Desktop (LWJGL3) backend for the FlixelGDX video extension.
+ *
+ * <p>Frames are decoded by libvlc directly into memory through its video callbacks and
+ * streamed into a reusable texture with double-buffered pixel buffer objects, so libvlc
+ * never owns a window and videos layer like ordinary state members. Install with
+ * {@link org.flixelgdx.backend.lwjgl3.video.FlixelVlcVideoHandler#install()} in your desktop
+ * launcher.
+ */
+package org.flixelgdx.backend.lwjgl3.video;

--- a/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/resources/META-INF/native-image/org.flixelgdx.video/native-image.properties
+++ b/flixelgdx-video/flixelgdx-video-lwjgl3/src/main/resources/META-INF/native-image/org.flixelgdx.video/native-image.properties
@@ -1,0 +1,6 @@
+# GraalVM native image configuration for the FlixelGDX video desktop backend.
+# Merged automatically when flixelgdx-video-lwjgl3 is on the native-image classpath.
+
+Args = --features=org.flixelgdx.backend.lwjgl3.video.graal.FlixelVideoGraalFeature \
+       -H:IncludeResources=com/sun/jna/.*/libjnidispatch.* \
+       --initialize-at-run-time=org.flixelgdx.backend.lwjgl3.video.FlixelVlcVideoHandler

--- a/flixelgdx-video/flixelgdx-video-teavm/build.gradle
+++ b/flixelgdx-video/flixelgdx-video-teavm/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'java-library'
+}
+
+[compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
+eclipse.project.name = appName + '-video-teavm'
+
+java {
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
+}
+
+// Web backend for the video extension. No libvlc here: the browser's own
+// decoder drives a hidden HTML video element and WebGL uploads the frames.
+dependencies {
+  api project(':flixelgdx-video-core')
+  api "com.github.xpenatan.gdx-teavm:backend-web:$gdxTeaVMVersion"
+  implementation 'org.jetbrains:annotations:15.0'
+}

--- a/flixelgdx-video/flixelgdx-video-teavm/src/main/java/org/flixelgdx/backend/teavm/video/FlixelTeaVMVideo.java
+++ b/flixelgdx-video/flixelgdx-video-teavm/src/main/java/org/flixelgdx/backend/teavm/video/FlixelTeaVMVideo.java
@@ -1,0 +1,520 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.teavm.video;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.TextureData;
+import com.github.xpenatan.gdx.teavm.backends.web.WebGL20;
+import com.github.xpenatan.gdx.teavm.backends.web.gl.WebGLRenderingContextExt;
+
+import org.flixelgdx.video.FlixelVideoBackend;
+import org.flixelgdx.video.FlixelVideoQuality;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.teavm.jso.JSBody;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.dom.html.HTMLVideoElement;
+
+/**
+ * Web {@link FlixelVideoBackend} built on a hidden HTML video element.
+ *
+ * <p>The video element is used strictly as a decoding source and is never attached to
+ * the DOM, so it cannot float above or below the game canvas; every frame is pulled
+ * into a WebGL texture and drawn by the regular batch, which keeps state draw order
+ * intact (a sprite added after the video renders above it).
+ *
+ * <p>At {@link FlixelVideoQuality#FULL} quality each new frame goes straight through
+ * {@code texImage2D(..., video)}, which browsers implement as a GPU-to-GPU transfer
+ * whenever the decoder runs on the GPU. Lower presets route through an offscreen
+ * canvas ({@code drawImage} downscale, then {@code texImage2D(..., canvas)}).
+ *
+ * <p>Autoplay policies may block {@link #play()} with sound before the first user
+ * gesture; in that case playback resumes automatically on the next pointer or key
+ * event (the rejection handler in {@link #jsPlay} registers one-shot listeners).
+ */
+final class FlixelTeaVMVideo implements FlixelVideoBackend {
+
+  /** The hidden video element doing the decoding. */
+  private final JSObject element;
+
+  /** Offscreen canvas used only for the downscaled quality presets. */
+  @Nullable
+  private JSObject scaleCanvas;
+
+  @Nullable
+  private Texture texture;
+
+  @NotNull
+  private FlixelVideoQuality quality = FlixelVideoQuality.FULL;
+
+  /** Texture dimensions currently allocated on the GPU. */
+  private int textureWidth;
+  private int textureHeight;
+
+  private float volume = 1f;
+  private float rate = 1f;
+
+  /** Seek requested before the element had metadata; applied once seekable. -1 = none. */
+  private float pendingSeekMs = -1f;
+
+  /** currentTime (in seconds) of the last uploaded frame, to skip duplicate uploads. */
+  private double lastUploadedTime = -1.0;
+
+  private boolean looping;
+  private boolean ready;
+  private boolean disposed;
+
+  /**
+   * Creates a video element for the given URL path.
+   *
+   * @param url The video URL, typically an internal asset path relative to the page.
+   */
+  FlixelTeaVMVideo(@NotNull String url) {
+    element = jsCreateVideo(url);
+  }
+
+  @Override
+  public void play() {
+    if (disposed) {
+      return;
+    }
+    jsPlay(element);
+  }
+
+  @Override
+  public void pause() {
+    if (disposed) {
+      return;
+    }
+    jsPause(element);
+  }
+
+  @Override
+  public void resume() {
+    play();
+  }
+
+  @Override
+  public void stop() {
+    if (disposed) {
+      return;
+    }
+    jsPause(element);
+    jsSetTime(element, 0.0);
+    pendingSeekMs = -1f;
+  }
+
+  @Override
+  public boolean isPlaying() {
+    return !disposed && jsIsPlaying(element);
+  }
+
+  @Override
+  public boolean isEnd() {
+    return !disposed && jsIsEnded(element);
+  }
+
+  @Override
+  public boolean isReady() {
+    return ready;
+  }
+
+  @Override
+  public float getTime() {
+    if (disposed) {
+      return 0f;
+    }
+    if (pendingSeekMs >= 0f) {
+      return pendingSeekMs;
+    }
+    return (float) (jsGetTime(element) * 1000.0);
+  }
+
+  @Override
+  public void setTime(float timeMs) {
+    if (disposed) {
+      return;
+    }
+    float target = Math.max(0f, timeMs);
+    if (jsGetReadyState(element) >= 1) {
+      // HAVE_METADATA or better: the element accepts seeks immediately.
+      jsSetTime(element, target / 1000.0);
+      pendingSeekMs = -1f;
+    } else {
+      pendingSeekMs = target;
+    }
+  }
+
+  @Override
+  public float getLength() {
+    if (disposed) {
+      return 0f;
+    }
+    double duration = jsGetDuration(element);
+    if (Double.isNaN(duration) || Double.isInfinite(duration)) {
+      return 0f;
+    }
+    return (float) (duration * 1000.0);
+  }
+
+  @Override
+  public float getRate() {
+    return rate;
+  }
+
+  @Override
+  public void setRate(float rate) {
+    if (disposed || rate <= 0f) {
+      return;
+    }
+    this.rate = rate;
+    jsSetRate(element, rate);
+  }
+
+  @Override
+  public boolean isLooping() {
+    return looping;
+  }
+
+  @Override
+  public void setLooping(boolean looping) {
+    this.looping = looping;
+    if (!disposed) {
+      jsSetLoop(element, looping);
+    }
+  }
+
+  @Override
+  public float getVolume() {
+    return volume;
+  }
+
+  @Override
+  public void setVolume(float volume) {
+    this.volume = Math.max(0f, Math.min(1f, volume));
+    if (!disposed) {
+      jsSetVolume(element, this.volume);
+    }
+  }
+
+  @Override
+  public void setQuality(@NotNull FlixelVideoQuality quality) {
+    if (this.quality == quality) {
+      return;
+    }
+    this.quality = quality;
+    // Force the texture to be recreated at the new decode size on the next frame.
+    lastUploadedTime = -1.0;
+    if (texture != null) {
+      texture.dispose();
+      texture = null;
+      ready = false;
+    }
+  }
+
+  @Override
+  public int getVideoWidth() {
+    if (disposed) {
+      return 0;
+    }
+    return scaledDimension(jsGetVideoWidth(element));
+  }
+
+  @Override
+  public int getVideoHeight() {
+    if (disposed) {
+      return 0;
+    }
+    return scaledDimension(jsGetVideoHeight(element));
+  }
+
+  @Override
+  public void update() {
+    if (disposed) {
+      return;
+    }
+
+    if (pendingSeekMs >= 0f && jsGetReadyState(element) >= 1) {
+      jsSetTime(element, pendingSeekMs / 1000.0);
+      pendingSeekMs = -1f;
+    }
+
+    // Defensive volume reconciliation: if anything reset the element's volume (a
+    // browser policy, an extension, or a source reload), the desired value wins.
+    if (jsGetVolume(element) != volume) {
+      jsSetVolume(element, volume);
+    }
+
+    // HAVE_CURRENT_DATA (2) means a decoded frame is available for the current time.
+    if (jsGetReadyState(element) < 2) {
+      return;
+    }
+    int width = getVideoWidth();
+    int height = getVideoHeight();
+    if (width <= 0 || height <= 0) {
+      return;
+    }
+
+    double time = jsGetTime(element);
+    boolean firstFrame = texture == null || width != textureWidth || height != textureHeight;
+    if (!firstFrame && time == lastUploadedTime) {
+      return;
+    }
+
+    if (firstFrame) {
+      recreateTexture(width, height);
+    }
+    uploadFrame(width, height);
+    lastUploadedTime = time;
+    ready = true;
+  }
+
+  @Override
+  @Nullable
+  public Texture getTexture() {
+    return ready ? texture : null;
+  }
+
+  @Override
+  public void dispose() {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    jsDispose(element);
+    if (texture != null) {
+      texture.dispose();
+      texture = null;
+    }
+    scaleCanvas = null;
+    ready = false;
+  }
+
+  /** Allocates (or reallocates) the GPU texture at the current decode size. */
+  private void recreateTexture(int width, int height) {
+    if (texture != null) {
+      texture.dispose();
+    }
+    texture = new Texture(new WebVideoTextureData(width, height));
+    // NPOT video dimensions in WebGL 1 require clamping and no mipmaps.
+    texture.setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+    texture.setWrap(Texture.TextureWrap.ClampToEdge, Texture.TextureWrap.ClampToEdge);
+    textureWidth = width;
+    textureHeight = height;
+  }
+
+  /** Pulls the current video frame into the bound GL texture. */
+  private void uploadFrame(int width, int height) {
+    Texture target = texture;
+    if (target == null) {
+      return;
+    }
+    Gdx.gl.glBindTexture(GL20.GL_TEXTURE_2D, target.getTextureObjectHandle());
+    if (quality == FlixelVideoQuality.FULL) {
+      HTMLVideoElement video = element.cast();
+      context().texImage2D(GL20.GL_TEXTURE_2D, 0, GL20.GL_RGBA, GL20.GL_RGBA,
+          GL20.GL_UNSIGNED_BYTE, video);
+    } else {
+      if (scaleCanvas == null) {
+        scaleCanvas = jsCreateCanvas();
+      }
+      jsDrawScaled(scaleCanvas, element, width, height);
+      jsTexImage2DCanvas(context(), scaleCanvas);
+    }
+  }
+
+  private int scaledDimension(int sourceSize) {
+    if (sourceSize <= 0) {
+      return 0;
+    }
+    if (quality == FlixelVideoQuality.FULL) {
+      return sourceSize;
+    }
+    return Math.max(2, Math.round(sourceSize * quality.getScale()));
+  }
+
+  @NotNull
+  private static WebGLRenderingContextExt context() {
+    if (Gdx.gl20 instanceof WebGL20 webGl) {
+      return webGl.gl;
+    }
+    throw new IllegalStateException(
+        "FlixelGDX video requires the standard WebGL20 backend (got "
+            + (Gdx.gl20 == null ? "no GL20" : Gdx.gl20.getClass().getName()) + ").");
+  }
+
+  @JSBody(params = { "url" }, script = "var v = document.createElement('video');"
+      + "v.src = url;"
+      + "v.crossOrigin = 'anonymous';"
+      + "v.preload = 'auto';"
+      + "v.playsInline = true;"
+      + "v.load();"
+      + "return v;")
+  private static native JSObject jsCreateVideo(String url);
+
+  /**
+   * Starts playback. If the browser's autoplay policy rejects the call (no user
+   * gesture yet), one-shot listeners retry on the next pointer or key event.
+   */
+  @JSBody(params = { "v" }, script = "var p = v.play();"
+      + "if (p && p.catch) {"
+      + "  p.catch(function() {"
+      + "    if (v.flixelResumeArmed) return;"
+      + "    v.flixelResumeArmed = true;"
+      + "    var resume = function() {"
+      + "      v.flixelResumeArmed = false;"
+      + "      document.removeEventListener('pointerdown', resume);"
+      + "      document.removeEventListener('keydown', resume);"
+      + "      v.play();"
+      + "    };"
+      + "    document.addEventListener('pointerdown', resume);"
+      + "    document.addEventListener('keydown', resume);"
+      + "  });"
+      + "}")
+  private static native void jsPlay(JSObject v);
+
+  @JSBody(params = { "v" }, script = "v.pause();")
+  private static native void jsPause(JSObject v);
+
+  @JSBody(params = { "v" }, script = "return !v.paused && !v.ended;")
+  private static native boolean jsIsPlaying(JSObject v);
+
+  @JSBody(params = { "v" }, script = "return v.ended;")
+  private static native boolean jsIsEnded(JSObject v);
+
+  @JSBody(params = { "v" }, script = "return v.currentTime;")
+  private static native double jsGetTime(JSObject v);
+
+  @JSBody(params = { "v", "seconds" }, script = "v.currentTime = seconds;")
+  private static native void jsSetTime(JSObject v, double seconds);
+
+  @JSBody(params = { "v" }, script = "return v.duration;")
+  private static native double jsGetDuration(JSObject v);
+
+  @JSBody(params = { "v", "rate" }, script = "v.playbackRate = rate;")
+  private static native void jsSetRate(JSObject v, float rate);
+
+  @JSBody(params = { "v", "loop" }, script = "v.loop = loop;")
+  private static native void jsSetLoop(JSObject v, boolean loop);
+
+  @JSBody(params = { "v", "volume" }, script = "v.volume = volume;")
+  private static native void jsSetVolume(JSObject v, float volume);
+
+  @JSBody(params = { "v" }, script = "return Math.fround(v.volume);")
+  private static native float jsGetVolume(JSObject v);
+
+  @JSBody(params = { "v" }, script = "return v.readyState;")
+  private static native int jsGetReadyState(JSObject v);
+
+  @JSBody(params = { "v" }, script = "return v.videoWidth;")
+  private static native int jsGetVideoWidth(JSObject v);
+
+  @JSBody(params = { "v" }, script = "return v.videoHeight;")
+  private static native int jsGetVideoHeight(JSObject v);
+
+  @JSBody(params = { "v" }, script = "v.pause();"
+      + "v.removeAttribute('src');"
+      + "v.load();")
+  private static native void jsDispose(JSObject v);
+
+  @JSBody(script = "return document.createElement('canvas');")
+  private static native JSObject jsCreateCanvas();
+
+  @JSBody(params = { "canvas", "v", "w", "h" }, script = ""
+      + "if (canvas.width !== w) canvas.width = w;"
+      + "if (canvas.height !== h) canvas.height = h;"
+      + "canvas.getContext('2d').drawImage(v, 0, 0, w, h);")
+  private static native void jsDrawScaled(JSObject canvas, JSObject v, int w, int h);
+
+  /** texImage2D from a canvas source: 3553 = TEXTURE_2D, 6408 = RGBA, 5121 = UNSIGNED_BYTE. */
+  @JSBody(params = { "ctx", "canvas" }, script = "ctx.texImage2D(3553, 0, 6408, 6408, 5121, canvas);")
+  private static native void jsTexImage2DCanvas(JSObject ctx, JSObject canvas);
+
+  /**
+     * Custom texture data that allocates GPU storage for the video frames.
+     *
+     * <p>The actual pixels are re-specified every frame by {@code texImage2D} with a
+     * video or canvas source, so this only performs the initial allocation that gives
+     * the libGDX {@link Texture} wrapper its correct dimensions for UV math.
+     */
+  private record WebVideoTextureData(int width, int height) implements TextureData {
+
+    @Override
+    public TextureDataType getType() {
+      return TextureDataType.Custom;
+    }
+
+    @Override
+    public boolean isPrepared() {
+      return true;
+    }
+
+    @Override
+    public void prepare() {}
+
+    @Override
+    public Pixmap consumePixmap() {
+      throw new UnsupportedOperationException("This TextureData implementation is custom.");
+    }
+
+    @Override
+    public boolean disposePixmap() {
+      return false;
+    }
+
+    @Override
+    public void consumeCustomData(int target) {
+      Gdx.gl.glTexImage2D(target, 0, GL20.GL_RGBA, width, height, 0,
+          GL20.GL_RGBA, GL20.GL_UNSIGNED_BYTE, null);
+    }
+
+    @Override
+    public int getWidth() {
+      return width;
+    }
+
+    @Override
+    public int getHeight() {
+      return height;
+    }
+
+    @Override
+    public Pixmap.Format getFormat() {
+      return Pixmap.Format.RGBA8888;
+    }
+
+    @Override
+    public boolean useMipMaps() {
+      return false;
+    }
+
+    @Override
+    public boolean isManaged() {
+      return false;
+    }
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-teavm/src/main/java/org/flixelgdx/backend/teavm/video/FlixelTeaVMVideoHandler.java
+++ b/flixelgdx-video/flixelgdx-video-teavm/src/main/java/org/flixelgdx/backend/teavm/video/FlixelTeaVMVideoHandler.java
@@ -1,0 +1,70 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.teavm.video;
+
+import org.flixelgdx.video.FlixelVideoBackend;
+import org.flixelgdx.video.FlixelVideos;
+
+/**
+ * Web video backend factory powered by the browser's own decoder.
+ *
+ * <p>Install it once in your web launcher, before the game starts:
+ *
+ * <pre>{@code
+ * public static void main(String[] args) {
+ *   FlixelTeaVMVideoHandler.install();
+ *   FlixelTeaVMLauncher.launch(new MyGame());
+ * }
+ * }</pre>
+ */
+public final class FlixelTeaVMVideoHandler implements FlixelVideoBackend.Factory {
+
+  /**
+   * Registers this handler as the video backend factory for {@link FlixelVideos}.
+   * Safe to call multiple times.
+   */
+  public static void install() {
+    FlixelVideos.setBackendFactory(new FlixelTeaVMVideoHandler());
+  }
+
+  @Override
+  public FlixelVideoBackend createVideo(String path, boolean external) {
+    return new FlixelTeaVMVideo(resolveUrl(path, external));
+  }
+
+  /**
+   * Maps an internal asset path to the URL it is served from.
+   *
+   * <p>The web packaging (flixelgdx-teavm-plugin) copies game assets into an
+   * {@code assets/} directory next to {@code index.html}, so a relative internal path
+   * like {@code "videos/intro.mp4"} is reachable at {@code "assets/videos/intro.mp4"}.
+   * Absolute URLs and external paths pass through untouched.
+   */
+  private static String resolveUrl(String path, boolean external) {
+    if (external || path.contains("://") || path.startsWith("/")) {
+      return path;
+    }
+    return "assets/" + path;
+  }
+}

--- a/flixelgdx-video/flixelgdx-video-teavm/src/main/java/org/flixelgdx/backend/teavm/video/package-info.java
+++ b/flixelgdx-video/flixelgdx-video-teavm/src/main/java/org/flixelgdx/backend/teavm/video/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Web (TeaVM) backend for the FlixelGDX video extension.
+ *
+ * <p>A hidden HTML video element decodes the stream, and each frame is pulled into a
+ * WebGL texture with {@code texImage2D}, so videos draw through the normal batch and
+ * layer with other state members. Install with
+ * {@link org.flixelgdx.backend.teavm.video.FlixelTeaVMVideoHandler#install()} in your web
+ * launcher.
+ */
+package org.flixelgdx.backend.teavm.video;

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,10 @@ android.useAndroidX=true
 miniaudioVersion=0.7
 jansiVersion=2.4.2
 imguiJavaVersion=1.90.0
+jnaVersion=5.17.0
+# libvlc release used by the flixelgdx-video-lwjgl3 natives pipeline. All desktop
+# platforms (Windows, macOS, Linux) are pinned to this exact upstream version.
+vlcVersion=3.0.23
 projectVersion=0.4.4
 groupId=org.flixelgdx
 gdxTeaVMVersion=1.5.2

--- a/gradle/flixelgdx-injected-dependencies.gradle
+++ b/gradle/flixelgdx-injected-dependencies.gradle
@@ -30,6 +30,9 @@ configure(subprojects.findAll { p ->
     && p.name != 'flixelgdx-test'
     && p.name != 'flixelgdx-teavm-plugin'
     && p.name != 'flixelgdx-logging-plugin'
+    // Video core and web modules must stay TeaVM-safe, so they never pull the JVM-only helpers.
+    && p.name != 'flixelgdx-video-core'
+    && p.name != 'flixelgdx-video-teavm'
 }) {
   afterEvaluate {
     if (it.plugins.hasPlugin('java-library') || it.plugins.hasPlugin('com.android.library')) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,3 +32,15 @@ if (gradle.ext.includeAndroid) {
   modules += 'flixelgdx-android'
 }
 include modules
+
+// Video extension: modules live nested under flixelgdx-video/ but keep flat Gradle
+// names so published coordinates stay org.flixelgdx:flixelgdx-video-<module>.
+def videoModules = [
+  'flixelgdx-video-core',
+  'flixelgdx-video-lwjgl3',
+  'flixelgdx-video-teavm'
+]
+include videoModules
+videoModules.each { name ->
+  project(":${name}").projectDir = new File(settingsDir, "flixelgdx-video/${name}")
+}


### PR DESCRIPTION
## Description

This PR adds an optional video playback extension to FlixelGDX, aimed at cutscenes, animated menu backgrounds, and similar use cases. It introduces a new `flixelgdx-video/` directory with three modules:

- **`flixelgdx-video-core`**: the platform-agnostic API. `FlixelVideo` is an interface extending `IFlixelBasic`; `FlixelVideos` is the static factory games call (`FlixelVideos.create("intro.mp4")`); `FlixelBaseVideo` is the concrete `FlixelBasic`-based implementation that pumps the backend and draws through the regular batch (so state draw order works exactly like sprites). TeaVM-safe, depends only on `flixelgdx-core`.
- **`flixelgdx-video-lwjgl3`**: desktop backend decoding through libvlc's in-memory (vmem) callbacks. Frames stream to the GPU through double-buffered pixel buffer objects; the per-frame path allocates nothing. VLC natives for Windows, macOS, and Linux are downloaded (SHA-256 pinned to VLC 3.0.23) and bundled into the jar by default; `-PskipVlcNatives=true` produces a slim jar. Discovery probes each candidate (system property, game-shipped `vlc/` folder, bundled natives, system install) with a real `libvlc_new` call plus a codec plugin load check, so broken installations are skipped instead of producing a silent black screen. If nothing works, videos degrade to a never-ready state with a clear logged error instead of crashing the game. Includes a GraalVM native-image feature for JNA callback registration.
- **`flixelgdx-video-teavm`**: web backend built on a hidden HTML video element used purely as a decode source. At FULL quality each frame is a GPU-to-GPU `texImage2D(video)` transfer; lower quality presets downscale through an offscreen canvas. Autoplay rejection is handled with one-shot gesture listeners.

The API supports play/pause/resume/stop, seeking, playback rate, looping, per-video volume (reconciled every frame so audio output quirks such as PulseAudio stream-restore cannot leak volume between videos), quality presets, an `onComplete` signal, auto-destroy, and camera-aware positioning/parallax. Codec row padding (e.g. 1080p decoding into a 1088/1090-row buffer) is cropped automatically.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Verified in a separate test project consuming the modules from mavenLocal:

- Desktop (Linux, libvlc): two simultaneous videos (1080p MKV looping + MP4 one-shot with auto-destroy), correct draw order under a sprite, seamless looping, per-video volume staying independent across loop restarts, and graceful degradation (clear error log, game keeps running) when no working VLC is present.
- Web (TeaVM): playback via the browser decoder, `assets/` URL resolution, autoplay-gesture recovery, looping, and per-video element volume verified in the live DOM (including reconciliation pulling an externally modified volume back within one frame).

🤖 Generated with [Claude Code](https://claude.com/claude-code)