### PR TITLE
Moved debug keybinds and overlay reference onto the manager and overlay

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -6,7 +6,7 @@ FlixelGDX is organized into multiple Gradle modules to separate the core framewo
 
 The project is split into several modules, each serving a specific purpose:
 
-- **`flixelgdx-core`**: This is the heart of FlixelGDX. It contains the base framework classes (`FlixelGame`, `FlixelSprite`, `FlixelState`, etc.) and logic that is platform-independent.
+- **`flixelgdx-core`**: The heart of FlixelGDX. It contains the base framework classes (`FlixelGame`, `FlixelSprite`, `FlixelState`, etc.) and logic that is platform-independent. Every module in the entire framework depends on this one.
 - **`flixelgdx-common`**: Shared code that multiple JVM-family backends can use without pulling in LWJGL3 or TeaVM. This includes the MiniAudio-based sound handler used by desktop, Android, and iOS launchers.
 - **`flixelgdx-lwjgl3`**: The primary desktop backend using the third release of the **[Lightweight Java Game Library](https://www.lwjgl.org/)**. When you create a desktop launcher with FlixelGDX, this is the module that provides the actual `Lwjgl3Application`.
 - **`flixelgdx-android`**: The backend for Android devices. This integrates FlixelGDX with libGDX's Android launcher and lifecycle.
@@ -16,11 +16,11 @@ The project is split into several modules, each serving a specific purpose:
 - **`flixelgdx-teavm-plugin`**: Plugin that automates the workflow for web games. This includes copying assets, creating the HTML index file, extracting native scripts, and more.
 - **`flixelgdx-logging-plugin`**: Plugin that runs after `compileJava` and rewrites `FlixelLogger` and **`Flixel`** static `info(...)` / `warn(...)` / `error(...)` calls to injected hooks / `*WithSite` overloads so logs show accurate file and line without relying on stack walking (essential on TeaVM and helpful on the JVM).
 - **`flixelgdx-jvm`**: JVM-only helpers that are not suitable for TeaVM or other non-JVM targets (stack traces, optional log files, etc.). It depends on **`flixelgdx-common`** for shared native-friendly pieces such as MiniAudio.
-- **`flixelgdx-video/`**: Optional video playback extension (for cutscenes, animated backgrounds, and so on), split into per-platform modules so games only ship the decoder they need:
-  - **`flixelgdx-video-core`**: The platform-agnostic API (`FlixelVideo`, `FlixelVideos`, `FlixelBaseVideo`, `FlixelVideoBackend`). TeaVM-safe; depends only on `flixelgdx-core`.
-  - **`flixelgdx-video-lwjgl3`**: Desktop backend that decodes through [libvlc](https://www.videolan.org/vlc/libvlc.html) in-memory callbacks and streams frames to the GPU with double-buffered PBOs. Bundles the VLC natives for Windows/macOS/Linux into the jar by default (build with `-PskipVlcNatives=true` for a slim jar) and falls back to a game-shipped `vlc/` folder or a system VLC install. If no working VLC is found, videos degrade to a never-ready state with a logged error instead of crashing the game.
-  - **`flixelgdx-video-teavm`**: Web backend built on a hidden HTML video element; the browser decodes and each frame is transferred GPU-to-GPU with `texImage2D`.
-  - **`flixelgdx-video-android`**: Android backend that decodes with the platform `MediaPlayer` into a `SurfaceTexture` bound to a `GL_TEXTURE_EXTERNAL_OES` texture, then blits each frame into a normal framebuffer texture so videos draw through the regular batch and follow state draw order (added first draws under, added last draws over). Audio, per-video volume, looping, seeking, and playback rate come from `MediaPlayer`. Follows the same opt-in as `flixelgdx-android`, so it is only part of the build when Android support is enabled.
+- **`flixelgdx-video`**: Optional video playback extension (i.e., for cutscenes), split into per-platform modules so games only ship the decoder they need.
+  - **`flixelgdx-video-core`**: The platform-agnostic API (`FlixelVideo`, `FlixelVideos`, `FlixelBaseVideo`, `FlixelVideoBackend`). Depends only on `flixelgdx-core`.
+  - **`flixelgdx-video-lwjgl3`**: Desktop backend powered by [libvlc](https://www.videolan.org/vlc/libvlc.html).
+  - **`flixelgdx-video-teavm`**: Web backend built on a hidden HTML video element, which the browser decodes and each frame is transferred GPU-to-GPU with `texImage2D`.
+  - **`flixelgdx-video-android`**: Android backend that decodes with the platform `MediaPlayer` into a `SurfaceTexture` bound to a `GL_TEXTURE_EXTERNAL_OES` texture, then blits each frame into a normal framebuffer texture so videos draw through the regular batch and follow state draw order (added first draws under, added last draws over).
 - **`flixelgdx-test`**: **Test-only** module. Holds JUnit tests for `flixelgdx-core` (tweens, utilities, signals, etc.). It is not published to Maven; run `./gradlew :flixelgdx-test:test` locally and in CI.
 
 ## Build System
@@ -29,37 +29,16 @@ FlixelGDX uses **Gradle** as its build system.
 
 ### Key Files
 
-- **`build.gradle`**: The root build file that configures all projects, common repositories, and shared dependencies.
+- **`build.gradle`**: The root aggregator where the build system enters. It triggers other task-specific scripts inside of [`gradle/`](./gradle).
 - **`settings.gradle`**: Defines all the modules included in the project.
 - **`gradle.properties`**: Contains version numbers for libGDX and other dependencies, as well as JVM settings for the build process.
 
 ### Dependency Management
 
-Dependencies are managed in the `build.gradle` file of each module. We use `api` and `implementation` configurations to control which dependencies are exposed to downstream projects. 
-
+Dependencies are managed in the `build.gradle` file of each module. We use `api` and `implementation` configurations to control which dependencies are exposed to downstream projects.
 For example, the `flixelgdx-core` module uses `api` for libGDX, which means any project using FlixelGDX will also have access to the underlying libGDX classes.
 
-When you publish FlixelGDX to your local Maven repository (see [`COMPILING.md`](./COMPILING.md)), other projects can simply add:
+## GitHub Integration
 
-```gradle
-dependencies {
-  implementation "org.flixelgdx:core:<version>"
-}
-```
-
-to their own `core` module, and Gradle will transitively pull in the libGDX APIs used by FlixelGDX.
-
-## Architecture
-
-We aim to replicate the HaxeFlixel API as closely as possible while using libGDX idioms. 
-
-- **Lifecycle Methods**: We use `update(float elapsed)`, `draw(Batch batch)`, and `destroy()` throughout the framework.
-- **Strict Typing**: As this is a Java project, we ensure all methods and fields are strictly typed to provide a better developer experience.
-- **Modularity**: The separation of backends allows the core logic to remain clean and portable across different platforms.
-
-In practice this means:
-
-- Game code lives in your `core` module alongside FlixelGDX's `flixelgdx-core` API.
-- Platform launchers are thin wrappers that delegate to `FlixelGame` (or your subclass) while reusing libGDX's existing bootstrapping.
-
-For concrete examples of how to wire FlixelGDX into a new libGDX project, see the launcher and `FlixelGame` samples in the main `README.md`, and the Maven/Gradle setup in `TESTING.md`.
+FlixelGDX's codebase has multiple GitHub configurations and templates, which can be found inside of [`.github/`](./.github).
+It holds the issue and pull request templates, Dependabot configurations, workflows, and more.

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ java {
   targetCompatibility = JavaVersion.VERSION_17
 }
 
-// Root is an aggregator only (no src/). Do not apply tasks like processResources at this level.
+// Root is an aggregator only. Do not apply tasks like processResources at this level.
 // Put in a script instead, as it keeps it more organized.
 
 apply from: 'gradle/flixelgdx-allprojects.gradle'

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -44,6 +44,7 @@ import org.flixelgdx.debug.FlixelDebugManager;
 import org.flixelgdx.debug.FlixelDebugOverlay;
 import org.flixelgdx.debug.FlixelDebugWatchManager;
 import org.flixelgdx.debug.FlixelHeadlessDebugOverlay;
+import org.flixelgdx.debug.FlixelNoopDebugOverlay;
 import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.group.FlixelGroupable;
@@ -286,10 +287,10 @@ public final class Flixel {
    * <p>Example:
    * <pre>{@code
    * // Show a blocking error dialog (execution pauses until dismissed).
-   * Flixel.showErrorAlert("Save Failed", "Could not write to disk. Check your permissions.");
+   * Flixel.alert.showErrorAlert("Save Failed", "Could not write to disk. Check your permissions.");
    *
    * // Access the alerter directly for platform-specific behavior.
-   * Flixel.alerter.showInfoAlert("Hello", "Welcome to the game!");
+   * Flixel.alert.showInfoAlert("Hello", "Welcome to the game!");
    * }</pre>
    */
   @NotNull
@@ -1151,13 +1152,13 @@ public final class Flixel {
   }
 
   /**
-   * Clears the active debug overlay reference after it has been disposed.
+   * Resets the debug overlay back to the inert noop after it has been disposed.
    * {@link FlixelGame#dispose()} calls {@link org.flixelgdx.debug.FlixelDebugOverlay#destroy() FlixelDebugOverlay.destroy()}
-   * first; this method only nulls the static handle to avoid double-dispose.
+   * first; this method only resets the handle to avoid double-dispose.
    */
   static void clearDebugOverlay() {
     if (debug != null) {
-      debug.overlay = null;
+      debug.overlay = FlixelNoopDebugOverlay.INSTANCE;
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -24,7 +24,6 @@
 package org.flixelgdx;
 
 import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.Input;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 
@@ -50,7 +49,6 @@ import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.group.FlixelGroupable;
 import org.flixelgdx.input.gamepad.FlixelGamepadManager;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
-import org.flixelgdx.input.mouse.FlixelMouseButton;
 import org.flixelgdx.input.mouse.FlixelMouseManager;
 import org.flixelgdx.input.touch.FlixelTouchManager;
 import org.flixelgdx.logging.FlixelLogConsoleSink;
@@ -777,27 +775,6 @@ public final class Flixel {
    */
   private static Supplier<FlixelDebugOverlay> debugOverlayFactory = FlixelHeadlessDebugOverlay::new;
 
-  /** The active debug overlay instance, created by {@link FlixelGame} during startup. */
-  private static FlixelDebugOverlay debugOverlay;
-
-  /** Current key used to toggle the debug overlay. */
-  private static int debugToggleKey = FlixelDebugOverlay.Keybinds.DEFAULT_TOGGLE_KEY;
-
-  /** Current key used to toggle visual debug (bounding boxes). */
-  private static int debugDrawToggleKey = FlixelDebugOverlay.Keybinds.DEFAULT_DRAW_DEBUG_KEY;
-
-  /** Current key used to pause the game update loop (debug mode only). */
-  private static int debugPauseKey = FlixelDebugOverlay.Keybinds.DEFAULT_PAUSE_KEY;
-
-  /** Current button used to pan the debug camera. */
-  private static int debugCameraPanButton = FlixelMouseButton.RIGHT;
-
-  /** Current key used to cycle the debug camera to the left while paused (with Alt). */
-  private static int debugCameraCycleLeftKey = FlixelDebugOverlay.Keybinds.DEFAULT_DEBUG_CAMERA_CYCLE_LEFT;
-
-  /** Current key used to cycle the debug camera to the right while paused (with Alt). */
-  private static int debugCameraCycleRightKey = FlixelDebugOverlay.Keybinds.DEFAULT_DEBUG_CAMERA_CYCLE_RIGHT;
-
   /** Should the game use antialiasing globally? */
   private static boolean antialiasing = false;
 
@@ -1086,42 +1063,6 @@ public final class Flixel {
   }
 
   /**
-   * Returns the key used to toggle the debug overlay visibility.
-   *
-   * @see org.flixelgdx.input.keyboard.FlixelKey
-   */
-  public static int getDebugToggleKey() {
-    return debugToggleKey;
-  }
-
-  /**
-   * Returns the key used to toggle visual debug (bounding box drawing) on/off.
-   *
-   * @see org.flixelgdx.input.keyboard.FlixelKey
-   */
-  public static int getDebugDrawToggleKey() {
-    return debugDrawToggleKey;
-  }
-
-  /** Key used to pause the game update loop (debug mode only). */
-  public static int getDebugPauseKey() {
-    return debugPauseKey;
-  }
-
-  /** Mouse button (e.g. {@link Input.Buttons#RIGHT}) for debug camera pan while paused. */
-  public static int getDebugCameraPanButton() {
-    return debugCameraPanButton;
-  }
-
-  public static int getDebugCameraCycleLeftKey() {
-    return debugCameraCycleLeftKey;
-  }
-
-  public static int getDebugCameraCycleRightKey() {
-    return debugCameraCycleRightKey;
-  }
-
-  /**
    * Returns the capped elapsed time (in seconds) for the current frame. This value is clamped
    * between {@link #MIN_ELAPSED} and {@link #MAX_ELAPSED} by
    * {@link FlixelGame} each frame.
@@ -1209,20 +1150,12 @@ public final class Flixel {
   }
 
   /**
-   * Returns the active debug overlay instance, or {@code null} when debug mode is off
-   * or the overlay has not been created yet.
-   */
-  public static FlixelDebugOverlay getDebugOverlay() {
-    return debugOverlay;
-  }
-
-  /**
    * Creates the debug overlay using the registered factory. Called internally by
    * {@link FlixelGame} during startup when debug mode is enabled.
    */
   static FlixelDebugOverlay createDebugOverlay() {
-    debugOverlay = debugOverlayFactory.get();
-    return debugOverlay;
+    debug.overlay = debugOverlayFactory.get();
+    return debug.overlay;
   }
 
   /**
@@ -1231,7 +1164,9 @@ public final class Flixel {
    * first; this method only nulls the static handle to avoid double-dispose.
    */
   static void clearDebugOverlay() {
-    debugOverlay = null;
+    if (debug != null) {
+      debug.overlay = null;
+    }
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -1017,14 +1017,6 @@ public final class Flixel {
     return assets;
   }
 
-  public static FlixelGame getGame() {
-    return game;
-  }
-
-  public static FlixelState getState() {
-    return state;
-  }
-
   /**
    * Returns the visible width of the game world in game pixels.
    *
@@ -1180,48 +1172,12 @@ public final class Flixel {
   }
 
   /**
-   * Returns the Java heap memory currently in use, in megabytes.
-   *
-   * @return The Java heap memory currently in use, in megabytes.
-   */
-  public static float getJavaHeapUsedMegabytes() {
-    return getJavaHeapUsedBytes() / (1024f * 1024f);
-  }
-
-  /**
-   * Returns the Java heap memory currently in use, in gigabytes.
-   *
-   * @return The Java heap memory currently in use, in gigabytes.
-   */
-  public static float getJavaHeapUsedGigabytes() {
-    return getJavaHeapUsedBytes() / (1024f * 1024f * 1024f);
-  }
-
-  /**
    * Returns the total Java heap memory allocated by the JVM, in bytes.
    *
    * @return The total Java heap memory allocated by the JVM, in bytes.
    */
   public static long getJavaHeapTotalBytes() {
     return Runtime.getRuntime().totalMemory();
-  }
-
-  /**
-   * Returns the total Java heap memory allocated by the JVM, in megabytes.
-   *
-   * @return The total Java heap memory allocated by the JVM, in megabytes.
-   */
-  public static float getJavaHeapTotalMegabytes() {
-    return getJavaHeapTotalBytes() / (1024f * 1024f);
-  }
-
-  /**
-   * Returns the total Java heap memory allocated by the JVM, in gigabytes.
-   *
-   * @return The total Java heap memory allocated by the JVM, in gigabytes.
-   */
-  public static float getJavaHeapTotalGigabytes() {
-    return getJavaHeapTotalBytes() / (1024f * 1024f * 1024f);
   }
 
   /**
@@ -1234,24 +1190,6 @@ public final class Flixel {
   }
 
   /**
-   * Returns the maximum Java heap memory available to the JVM, in megabytes.
-   *
-   * @return The maximum Java heap memory available to the JVM, in megabytes.
-   */
-  public static float getJavaHeapMaxMegabytes() {
-    return getJavaHeapMaxBytes() / (1024f * 1024f);
-  }
-
-  /**
-   * Returns the maximum Java heap memory available to the JVM, in gigabytes.
-   *
-   * @return The maximum Java heap memory available to the JVM, in gigabytes.
-   */
-  public static float getJavaHeapMaxGigabytes() {
-    return getJavaHeapMaxBytes() / (1024f * 1024f * 1024f);
-  }
-
-  /**
    * Returns an estimate of the native heap usage in bytes as reported by libGDX.
    *
    * <p>This is not available on all platforms and may return the same number as the
@@ -1259,30 +1197,6 @@ public final class Flixel {
    */
   public static long getNativeHeapUsedBytes() {
     return Gdx.app != null ? Gdx.app.getNativeHeap() : 0L;
-  }
-
-  /**
-   * Returns the native heap usage in megabytes.
-   *
-   * <p>This is not available on all platforms and may return the same number as the
-   * Java heap when unsupported.
-   *
-   * @return The native heap usage in megabytes.
-   */
-  public static float getNativeHeapUsedMegabytes() {
-    return getNativeHeapUsedBytes() / (1024f * 1024f);
-  }
-
-  /**
-   * Returns the native heap usage in gigabytes.
-   *
-   * <p>This is not available on all platforms and may return the same number as the
-   * Java heap when unsupported.
-   *
-   * @return The native heap usage in gigabytes.
-   */
-  public static float getNativeHeapUsedGigabytes() {
-    return getNativeHeapUsedBytes() / (1024f * 1024f * 1024f);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
@@ -1309,7 +1309,7 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
   }
 
   private static int resolveWindowWidth() {
-    if (Flixel.getGame() != null) {
+    if (Flixel.game != null) {
       return Flixel.getWidth();
     }
     if (Gdx.graphics != null) {
@@ -1323,7 +1323,7 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
    * {@link com.badlogic.gdx.Graphics#getHeight()}.
    */
   private static int resolveWindowHeight() {
-    if (Flixel.getGame() != null) {
+    if (Flixel.game != null) {
       return Flixel.getHeight();
     }
     if (Gdx.graphics != null) {
@@ -1363,7 +1363,7 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
     if (useSubScreenViewport || hasCustomPixelRegion || regionMode != RegionMode.PIXEL_TOP_LEFT) {
       return true;
     }
-    FlixelGame game = Flixel.getGame();
+    FlixelGame game = Flixel.game;
     if (game == null || game.getCameras() == null || game.getCameras().size <= 1) {
       return false;
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -501,7 +501,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     if (Flixel.gamepads != null) {
       Flixel.gamepads.update();
     }
-    FlixelActionSets.updateAll(elapsed);
+    FlixelActionSets.update(elapsed);
 
     if (!gamePaused) {
       FlixelTween.updateTweens(elapsed);

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -510,7 +510,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
       // Walk the state/substate chain. Each state in the chain is updated only
       // if it is the active (innermost) state or if its persistentUpdate flag is true.
-      FlixelState current = Flixel.getState();
+      FlixelState current = Flixel.state;
       while (current != null) {
         FlixelState sub = current.getSubState();
         boolean hasSubState = (sub != null);
@@ -554,7 +554,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     Flixel.Signals.preDraw.dispatch();
 
     ScreenUtils.clear(bgColor); // Clear the screen to refresh it.
-    FlixelState state = Flixel.getState();
+    FlixelState state = Flixel.state;
 
     int totalRenderCallsBefore = batch.getTotalRenderCalls();
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -464,9 +464,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       overlayCamera.update(width, height, overlayCamera.centerCameraOnResize);
     }
 
-    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
-    if (debugOverlay != null) {
-      debugOverlay.resize(width, height);
+    if (Flixel.debug != null) {
+      Flixel.debug.overlay.resize(width, height);
     }
 
     FlixelState state = Flixel.state;
@@ -535,9 +534,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       }
     }
 
-    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
-    if (debugOverlay != null && Flixel.isDebugMode()) {
-      debugOverlay.update(elapsed);
+    if (Flixel.debug != null && Flixel.isDebugMode()) {
+      Flixel.debug.overlay.update(elapsed);
     }
 
     postUpdateData.set(elapsed);
@@ -667,10 +665,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
     frameRenderCalls = batch.getTotalRenderCalls() - totalRenderCallsBefore;
 
-    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
-    if (debugOverlay != null) {
-      debugOverlay.drawBoundingBoxes(cameras.items);
-      debugOverlay.draw();
+    if (Flixel.debug != null) {
+      Flixel.debug.overlay.drawBoundingBoxes(cameras.items);
+      Flixel.debug.overlay.draw();
     }
 
     squashFramebufferAlpha();
@@ -1103,12 +1100,11 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
     Flixel.Signals.preGameClose.dispatch();
 
-    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
-    if (debugOverlay != null) {
+    if (Flixel.debug != null) {
       if (Flixel.log != null) {
-        Flixel.log.removeLogListener(debugOverlay.getLogListener());
+        Flixel.log.removeLogListener(Flixel.debug.overlay.getLogListener());
       }
-      debugOverlay.destroy();
+      Flixel.debug.overlay.destroy();
       Flixel.clearDebugOverlay();
     }
 
@@ -1195,7 +1191,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       String logs = FlixelRuntimeUtil.getFullExceptionMessage(throwable);
       String msg = "There was an uncaught exception on thread \"" + thread.getName() + "\"!\n" + logs;
       Flixel.error(msg);
-      Flixel.showErrorAlert("Uncaught Exception", msg);
+      Flixel.alert.showErrorAlert("Uncaught Exception", msg);
       destroy();
       // Only use Gdx.app.exit() on non-iOS platforms to avoid App Store guideline violations!
       if (Gdx.app.getType() != Application.ApplicationType.iOS) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -464,7 +464,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       overlayCamera.update(width, height, overlayCamera.centerCameraOnResize);
     }
 
-    FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
+    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
     if (debugOverlay != null) {
       debugOverlay.resize(width, height);
     }
@@ -535,7 +535,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
       }
     }
 
-    FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
+    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
     if (debugOverlay != null && Flixel.isDebugMode()) {
       debugOverlay.update(elapsed);
     }
@@ -667,7 +667,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
     frameRenderCalls = batch.getTotalRenderCalls() - totalRenderCallsBefore;
 
-    FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
+    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
     if (debugOverlay != null) {
       debugOverlay.drawBoundingBoxes(cameras.items);
       debugOverlay.draw();
@@ -1103,7 +1103,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
     Flixel.Signals.preGameClose.dispatch();
 
-    FlixelDebugOverlay debugOverlay = Flixel.getDebugOverlay();
+    FlixelDebugOverlay debugOverlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
     if (debugOverlay != null) {
       if (Flixel.log != null) {
         Flixel.log.removeLogListener(debugOverlay.getLogListener());
@@ -1126,8 +1126,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     FlixelTween.resetRegistry();
     FlixelTimer.cancelAll();
 
-    if (Flixel.getState() != null) {
-      Flixel.getState().destroy();
+    if (Flixel.state != null) {
+      Flixel.state.destroy();
     }
     if (batch != null) {
       batch.dispose();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
@@ -111,7 +111,7 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
 
   /**
    * Called when the state is first created. This is where you want to assign your
-   * sprites and set up everything your state uses!
+   * sprites and set up everything your state uses.
    *
    * <p>Make sure to override this, NOT the constructor!
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelState.java
@@ -309,8 +309,7 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
    * @return The background color of the first camera.
    */
   public Color getBgColor() {
-    FlixelGame game = Flixel.getGame();
-    if (game == null) {
+    if (Flixel.game == null) {
       return Color.BLACK;
     }
     return Flixel.cameras.first().bgColor;
@@ -325,11 +324,10 @@ public abstract class FlixelState extends FlixelBasicGroup<IFlixelBasic> impleme
     if (value == null) {
       return;
     }
-    FlixelGame game = Flixel.getGame();
-    if (game == null) {
+    if (Flixel.game == null) {
       return;
     }
-    for (FlixelCamera cam : game.getCameras()) {
+    for (FlixelCamera cam : Flixel.game.getCameras()) {
       cam.bgColor.set(value);
     }
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -243,13 +243,13 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
 
   @Override
   public boolean update() {
-    boolean prewarmPending = Flixel.getSoundFactory() != null && !Flixel.getSoundFactory().isPrewarmPending();
+    boolean prewarmPending = Flixel.soundFactory != null && !Flixel.soundFactory.isPrewarmPending();
     return manager.update() && !prewarmPending;
   }
 
   @Override
   public boolean update(int millis) {
-    boolean prewarmPending = Flixel.getSoundFactory() != null && !Flixel.getSoundFactory().isPrewarmPending();
+    boolean prewarmPending = Flixel.soundFactory != null && !Flixel.soundFactory.isPrewarmPending();
     return manager.update(millis) && prewarmPending;
   }
 
@@ -550,8 +550,8 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     if (Gdx.app == null || Gdx.app.getType() != Application.ApplicationType.WebGL) {
       return;
     }
-    if (Flixel.getSoundFactory() != null) {
-      Flixel.getSoundFactory().prewarmSound(resolveAudioPath(path));
+    if (Flixel.soundFactory != null) {
+      Flixel.soundFactory.prewarmSound(resolveAudioPath(path));
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
@@ -614,7 +614,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
    * Called from {@link #destroy()}.
    */
   public void clearAudioEffectChain() {
-    FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
+    FlixelSoundBackend.Factory factory = Flixel.soundFactory;
     for (int i = audioEffectNodes.size - 1; i >= 0; i--) {
       FlixelSoundBackend.EffectNode n = audioEffectNodes.get(i);
       n.detach(0);
@@ -645,7 +645,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
    */
   @NotNull
   public FlixelSoundBackend.ReverbNode addReverb(float wetAmount) {
-    FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
+    FlixelSoundBackend.Factory factory = Flixel.soundFactory;
     if (factory == null)
       return FlixelSoundBackend.ReverbNode.NOOP;
     FlixelSoundBackend.ReverbNode node = factory.createReverbNode(wetAmount);
@@ -665,7 +665,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
    */
   @NotNull
   public FlixelSoundBackend.EchoNode addEcho(float delaySeconds, float decay) {
-    FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
+    FlixelSoundBackend.Factory factory = Flixel.soundFactory;
     if (factory == null)
       return FlixelSoundBackend.EchoNode.NOOP;
     FlixelSoundBackend.EchoNode node = factory.createDelayNode(delaySeconds, decay);
@@ -689,7 +689,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
    */
   @NotNull
   public FlixelSoundBackend.LowPassNode addLowPassMuffle(double cutoffHz) {
-    FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
+    FlixelSoundBackend.Factory factory = Flixel.soundFactory;
     if (factory == null)
       return FlixelSoundBackend.LowPassNode.NOOP;
     FlixelSoundBackend.LowPassNode node = factory.createLowPassFilter(cutoffHz, 2);
@@ -712,7 +712,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
   }
 
   private void attachEffectNode(@NotNull FlixelSoundBackend.EffectNode node) {
-    FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
+    FlixelSoundBackend.Factory factory = Flixel.soundFactory;
     if (audioEffectNodes.size == 0) {
       node.attachToUpstream(sound, 0);
     } else {
@@ -750,7 +750,7 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
 
   private static FlixelSoundBackend createSoundForHandle(@NotNull FileHandle path) {
     String resolvedPath = FlixelPathsUtil.resolveAudioPath(path.path());
-    FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
+    FlixelSoundBackend.Factory factory = Flixel.soundFactory;
     Object sfxGroup = Flixel.sound != null ? Flixel.sound.getSfxGroup() : null;
     return factory.createSound(resolvedPath, (short) 0, sfxGroup, false);
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundSource.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundSource.java
@@ -98,7 +98,7 @@ public final class FlixelSoundSource {
   public FlixelSound create(@Nullable Object group) {
     String resolvedPath = external ? assetKey : FlixelPathsUtil.resolveAudioPath(assetKey);
     Object targetGroup = (group != null) ? group : Flixel.sound.getSfxGroup();
-    FlixelSoundBackend.Factory factory = Flixel.getSoundFactory();
+    FlixelSoundBackend.Factory factory = Flixel.soundFactory;
     FlixelSoundBackend backend = factory.createSound(resolvedPath, (short) 0, targetGroup, external);
     return new FlixelSound(backend);
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelWindow.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelWindow.java
@@ -90,8 +90,7 @@ public interface FlixelWindow extends FlixelShakeable {
    * @return current launch-time request for an alpha-capable default framebuffer.
    */
   default boolean isTransparentFramebufferRequested() {
-    FlixelGame g = Flixel.getGame();
-    return g != null && g.isTransparentFramebufferRequested();
+    return Flixel.game != null && Flixel.game.isTransparentFramebufferRequested();
   }
 
   /**
@@ -105,9 +104,8 @@ public interface FlixelWindow extends FlixelShakeable {
    * @param active {@code true} to composite with the desktop through alpha; {@code false} for a normal opaque window interior.
    */
   default void setTransparencyActive(boolean active) {
-    FlixelGame g = Flixel.getGame();
-    if (g != null) {
-      g.applyBackdropForDesktopTransparency(active);
+    if (Flixel.game != null) {
+      Flixel.game.applyBackdropForDesktopTransparency(active);
     }
   }
 
@@ -115,8 +113,7 @@ public interface FlixelWindow extends FlixelShakeable {
    * @return last value applied by {@link #setTransparencyActive(boolean)} for this game session.
    */
   default boolean isTransparencyActive() {
-    FlixelGame g = Flixel.getGame();
-    return g != null && g.isTransparencyActive();
+    return Flixel.game != null && Flixel.game.isTransparencyActive();
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
@@ -76,18 +76,6 @@ import java.util.regex.Pattern;
 public class FlixelDebugManager {
 
   /**
-   * Internal handler form used after registration has wrapped the raw consumer. Kept
-   * package-private because external code never has a reason to construct one directly.
-   */
-  @FunctionalInterface
-  interface CommandHandler {
-    void invoke(@NotNull FlixelDebugCommandArgs args);
-  }
-
-  record RegisteredCommand(String name, CommandHandler handler) {
-  }
-
-  /**
    * Regex enforced by {@link #registerCommand(String, Consumer)}. A valid command name must
    * consist of one or more letters and / or periods only; everything else (numbers, hyphens, underscores,
    * whitespace, symbols, etc.) triggers an {@link IllegalArgumentException} from {@link #validateCommandName(String)}.
@@ -252,8 +240,7 @@ public class FlixelDebugManager {
     }
   }
 
-  /** Returns the live array of user-registered batches. Package-private; consumed by the debug overlay. */
-  Array<FlixelBatch> getTrackedBatches() {
+  public Array<FlixelBatch> getTrackedBatches() {
     return trackedBatches;
   }
 
@@ -471,5 +458,17 @@ public class FlixelDebugManager {
         Flixel.watch.addMouse();
       }
     });
+  }
+
+  /**
+   * Internal handler form used after registration has wrapped the raw consumer. Kept
+   * package-private because external code never has a reason to construct one directly.
+   */
+  @FunctionalInterface
+  interface CommandHandler {
+    void invoke(@NotNull FlixelDebugCommandArgs args);
+  }
+
+  record RegisteredCommand(String name, CommandHandler handler) {
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
@@ -103,7 +103,7 @@ public class FlixelDebugManager {
 
   /**
    * The active debug overlay. Defaults to {@link FlixelNoopDebugOverlay#INSTANCE} so this field
-   * is never {@code null} -- callers do not need a null check. When debug mode starts,
+   * is never {@code null}, meaning callers do not need a null check. When debug mode starts,
    * {@link org.flixelgdx.Flixel Flixel} replaces this with a real overlay instance.
    *
    * <p>Access keybinds and visibility via this field:

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
@@ -48,6 +48,11 @@ import java.util.regex.Pattern;
  * Flixel.debug.setDrawDebug(true);
  * Flixel.debug.registerCommand("hello", args -> Flixel.info("Hi!"));
  * Flixel.debug.executeCommand("hello");
+ *
+ * // Customize keybinds via the overlay field (null-safe: only set after debug mode starts).
+ * if (Flixel.debug.overlay != null) {
+ *   Flixel.debug.overlay.toggleKey = FlixelKey.F1;
+ * }
  * }</pre>
  *
  * <p>The manager is intentionally lightweight: it forwards visibility/hitbox toggles to the active
@@ -108,6 +113,19 @@ public class FlixelDebugManager {
    */
   private final Array<FlixelDebugTrackerEntry> trackerEntries = new Array<>(FlixelDebugTrackerEntry[]::new);
 
+  /**
+   * The active debug overlay instance, or {@code null} when debug mode is off or the overlay
+   * has not been created yet. Assigned by {@link org.flixelgdx.Flixel Flixel} during startup.
+   *
+   * <p>Access keybinds and visibility via this field:
+   * <pre>{@code
+   * Flixel.debug.overlay.toggleKey = FlixelKey.F1;
+   * Flixel.debug.overlay.setVisible(true);
+   * }</pre>
+   */
+  @Nullable
+  public FlixelDebugOverlay overlay;
+
   /** The sprite currently selected by the LMB picker, or {@code null}. */
   @Nullable
   private FlixelObject inspectedSprite;
@@ -121,20 +139,8 @@ public class FlixelDebugManager {
     registerBuiltinCommands();
   }
 
-  /**
-   * Returns the currently active {@link FlixelDebugOverlay}, or {@code null} if the game is not
-   * running in debug mode (or the overlay has not been created yet).
-   *
-   * @return The active overlay, or {@code null}.
-   */
-  @Nullable
-  public FlixelDebugOverlay getOverlay() {
-    return Flixel.getDebugOverlay();
-  }
-
   /** Returns {@code true} when the overlay is on screen. */
   public boolean isVisible() {
-    FlixelDebugOverlay overlay = getOverlay();
     return overlay != null && overlay.isVisible();
   }
 
@@ -144,7 +150,6 @@ public class FlixelDebugManager {
    * @param visible {@code true} to show, {@code false} to hide.
    */
   public void setVisible(boolean visible) {
-    FlixelDebugOverlay overlay = getOverlay();
     if (overlay != null) {
       overlay.setVisible(visible);
     }
@@ -152,7 +157,6 @@ public class FlixelDebugManager {
 
   /** Toggles the overlay visibility. */
   public void toggleVisible() {
-    FlixelDebugOverlay overlay = getOverlay();
     if (overlay != null) {
       overlay.toggleVisible();
     }
@@ -160,7 +164,6 @@ public class FlixelDebugManager {
 
   /** Returns {@code true} when bounding-box drawing (hitboxes) is on. */
   public boolean isDrawDebug() {
-    FlixelDebugOverlay overlay = getOverlay();
     return overlay != null && overlay.isDrawDebug();
   }
 
@@ -170,7 +173,6 @@ public class FlixelDebugManager {
    * @param drawDebug {@code true} to draw, {@code false} to hide.
    */
   public void setDrawDebug(boolean drawDebug) {
-    FlixelDebugOverlay overlay = getOverlay();
     if (overlay != null) {
       overlay.setDrawDebug(drawDebug);
     }
@@ -178,7 +180,6 @@ public class FlixelDebugManager {
 
   /** Toggles bounding-box drawing. */
   public void toggleDrawDebug() {
-    FlixelDebugOverlay overlay = getOverlay();
     if (overlay != null) {
       overlay.toggleDrawDebug();
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugManager.java
@@ -114,8 +114,9 @@ public class FlixelDebugManager {
   private final Array<FlixelDebugTrackerEntry> trackerEntries = new Array<>(FlixelDebugTrackerEntry[]::new);
 
   /**
-   * The active debug overlay instance, or {@code null} when debug mode is off or the overlay
-   * has not been created yet. Assigned by {@link org.flixelgdx.Flixel Flixel} during startup.
+   * The active debug overlay. Defaults to {@link FlixelNoopDebugOverlay#INSTANCE} so this field
+   * is never {@code null} -- callers do not need a null check. When debug mode starts,
+   * {@link org.flixelgdx.Flixel Flixel} replaces this with a real overlay instance.
    *
    * <p>Access keybinds and visibility via this field:
    * <pre>{@code
@@ -123,8 +124,7 @@ public class FlixelDebugManager {
    * Flixel.debug.overlay.setVisible(true);
    * }</pre>
    */
-  @Nullable
-  public FlixelDebugOverlay overlay;
+  public FlixelDebugOverlay overlay = FlixelNoopDebugOverlay.INSTANCE;
 
   /** The sprite currently selected by the LMB picker, or {@code null}. */
   @Nullable
@@ -141,7 +141,7 @@ public class FlixelDebugManager {
 
   /** Returns {@code true} when the overlay is on screen. */
   public boolean isVisible() {
-    return overlay != null && overlay.isVisible();
+    return overlay.isVisible();
   }
 
   /**
@@ -150,21 +150,17 @@ public class FlixelDebugManager {
    * @param visible {@code true} to show, {@code false} to hide.
    */
   public void setVisible(boolean visible) {
-    if (overlay != null) {
-      overlay.setVisible(visible);
-    }
+    overlay.setVisible(visible);
   }
 
   /** Toggles the overlay visibility. */
   public void toggleVisible() {
-    if (overlay != null) {
-      overlay.toggleVisible();
-    }
+    overlay.toggleVisible();
   }
 
   /** Returns {@code true} when bounding-box drawing (hitboxes) is on. */
   public boolean isDrawDebug() {
-    return overlay != null && overlay.isDrawDebug();
+    return overlay.isDrawDebug();
   }
 
   /**
@@ -173,16 +169,12 @@ public class FlixelDebugManager {
    * @param drawDebug {@code true} to draw, {@code false} to hide.
    */
   public void setDrawDebug(boolean drawDebug) {
-    if (overlay != null) {
-      overlay.setDrawDebug(drawDebug);
-    }
+    overlay.setDrawDebug(drawDebug);
   }
 
   /** Toggles bounding-box drawing. */
   public void toggleDrawDebug() {
-    if (overlay != null) {
-      overlay.toggleDrawDebug();
-    }
+    overlay.toggleDrawDebug();
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -135,7 +135,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   /** Mouse button used to pan the debug camera while paused. Set to a negative value to disable. */
   public int cameraPanButton = FlixelMouseButton.RIGHT;
 
-  private final ShapeRenderer shapeRenderer;
+  @Nullable
+  private ShapeRenderer shapeRenderer;
 
   protected float statsTimer = 0f;
   protected int cachedFps;
@@ -224,9 +225,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   private boolean destroyed = false;
 
   /** Constructs the shared debug overlay state. Subclasses should call this before wiring platform UI. */
-  protected FlixelDebugOverlay() {
-    shapeRenderer = new ShapeRenderer();
-  }
+  protected FlixelDebugOverlay() {}
 
   public final Consumer<FlixelLogEntry> getLogListener() {
     return logListener;
@@ -801,6 +800,10 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
       return;
     }
 
+    if (shapeRenderer == null) {
+      shapeRenderer = new ShapeRenderer();
+    }
+
     Gdx.gl.glEnable(GL20.GL_BLEND);
     Gdx.gl.glBlendFunc(GL20.GL_SRC_ALPHA, GL20.GL_ONE_MINUS_SRC_ALPHA);
 
@@ -995,7 +998,9 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
       return;
     }
     destroyed = true;
-    shapeRenderer.dispose();
+    if (shapeRenderer != null) {
+      shapeRenderer.dispose();
+    }
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -298,8 +298,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (Flixel.isDebugMode()) {
       // Raw* so the game loop pause toggle keeps working even while an imgui text field is focused,
       // unless a backend suppresses typable keys while a command field is active (see LWJGL ImGui overlay).
-      if (pauseKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(pauseKey)
-          && !shouldSuppressDebugRawKeybind(pauseKey)) {
+      if (Flixel.keys.rawJustPressed(pauseKey) && !shouldSuppressDebugRawKeybind(pauseKey)) {
         Flixel.game.setGamePaused(!Flixel.game.isGamePaused());
       }
       if (Flixel.game.isGamePaused()) {
@@ -429,12 +428,10 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     // Use the raw* variants so the toggle keys still work even while a Dear ImGui text field
     // (for example, the debug command line) has keyboard focus and the regular justPressed
     // helpers are intentionally suppressed.
-    if (toggleKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(toggleKey)
-        && !shouldSuppressDebugRawKeybind(toggleKey)) {
+    if (Flixel.keys.rawJustPressed(toggleKey) && !shouldSuppressDebugRawKeybind(toggleKey)) {
       toggleVisible();
     }
-    if (drawDebugKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(drawDebugKey)
-        && !shouldSuppressDebugRawKeybind(drawDebugKey)) {
+    if (Flixel.keys.rawJustPressed(drawDebugKey) && !shouldSuppressDebugRawKeybind(drawDebugKey)) {
       toggleDrawDebug();
     }
   }
@@ -540,11 +537,11 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     // input suppression we set up to protect the game's regular input).
     boolean alt = Flixel.keys.rawPressed(FlixelKey.ALT_LEFT) || Flixel.keys.rawPressed(FlixelKey.ALT_RIGHT)
         || Gdx.input.isKeyPressed(Input.Keys.ALT_LEFT) || Gdx.input.isKeyPressed(Input.Keys.ALT_RIGHT);
-    if (alt && cameraCycleLeftKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(cameraCycleLeftKey)
+    if (alt && Flixel.keys.rawJustPressed(cameraCycleLeftKey)
         && !shouldSuppressDebugRawKeybind(cameraCycleLeftKey)) {
       debugInspectCameraIndex = (debugInspectCameraIndex - 1 + cams.size) % cams.size;
     }
-    if (alt && cameraCycleRightKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(cameraCycleRightKey)
+    if (alt && Flixel.keys.rawJustPressed(cameraCycleRightKey)
         && !shouldSuppressDebugRawKeybind(cameraCycleRightKey)) {
       debugInspectCameraIndex = (debugInspectCameraIndex + 1) % cams.size;
     }
@@ -564,7 +561,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     }
     cam.applyLibCameraTransform();
 
-    if (!uiCapturedMouse && cameraPanButton >= 0 && Flixel.mouse.rawPressed(cameraPanButton)) {
+    if (!uiCapturedMouse && Flixel.mouse.rawPressed(cameraPanButton)) {
       int sx = Flixel.mouse.getScreenX();
       int sy = Flixel.mouse.getScreenY();
       if (Flixel.mouse.rawJustPressed(cameraPanButton)) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -312,8 +312,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     }
 
     // Performance ring buffers are sampled whenever the game runs in debug mode, not only while
-    // the overlay is visible, so opening the Performance window mid-session still shows a useful
-    // history instead of an empty graph for the first several seconds.
+    // the overlay is visible, so opening a panel mid-session still shows a useful history instead
+    // of an empty graph for the first several seconds.
     if (Flixel.isDebugMode()) {
       perfSampleTimer += elapsed;
       if (perfSampleTimer >= PERF_SAMPLE_INTERVAL) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -77,11 +77,11 @@ import java.util.function.Consumer;
  *       and registers it with the logger.</li>
  * </ol>
  *
- * <p>Toggle overlay visibility with {@link Flixel#getDebugToggleKey()} (default
- * {@link Keybinds#DEFAULT_TOGGLE_KEY}). Toggle visual debug (hitboxes) with
- * {@link Flixel#getDebugDrawToggleKey()} (default {@link Keybinds#DEFAULT_DRAW_DEBUG_KEY}).
- * In debug mode, {@link Flixel#getDebugPauseKey()} (default F4) pauses the game; while paused you
- * can inspect the camera with Alt+arrows, RMB pan, and the mouse wheel zoom.
+ * <p>Toggle overlay visibility with {@link #toggleKey} (default {@link Keybinds#DEFAULT_TOGGLE_KEY}).
+ * Toggle visual debug (hitboxes) with {@link #drawDebugKey} (default {@link Keybinds#DEFAULT_DRAW_DEBUG_KEY}).
+ * In debug mode, {@link #pauseKey} (default F4) pauses the game; while paused you can inspect the camera
+ * with Alt+arrows ({@link #cameraCycleLeftKey} / {@link #cameraCycleRightKey}), {@link #cameraPanButton} pan,
+ * and the mouse wheel zoom.
  *
  * <h2>Reduced allocation rate</h2>
  *
@@ -116,6 +116,24 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
 
   /** Fallback color used when a {@link FlixelDebugDrawable} returns a {@code null} or undersized array. */
   private static final float[] FALLBACK_BOUNDING_BOX_COLOR = { 1f, 0.2f, 0.2f, 0.6f };
+
+  /** Key that toggles overlay visibility. Set to {@link FlixelKey#NONE} to disable. */
+  public int toggleKey = Keybinds.DEFAULT_TOGGLE_KEY;
+
+  /** Key that toggles bounding-box (hitbox) drawing. Set to {@link FlixelKey#NONE} to disable. */
+  public int drawDebugKey = Keybinds.DEFAULT_DRAW_DEBUG_KEY;
+
+  /** Key that pauses/unpauses the game loop (debug mode only). Set to {@link FlixelKey#NONE} to disable. */
+  public int pauseKey = Keybinds.DEFAULT_PAUSE_KEY;
+
+  /** Key that cycles the debug inspect camera left while paused (with Alt). Set to {@link FlixelKey#NONE} to disable. */
+  public int cameraCycleLeftKey = Keybinds.DEFAULT_DEBUG_CAMERA_CYCLE_LEFT;
+
+  /** Key that cycles the debug inspect camera right while paused (with Alt). Set to {@link FlixelKey#NONE} to disable. */
+  public int cameraCycleRightKey = Keybinds.DEFAULT_DEBUG_CAMERA_CYCLE_RIGHT;
+
+  /** Mouse button used to pan the debug camera while paused. Set to a negative value to disable. */
+  public int cameraPanButton = FlixelMouseButton.RIGHT;
 
   private final ShapeRenderer shapeRenderer;
 
@@ -280,8 +298,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (Flixel.isDebugMode()) {
       // Raw* so the game loop pause toggle keeps working even while an imgui text field is focused,
       // unless a backend suppresses typable keys while a command field is active (see LWJGL ImGui overlay).
-      int pauseKey = Flixel.getDebugPauseKey();
-      if (Flixel.keys.rawJustPressed(pauseKey) && !shouldSuppressDebugRawKeybind(pauseKey)) {
+      if (pauseKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(pauseKey)
+          && !shouldSuppressDebugRawKeybind(pauseKey)) {
         Flixel.game.setGamePaused(!Flixel.game.isGamePaused());
       }
       if (Flixel.game.isGamePaused()) {
@@ -316,8 +334,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (statsTimer >= STATS_UPDATE_INTERVAL) {
       statsTimer = 0f;
       cachedFps = Gdx.graphics.getFramesPerSecond();
-      cachedHeapMegabytes = Flixel.getJavaHeapUsedMegabytes();
-      cachedNativeMegabytes = Flixel.getNativeHeapUsedMegabytes();
+      cachedHeapMegabytes = Flixel.getJavaHeapUsedBytes() / (1024f * 1024f);
+      cachedNativeMegabytes = Flixel.getNativeHeapUsedBytes() / (1024f * 1024f);
       cachedObjectCount = FlixelDebugUtil.countActiveMembers();
       cachedAssetCount = Flixel.assets != null ? Flixel.assets.getLoadedAssetCount() : 0;
     }
@@ -340,8 +358,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   protected void pushPerfSample(float elapsed) {
     int idx = perfHead;
     perfFrameMs[idx] = elapsed * 1000f;
-    perfHeapMb[idx] = Flixel.getJavaHeapUsedMegabytes();
-    perfNativeMb[idx] = Flixel.getNativeHeapUsedMegabytes();
+    perfHeapMb[idx] = Flixel.getJavaHeapUsedBytes() / (1024f * 1024f);
+    perfNativeMb[idx] = Flixel.getNativeHeapUsedBytes() / (1024f * 1024f);
     perfFps[idx] = Gdx.graphics.getFramesPerSecond();
     perfRenderCalls[idx] = sampleRenderCallsNow();
     perfHead = (idx + 1) % PERF_HISTORY_SIZE;
@@ -411,12 +429,12 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     // Use the raw* variants so the toggle keys still work even while a Dear ImGui text field
     // (for example, the debug command line) has keyboard focus and the regular justPressed
     // helpers are intentionally suppressed.
-    int toggleKey = Flixel.getDebugToggleKey();
-    if (Flixel.keys.rawJustPressed(toggleKey) && !shouldSuppressDebugRawKeybind(toggleKey)) {
+    if (toggleKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(toggleKey)
+        && !shouldSuppressDebugRawKeybind(toggleKey)) {
       toggleVisible();
     }
-    int drawKey = Flixel.getDebugDrawToggleKey();
-    if (Flixel.keys.rawJustPressed(drawKey) && !shouldSuppressDebugRawKeybind(drawKey)) {
+    if (drawDebugKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(drawDebugKey)
+        && !shouldSuppressDebugRawKeybind(drawDebugKey)) {
       toggleDrawDebug();
     }
   }
@@ -522,12 +540,12 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     // input suppression we set up to protect the game's regular input).
     boolean alt = Flixel.keys.rawPressed(FlixelKey.ALT_LEFT) || Flixel.keys.rawPressed(FlixelKey.ALT_RIGHT)
         || Gdx.input.isKeyPressed(Input.Keys.ALT_LEFT) || Gdx.input.isKeyPressed(Input.Keys.ALT_RIGHT);
-    int cycleLeft = Flixel.getDebugCameraCycleLeftKey();
-    int cycleRight = Flixel.getDebugCameraCycleRightKey();
-    if (alt && Flixel.keys.rawJustPressed(cycleLeft) && !shouldSuppressDebugRawKeybind(cycleLeft)) {
+    if (alt && cameraCycleLeftKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(cameraCycleLeftKey)
+        && !shouldSuppressDebugRawKeybind(cameraCycleLeftKey)) {
       debugInspectCameraIndex = (debugInspectCameraIndex - 1 + cams.size) % cams.size;
     }
-    if (alt && Flixel.keys.rawJustPressed(cycleRight) && !shouldSuppressDebugRawKeybind(cycleRight)) {
+    if (alt && cameraCycleRightKey != FlixelKey.NONE && Flixel.keys.rawJustPressed(cameraCycleRightKey)
+        && !shouldSuppressDebugRawKeybind(cameraCycleRightKey)) {
       debugInspectCameraIndex = (debugInspectCameraIndex + 1) % cams.size;
     }
 
@@ -546,10 +564,10 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     }
     cam.applyLibCameraTransform();
 
-    if (!uiCapturedMouse && Flixel.mouse.rawPressed(Flixel.getDebugCameraPanButton())) {
+    if (!uiCapturedMouse && cameraPanButton >= 0 && Flixel.mouse.rawPressed(cameraPanButton)) {
       int sx = Flixel.mouse.getScreenX();
       int sy = Flixel.mouse.getScreenY();
-      if (Flixel.mouse.rawJustPressed(Flixel.getDebugCameraPanButton())) {
+      if (Flixel.mouse.rawJustPressed(cameraPanButton)) {
         lastPanScreenX = sx;
         lastPanScreenY = sy;
       } else {
@@ -568,7 +586,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   /**
    * Handles the LMB picker while the game is paused: clicks select a {@link FlixelObject} for the
    * texture inspector, drags move the selected object around in world space. Camera panning is on
-   * the right mouse button (see {@link Flixel#getDebugCameraPanButton()}) so the two interactions
+   * the right mouse button (see {@link #cameraPanButton}) so the two interactions
    * never fight over the same gesture.
    *
    * <p>Driven from {@link #update(float)} only when the game is paused. Skipped when the cursor is
@@ -676,7 +694,7 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    */
   @Nullable
   private FlixelObject pickTopMostObject(@NotNull FlixelCamera cam, float viewX, float viewY) {
-    FlixelState state = Flixel.getState();
+    FlixelState state = Flixel.state;
     if (state == null) {
       return null;
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelNoopDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelNoopDebugOverlay.java
@@ -1,0 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.debug;
+
+/**
+ * A fully inert debug overlay used as the default value of
+ * {@link org.flixelgdx.debug.FlixelDebugManager#overlay FlixelDebugManager.overlay} so callers
+ * never need to null-check the field.
+ *
+ * <p>All lifecycle methods ({@link #update(float)}, {@link #resize(int, int)}, {@link #drawUI()})
+ * are no-ops. The singleton is safe to share across the application's lifetime.
+ */
+public final class FlixelNoopDebugOverlay extends FlixelDebugOverlay {
+
+  /** Shared singleton instance used as the default overlay before debug mode starts. */
+  public static final FlixelNoopDebugOverlay INSTANCE = new FlixelNoopDebugOverlay();
+
+  private FlixelNoopDebugOverlay() {}
+
+  @Override
+  public void update(float elapsed) {}
+
+  @Override
+  public void resize(int width, int height) {}
+
+  @Override
+  protected void drawUI() {}
+
+  @Override
+  public void destroy() {}
+}

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -51,7 +51,7 @@ import org.jetbrains.annotations.Nullable;
  * </ul>
  *
  * <p>State is refreshed in {@link FlixelActionSet#update(float)} (via
- * {@link FlixelActionSets#updateAll(float)}). {@link FlixelActionSet#endFrame()} (via
+ * {@link FlixelActionSets#update(float)}). {@link FlixelActionSet#endFrame()} (via
  * {@link FlixelActionSets#endFrameAll()}) runs after
  * {@link org.flixelgdx.FlixelGame#render() FlixelGame.render()} finalizes keys and mouse, matching
  * their {@code justPressed} timing.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
@@ -26,6 +26,7 @@ package org.flixelgdx.input.action;
 import com.badlogic.gdx.utils.Array;
 
 import org.flixelgdx.functional.FlixelDestroyable;
+import org.flixelgdx.functional.FlixelUpdatable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -44,7 +45,7 @@ import org.jetbrains.annotations.Nullable;
  *   <li>In the subclass constructor, create {@link FlixelActionDigital} / {@link FlixelActionAnalog} instances,
  *       call {@link #add(FlixelAction)} for each, and add {@link FlixelDigitalBinding} / {@link FlixelAnalogBinding} instances.</li>
  *   <li>By default the set registers with {@link FlixelActionSets}; {@link org.flixelgdx.FlixelGame FlixelGame} calls
- *       {@link FlixelActionSets#updateAll(float)} after {@code Flixel.gamepads.update()} and {@link FlixelActionSets#endFrameAll()}
+ *       {@link FlixelActionSets#update(float)} after {@code Flixel.gamepads.update()} and {@link FlixelActionSets#endFrameAll()}
  *       after keys, mouse, and gamepads {@code endFrame()} in {@code render()}.</li>
  *   <li>From {@link org.flixelgdx.FlixelState#update(float) FlixelState.update(float)} (or similar), read {@code jump.justPressed()},
  *       {@code move.getX()}, etc.</li>
@@ -110,7 +111,7 @@ import org.jetbrains.annotations.Nullable;
  * <p>Pass {@code false} to {@link #FlixelActionSet(boolean)} from an anonymous subclass so the set does not register globally,
  * then call {@link #update(float)} and {@link #endFrame()} yourself.
  */
-public class FlixelActionSet implements FlixelDestroyable {
+public class FlixelActionSet implements FlixelUpdatable, FlixelDestroyable {
 
   protected final Array<FlixelAction> members;
 
@@ -153,10 +154,11 @@ public class FlixelActionSet implements FlixelDestroyable {
   }
 
   /**
-   * Steps all member actions. Called from {@link FlixelActionSets#updateAll(float)} after gamepads update.
+   * Steps all member actions. Called from {@link FlixelActionSets#update(float)} after gamepads update.
    *
    * @param elapsed Frame delta in seconds.
    */
+  @Override
   public void update(float elapsed) {
     for (int i = 0, n = members.size; i < n; i++) {
       members.get(i).updateAction(elapsed);

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSets.java
@@ -30,13 +30,13 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Global registry of {@link FlixelActionSet} instances. {@link org.flixelgdx.FlixelGame FlixelGame} invokes
- * {@link #updateAll(float)} and {@link #endFrameAll()} so every registered set stays on the same contract as
+ * {@link #update(float)} and {@link #endFrameAll()} so every registered set stays on the same contract as
  * {@link org.flixelgdx.input.FlixelInputManager FlixelInputManager} (keys, mouse, gamepads).
  *
  * <h2>When {@code updateAll} runs</h2>
  *
  * <p>Order inside {@link org.flixelgdx.FlixelGame#update(float) FlixelGame.update(float)}: {@code Flixel.keys.update()},
- * {@code Flixel.mouse.update()}, {@code Flixel.gamepads.update()}, then {@link #updateAll(float)}. Gameplay code in
+ * {@code Flixel.mouse.update()}, {@code Flixel.gamepads.update()}, then {@link #update(float)}. Gameplay code in
  * {@link org.flixelgdx.FlixelState FlixelState} runs after that, so {@code jump.justPressed()} reflects this frame's input.
  *
  * <h2>When {@code endFrameAll} runs</h2>
@@ -74,7 +74,7 @@ public final class FlixelActionSets {
    *
    * @param elapsed Seconds since last frame (same as game update).
    */
-  public static void updateAll(float elapsed) {
+  public static void update(float elapsed) {
     for (int i = 0, n = registered.size; i < n; i++) {
       registered.get(i).update(elapsed);
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/package-info.java
@@ -13,7 +13,7 @@
  * <h2>Frame order (important)</h2>
  *
  * <p>{@link org.flixelgdx.FlixelGame#update(float) FlixelGame.update(float)} runs {@code Flixel.keys.update()}, {@code Flixel.mouse.update()},
- * {@code Flixel.gamepads.update()}, then {@link org.flixelgdx.input.action.FlixelActionSets#updateAll(float) FlixelActionSets.updateAll(float)}.
+ * {@code Flixel.gamepads.update()}, then {@link org.flixelgdx.input.action.FlixelActionSets#update(float) FlixelActionSets.updateAll(float)}.
  * Your {@link org.flixelgdx.FlixelState#update(float) FlixelState.update(float)} runs after that, so action queries see the current frame's
  * hardware snapshot. {@link org.flixelgdx.FlixelGame#render() FlixelGame.render()} ends with {@code endFrame()} on keys, mouse, gamepads,
  * then {@link org.flixelgdx.input.action.FlixelActionSets#endFrameAll() FlixelActionSets.endFrameAll()} so {@code justPressed()} / {@code justReleased()}

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -296,7 +296,7 @@ public class FlixelKeyInputManager implements FlixelInputProcessorManager {
    * while debug UI text fields are focused.
    */
   private static boolean isCapturedByDebugUI() {
-    FlixelDebugOverlay overlay = Flixel.getDebugOverlay();
+    FlixelDebugOverlay overlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
     return overlay != null && overlay.isKeyboardCapturedByUI();
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -656,7 +656,13 @@ public class FlixelKeyInputManager implements FlixelInputProcessorManager {
     pressedOrder.clear();
   }
 
-  private static boolean isValidKeycode(int key) {
+  /**
+   * Verifies if the provided {@link FlixelKey} code is valid.
+   *
+   * @param key {@link FlixelKey} to check.
+   * @return If the keycode is valid.
+   */
+  public boolean isValidKeycode(int key) {
     return key >= 0 && key <= FlixelKey.MAX_KEYCODE;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/keyboard/FlixelKeyInputManager.java
@@ -150,6 +150,7 @@ public class FlixelKeyInputManager implements FlixelInputProcessorManager {
    * <p>Call {@link #endFrame()} at the end of the frame so "just pressed/released" detection works
    * next frame.
    */
+  @Override
   public void update() {
     // Intentionally empty: state is maintained by the InputProcessor.
   }
@@ -296,8 +297,7 @@ public class FlixelKeyInputManager implements FlixelInputProcessorManager {
    * while debug UI text fields are focused.
    */
   private static boolean isCapturedByDebugUI() {
-    FlixelDebugOverlay overlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
-    return overlay != null && overlay.isKeyboardCapturedByUI();
+    return Flixel.debug != null && Flixel.debug.overlay.isKeyboardCapturedByUI();
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseCursor.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseCursor.java
@@ -26,12 +26,15 @@ package org.flixelgdx.input.mouse;
 /**
  * Portable native cursor presets for {@link FlixelMouseIconManager}.
  *
- * <p>Backends map these to OS or browser cursors where available. When a preset has no exact match, each backend chooses the closest
- * alternative and documents limits in its own Javadoc. Plain HTML/CSS builds can expose richer cursor sets through standard CSS keywords,
- * while GLFW on some Linux desktops may fall back to the arrow for waits, grabs, diagonal resizes, or blocked icons when the host
- * cursor theme omits matching glyphs.
+ * <p>Backends map these to OS or browser cursors where available. When a preset has no
+ * exact match, each backend chooses the closest alternative and documents limits in its own
+ * Javadoc.
+ *
+ * <p>Plain HTML/CSS builds can expose richer cursor sets through standard CSS keywords,
+ * while GLFW on some Linux desktops may fall back to the arrow for waits, grabs, diagonal
+ * resizes, or blocked icons when the host cursor theme omits matching glyphs.
  */
-public enum FlixelNativeMouseCursor {
+public enum FlixelMouseCursor {
 
   /** Default arrow pointer. */
   ARROW,
@@ -48,14 +51,11 @@ public enum FlixelNativeMouseCursor {
   /** Hand, often used for links or buttons. */
   HAND,
 
-  /**
-   * Open hand suggesting draggable content ({@code grab} in CSS backends). GLFW does not expose a universal grab shape here, so LWJGL3
-   * maps this to {@link #ARROW}.
-   */
+  /** Open hand suggesting draggable content. */
   GRAB,
 
   /**
-   * Closed hand while dragging ({@code grabbing}). LWJGL3 maps this to {@link #ARROW}.
+   * Closed hand while dragging ({@code grabbing}).
    *
    * @see #GRAB
    */
@@ -80,7 +80,7 @@ public enum FlixelNativeMouseCursor {
   NOT_ALLOWED,
 
   /**
-   * Invisible cursor. Use {@link FlixelMouseIconManager#clearNativeCursor()} to restore the
+   * Invisible cursor. Use {@link FlixelMouseIconManager#resetCursor()} to restore the
    * default instead of selecting this when possible.
    */
   NONE

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseIconManager.java
@@ -26,22 +26,21 @@ package org.flixelgdx.input.mouse;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Platform native cursor styling, exposed through {@link FlixelMouseManager#icons()}.
+ * Platform native cursor styling, exposed through {@link FlixelMouseManager#icons}.
  *
  * <p>Games that need the default Flixel cursor behavior never have to touch this type. When you
  * do need OS-level feedback (text field, busy state, resize handles), call
- * {@link #setNativeCursor(FlixelNativeMouseCursor)} during UI transitions and
- * {@link #clearNativeCursor()} when you are done.
+ * {@link #setCursor(FlixelMouseCursor)} during UI transitions and
+ * {@link #resetCursor()} when you are done.
  *
  * <p>Example:
  *
  * <pre>{@code
- * Flixel.mouse.icons().setNativeCursor(FlixelNativeMouseCursor.IBEAM);
- * // ...
- * Flixel.mouse.icons().clearNativeCursor();
+ * Flixel.mouse.icons.setCursor(FlixelMouseCursor.IBEAM);
+ * Flixel.mouse.icons.resetCursor();
  * }</pre>
  *
- * @see FlixelMouseManager#icons()
+ * @see FlixelMouseManager#icons
  */
 public interface FlixelMouseIconManager {
 
@@ -50,16 +49,16 @@ public interface FlixelMouseIconManager {
    *
    * @param cursor Non-null cursor kind; ignored on noop backends.
    */
-  void setNativeCursor(@NotNull FlixelNativeMouseCursor cursor);
+  void setCursor(@NotNull FlixelMouseCursor cursor);
 
   /**
    * Restores the default cursor for this session.
    */
-  void clearNativeCursor();
+  void resetCursor();
 
   /**
-   * @return {@code true} when {@link #setNativeCursor(FlixelNativeMouseCursor)} may change what
+   * @return {@code true} when {@link #setCursor(FlixelMouseCursor)} may change what
    *     the user sees for this target.
    */
-  boolean supportsNativeCursor();
+  boolean supportsCursors();
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseIconManager.java
@@ -57,6 +57,17 @@ public interface FlixelMouseIconManager {
   void resetCursor();
 
   /**
+   * Returns the cursor that was last set via {@link #setCursor(FlixelMouseCursor)}, or
+   * {@link FlixelMouseCursor#ARROW} after construction or {@link #resetCursor()}.
+   *
+   * @return The active cursor, never {@code null}.
+   */
+  @NotNull
+  default FlixelMouseCursor getCursor() {
+    return FlixelMouseCursor.ARROW;
+  }
+
+  /**
    * @return {@code true} when {@link #setCursor(FlixelMouseCursor)} may change what
    *     the user sees for this target.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseIconManager.java
@@ -45,6 +45,17 @@ import org.jetbrains.annotations.NotNull;
 public interface FlixelMouseIconManager {
 
   /**
+   * Returns the cursor that was last set via {@link #setCursor(FlixelMouseCursor)}, or
+   * {@link FlixelMouseCursor#ARROW} after construction or {@link #resetCursor()}.
+   *
+   * @return The active cursor, never {@code null}.
+   */
+  @NotNull
+  default FlixelMouseCursor getCursor() {
+    return FlixelMouseCursor.ARROW;
+  }
+
+  /**
    * Applies a preset native cursor for this session.
    *
    * @param cursor Non-null cursor kind; ignored on noop backends.
@@ -55,17 +66,6 @@ public interface FlixelMouseIconManager {
    * Restores the default cursor for this session.
    */
   void resetCursor();
-
-  /**
-   * Returns the cursor that was last set via {@link #setCursor(FlixelMouseCursor)}, or
-   * {@link FlixelMouseCursor#ARROW} after construction or {@link #resetCursor()}.
-   *
-   * @return The active cursor, never {@code null}.
-   */
-  @NotNull
-  default FlixelMouseCursor getCursor() {
-    return FlixelMouseCursor.ARROW;
-  }
 
   /**
    * @return {@code true} when {@link #setCursor(FlixelMouseCursor)} may change what

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
@@ -355,8 +355,7 @@ public class FlixelMouseManager implements FlixelInputProcessorManager {
    * debug UI panel.
    */
   private static boolean isCapturedByDebugUI() {
-    FlixelDebugOverlay overlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
-    return overlay != null && overlay.isMouseCapturedByUI();
+    return Flixel.debug != null && Flixel.debug.overlay.isMouseCapturedByUI();
   }
 
   public boolean overlap(@NotNull FlixelObject obj) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
@@ -355,7 +355,7 @@ public class FlixelMouseManager implements FlixelInputProcessorManager {
    * debug UI panel.
    */
   private static boolean isCapturedByDebugUI() {
-    FlixelDebugOverlay overlay = Flixel.getDebugOverlay();
+    FlixelDebugOverlay overlay = (Flixel.debug != null ? Flixel.debug.overlay : null);
     return overlay != null && overlay.isMouseCapturedByUI();
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelMouseManager.java
@@ -68,7 +68,7 @@ public class FlixelMouseManager implements FlixelInputProcessorManager {
   private static final int MAX_BUTTON = 4;
 
   @NotNull
-  private FlixelMouseIconManager iconManager = FlixelNoopMouseIconManager.INSTANCE;
+  public FlixelMouseIconManager icons = FlixelNoopMouseIconManager.INSTANCE;
 
   private int screenX;
   private int screenY;
@@ -149,15 +149,7 @@ public class FlixelMouseManager implements FlixelInputProcessorManager {
    * @param iconManager The {@link FlixelMouseIconManager} to implement.
    */
   public void setMouseIconManager(@Nullable FlixelMouseIconManager iconManager) {
-    this.iconManager = iconManager != null ? iconManager : FlixelNoopMouseIconManager.INSTANCE;
-  }
-
-  /**
-   * @return Native cursor integration for this session (never null).
-   */
-  @NotNull
-  public FlixelMouseIconManager icons() {
-    return iconManager;
+    this.icons = iconManager != null ? iconManager : FlixelNoopMouseIconManager.INSTANCE;
   }
 
   @NotNull

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
@@ -33,11 +33,23 @@ public enum FlixelNoopMouseIconManager implements FlixelMouseIconManager {
   /** Shared instance. */
   INSTANCE;
 
-  @Override
-  public void setCursor(@NotNull FlixelMouseCursor cursor) {}
+  private FlixelMouseCursor current = FlixelMouseCursor.ARROW;
 
   @Override
-  public void resetCursor() {}
+  public void setCursor(@NotNull FlixelMouseCursor cursor) {
+    current = cursor;
+  }
+
+  @Override
+  public void resetCursor() {
+    current = FlixelMouseCursor.ARROW;
+  }
+
+  @Override
+  @NotNull
+  public FlixelMouseCursor getCursor() {
+    return current;
+  }
 
   @Override
   public boolean supportsCursors() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/FlixelNoopMouseIconManager.java
@@ -34,13 +34,13 @@ public enum FlixelNoopMouseIconManager implements FlixelMouseIconManager {
   INSTANCE;
 
   @Override
-  public void setNativeCursor(@NotNull FlixelNativeMouseCursor cursor) {}
+  public void setCursor(@NotNull FlixelMouseCursor cursor) {}
 
   @Override
-  public void clearNativeCursor() {}
+  public void resetCursor() {}
 
   @Override
-  public boolean supportsNativeCursor() {
+  public boolean supportsCursors() {
     return false;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/mouse/package-info.java
@@ -13,9 +13,9 @@
  * {@link org.flixelgdx.input.mouse.FlixelNoopMouseIconManager FlixelNoopMouseIconManager} is used
  * until a backend installs its own.
  *
- * <p>{@link org.flixelgdx.input.mouse.FlixelNativeMouseCursor FlixelNativeMouseCursor} enumerates
+ * <p>{@link org.flixelgdx.input.mouse.FlixelMouseCursor FlixelMouseCursor} enumerates
  * the system cursor shapes (arrow, hand, crosshair, resize handles, and so on) that
- * {@link org.flixelgdx.input.mouse.FlixelMouseIconManager#setSystemCursor
- * FlixelMouseIconManager.setSystemCursor} accepts.
+ * {@link org.flixelgdx.input.mouse.FlixelMouseIconManager#setCursor(org.flixelgdx.input.mouse.FlixelMouseCursor)
+ * FlixelMouseCursor} accepts.
  */
 package org.flixelgdx.input.mouse;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
@@ -94,7 +94,7 @@ public class FlixelLogger implements ApplicationLogger {
    */
   public FlixelLogger(FlixelLogMode logMode) {
     this.logMode = logMode != null ? logMode : FlixelLogMode.SIMPLE;
-    this.stackTraceProvider = Flixel.getStackTraceProvider();
+    this.stackTraceProvider = Flixel.stackTraceProvider;
   }
 
   /**
@@ -179,7 +179,7 @@ public class FlixelLogger implements ApplicationLogger {
    * timestamped log file, and (on JVM) starts a background writer thread.
    */
   public void startFileLogging() {
-    FlixelLogFileHandler handler = Flixel.getLogFileHandler();
+    FlixelLogFileHandler handler = Flixel.logFileHandler;
     if (handler == null || !canStoreLogs) {
       return;
     }
@@ -196,7 +196,7 @@ public class FlixelLogger implements ApplicationLogger {
    * written during disposal are persisted.
    */
   public void stopFileLogging() {
-    FlixelLogFileHandler handler = Flixel.getLogFileHandler();
+    FlixelLogFileHandler handler = Flixel.logFileHandler;
     if (handler != null) {
       handler.stop();
     }
@@ -612,7 +612,7 @@ public class FlixelLogger implements ApplicationLogger {
 
     String ts = LocalDateTime.now().format(LOG_TIMESTAMP);
 
-    FlixelLogConsoleSink consoleSink = Flixel.getLogConsoleSink();
+    FlixelLogConsoleSink consoleSink = Flixel.logConsoleSink;
     if (consoleSink != null) {
       String safeTag = tag != null ? tag : "";
       consoleSink.emit(level, safeTag, rawMessage, simpleFile + ":", file, method, ts,
@@ -648,7 +648,7 @@ public class FlixelLogger implements ApplicationLogger {
     }
 
     // File: always detailed (plain, no ANSI).
-    FlixelLogFileHandler fileHandler = Flixel.getLogFileHandler();
+    FlixelLogFileHandler fileHandler = Flixel.logFileHandler;
     if (fileHandler != null && fileHandler.isActive()) {
       String levelTag = "[" + level + "]";
       String tagPart = "[" + tag + "]";

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -1077,7 +1077,7 @@ public class FlixelText extends FlixelSprite {
   private float currentScreenScale() {
     FlixelCamera cam = Flixel.getDrawCamera();
     if (cam == null) {
-      if (Flixel.getGame() == null) {
+      if (Flixel.game == null) {
         return 1f;
       }
       cam = Flixel.cameras.first();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -789,7 +789,7 @@ public class FlixelText extends FlixelSprite {
    * attributes have changed since the last rebuild.
    *
    * <p>This ensures that callers such as {@link #screenCenter()} always operate
-   * on up-to-date dimensions, even before the first {@link #draw(Batch)} call.
+   * on up-to-date dimensions, even before the first {@link #draw(FlixelBatch)} call.
    *
    * <p>If no font is available yet (for example, before a GL context exists),
    * the returned value is {@code 0} until the first successful rebuild.
@@ -805,7 +805,7 @@ public class FlixelText extends FlixelSprite {
    * attributes have changed since the last rebuild.
    *
    * <p>This ensures that callers such as {@link #screenCenter()} always operate
-   * on up-to-date dimensions, even before the first {@link #draw(Batch)} call.
+   * on up-to-date dimensions, even before the first {@link #draw(FlixelBatch)} call.
    *
    * <p>If no font is available yet (for example, before a GL context exists),
    * the returned value is {@code 0} until the first successful rebuild.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelDebugUtil.java
@@ -56,7 +56,7 @@ public final class FlixelDebugUtil {
    */
   public static int countActiveMembers() {
     int count = 0;
-    FlixelState current = Flixel.getState();
+    FlixelState current = Flixel.state;
     while (current != null) {
       FlixelState sub = current.getSubState();
       boolean hasSubState = (sub != null);
@@ -98,7 +98,7 @@ public final class FlixelDebugUtil {
    * @param callback Invoked once per visible {@link FlixelDebugDrawable}.
    */
   public static void forEachDebugDrawable(Consumer<FlixelDebugDrawable> callback) {
-    FlixelState current = Flixel.getState();
+    FlixelState current = Flixel.state;
     while (current != null) {
       FlixelState sub = current.getSubState();
       boolean hasSubState = (sub != null);

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -35,6 +35,7 @@ import org.flixelgdx.FlixelObject;
 import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.backend.FlixelRuntimeMode;
 import org.flixelgdx.debug.FlixelDebugOverlay;
+import org.flixelgdx.input.keyboard.FlixelKey;
 import org.flixelgdx.logging.FlixelLogLevel;
 import org.lwjgl.glfw.GLFW;
 
@@ -1106,23 +1107,23 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     int cl = this.cameraCycleLeftKey;
     int cr = this.cameraCycleRightKey;
     if (t != cachedToggleKey || keybindToggleLabel == null) {
-      keybindToggleLabel = Input.Keys.toString(t);
+      keybindToggleLabel = FlixelKey.toString(t);
       cachedToggleKey = t;
     }
     if (h != cachedHitboxKey || keybindHitboxLabel == null) {
-      keybindHitboxLabel = Input.Keys.toString(h);
+      keybindHitboxLabel = FlixelKey.toString(h);
       cachedHitboxKey = h;
     }
     if (p != cachedPauseKey || keybindPauseLabel == null) {
-      keybindPauseLabel = Input.Keys.toString(p);
+      keybindPauseLabel = FlixelKey.toString(p);
       cachedPauseKey = p;
     }
     if (cl != cachedCycleLeftKey || keybindCycleLeftLabel == null) {
-      keybindCycleLeftLabel = "Alt + " + Input.Keys.toString(cl);
+      keybindCycleLeftLabel = "Alt + " + FlixelKey.toString(cl);
       cachedCycleLeftKey = cl;
     }
     if (cr != cachedCycleRightKey || keybindCycleRightLabel == null) {
-      keybindCycleRightLabel = "Alt + " + Input.Keys.toString(cr);
+      keybindCycleRightLabel = "Alt + " + FlixelKey.toString(cr);
       cachedCycleRightKey = cr;
     }
   }

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -82,8 +82,8 @@ import imgui.type.ImString;
  *
  * <p>The imgui-java GLFW backend installs callbacks that <em>chain</em> with the existing
  * libGDX callbacks (using {@code installCallbacks=true}). Both libGDX and imgui see every
- * key, mouse, and scroll event, so {@link Flixel#getDebugToggleKey() F2}, {@link Flixel#getDebugDrawToggleKey() F3},
- * and {@link Flixel#getDebugPauseKey() F4} keep working even when an imgui window has focus. Keys that normally
+ * key, mouse, and scroll event, so {@link #toggleKey F2}, {@link #drawDebugKey F3},
+ * and {@link #pauseKey F4} keep working even when an imgui window has focus. Keys that normally
  * <em>type into</em> the command {@code InputText} (letters, punctuation such as backslash, arrows, Enter, Tab,
  * Backspace, and so on) do not trigger debug bindings while that field is focused, so they do not fight the text box.
  * Function keys, Escape, modifiers, and similar non-text keys still toggle the overlay and other debug actions.
@@ -1100,11 +1100,11 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
    * step keeps the controls panel allocation-free on the steady-state path.
    */
   private void refreshKeybindLabelsIfNeeded() {
-    int t = Flixel.getDebugToggleKey();
-    int h = Flixel.getDebugDrawToggleKey();
-    int p = Flixel.getDebugPauseKey();
-    int cl = Flixel.getDebugCameraCycleLeftKey();
-    int cr = Flixel.getDebugCameraCycleRightKey();
+    int t = this.toggleKey;
+    int h = this.drawDebugKey;
+    int p = this.pauseKey;
+    int cl = this.cameraCycleLeftKey;
+    int cr = this.cameraCycleRightKey;
     if (t != cachedToggleKey || keybindToggleLabel == null) {
       keybindToggleLabel = Input.Keys.toString(t);
       cachedToggleKey = t;

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/input/FlixelLwjgl3MouseIconManager.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/input/FlixelLwjgl3MouseIconManager.java
@@ -27,8 +27,8 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
 import com.badlogic.gdx.graphics.Cursor;
 
+import org.flixelgdx.input.mouse.FlixelMouseCursor;
 import org.flixelgdx.input.mouse.FlixelMouseIconManager;
-import org.flixelgdx.input.mouse.FlixelNativeMouseCursor;
 import org.jetbrains.annotations.NotNull;
 import org.lwjgl.glfw.GLFW;
 import org.lwjgl.glfw.GLFWErrorCallback;
@@ -49,7 +49,7 @@ import java.util.Objects;
 public final class FlixelLwjgl3MouseIconManager implements FlixelMouseIconManager {
 
   @Override
-  public void setNativeCursor(@NotNull FlixelNativeMouseCursor cursor) {
+  public void setCursor(@NotNull FlixelMouseCursor cursor) {
     Objects.requireNonNull(cursor, "cursor");
     if (!(Gdx.graphics instanceof Lwjgl3Graphics graphics)) {
       return;
@@ -58,7 +58,7 @@ public final class FlixelLwjgl3MouseIconManager implements FlixelMouseIconManage
   }
 
   @Override
-  public void clearNativeCursor() {
+  public void resetCursor() {
     if (!(Gdx.graphics instanceof Lwjgl3Graphics graphics)) {
       return;
     }
@@ -66,7 +66,7 @@ public final class FlixelLwjgl3MouseIconManager implements FlixelMouseIconManage
   }
 
   @Override
-  public boolean supportsNativeCursor() {
+  public boolean supportsCursors() {
     return Gdx.graphics instanceof Lwjgl3Graphics;
   }
 
@@ -100,16 +100,16 @@ public final class FlixelLwjgl3MouseIconManager implements FlixelMouseIconManage
     return os.contains("linux");
   }
 
-  private static Cursor.SystemCursor mapToBestSystemCursor(FlixelNativeMouseCursor cursor) {
-    if (cursor == FlixelNativeMouseCursor.WAIT
-        || cursor == FlixelNativeMouseCursor.GRAB
-        || cursor == FlixelNativeMouseCursor.GRABBING) {
+  private static Cursor.SystemCursor mapToBestSystemCursor(FlixelMouseCursor cursor) {
+    if (cursor == FlixelMouseCursor.WAIT
+        || cursor == FlixelMouseCursor.GRAB
+        || cursor == FlixelMouseCursor.GRABBING) {
       return Cursor.SystemCursor.Arrow;
     }
     if (likelyLinuxOs()) {
-      if (cursor == FlixelNativeMouseCursor.NORTH_WEST_SOUTH_EAST_RESIZE
-          || cursor == FlixelNativeMouseCursor.NORTH_EAST_SOUTH_WEST_RESIZE
-          || cursor == FlixelNativeMouseCursor.NOT_ALLOWED) {
+      if (cursor == FlixelMouseCursor.NORTH_WEST_SOUTH_EAST_RESIZE
+          || cursor == FlixelMouseCursor.NORTH_EAST_SOUTH_WEST_RESIZE
+          || cursor == FlixelMouseCursor.NOT_ALLOWED) {
         return Cursor.SystemCursor.Arrow;
       }
     }

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/input/FlixelLwjgl3MouseIconManager.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/input/FlixelLwjgl3MouseIconManager.java
@@ -48,9 +48,12 @@ import java.util.Objects;
  */
 public final class FlixelLwjgl3MouseIconManager implements FlixelMouseIconManager {
 
+  private FlixelMouseCursor current = FlixelMouseCursor.ARROW;
+
   @Override
   public void setCursor(@NotNull FlixelMouseCursor cursor) {
     Objects.requireNonNull(cursor, "cursor");
+    current = cursor;
     if (!(Gdx.graphics instanceof Lwjgl3Graphics graphics)) {
       return;
     }
@@ -59,10 +62,17 @@ public final class FlixelLwjgl3MouseIconManager implements FlixelMouseIconManage
 
   @Override
   public void resetCursor() {
+    current = FlixelMouseCursor.ARROW;
     if (!(Gdx.graphics instanceof Lwjgl3Graphics graphics)) {
       return;
     }
     graphics.getWindow().postRunnable(() -> setSystemCursorSwallowCursorUnavailable(Cursor.SystemCursor.Arrow));
+  }
+
+  @Override
+  @NotNull
+  public FlixelMouseCursor getCursor() {
+    return current;
   }
 
   @Override

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/window/FlixelLwjgl3WindowListener.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/window/FlixelLwjgl3WindowListener.java
@@ -93,9 +93,8 @@ public class FlixelLwjgl3WindowListener implements Lwjgl3WindowListener {
   @Override
   public void iconified(boolean isIconified) {
     if (isIconified) {
-      FlixelGame game = Flixel.getGame();
-      if (game != null) {
-        game.onMinimized();
+      if (Flixel.game != null) {
+        Flixel.game.onMinimized();
       }
     }
     if (next != null) {

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMMouseIconManager.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMMouseIconManager.java
@@ -23,8 +23,8 @@
  */
 package org.flixelgdx.backend.teavm;
 
+import org.flixelgdx.input.mouse.FlixelMouseCursor;
 import org.flixelgdx.input.mouse.FlixelMouseIconManager;
-import org.flixelgdx.input.mouse.FlixelNativeMouseCursor;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
 
@@ -40,21 +40,21 @@ public final class FlixelTeaVMMouseIconManager implements FlixelMouseIconManager
   }
 
   @Override
-  public void setNativeCursor(@NotNull FlixelNativeMouseCursor cursor) {
+  public void setCursor(@NotNull FlixelMouseCursor cursor) {
     setCanvasCursorCss(canvasElementId, cssFor(cursor));
   }
 
   @Override
-  public void clearNativeCursor() {
+  public void resetCursor() {
     setCanvasCursorCss(canvasElementId, "default");
   }
 
   @Override
-  public boolean supportsNativeCursor() {
+  public boolean supportsCursors() {
     return !canvasElementId.isEmpty();
   }
 
-  private static String cssFor(FlixelNativeMouseCursor cursor) {
+  private static String cssFor(FlixelMouseCursor cursor) {
     return switch (cursor) {
       case ARROW -> "default";
       case IBEAM -> "text";

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMMouseIconManager.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMMouseIconManager.java
@@ -33,6 +33,7 @@ import org.teavm.jso.JSBody;
  */
 public final class FlixelTeaVMMouseIconManager implements FlixelMouseIconManager {
 
+  private FlixelMouseCursor current = FlixelMouseCursor.ARROW;
   private final @NotNull String canvasElementId;
 
   public FlixelTeaVMMouseIconManager(@NotNull String canvasElementId) {
@@ -41,12 +42,20 @@ public final class FlixelTeaVMMouseIconManager implements FlixelMouseIconManager
 
   @Override
   public void setCursor(@NotNull FlixelMouseCursor cursor) {
+    current = cursor;
     setCanvasCursorCss(canvasElementId, cssFor(cursor));
   }
 
   @Override
   public void resetCursor() {
+    current = FlixelMouseCursor.ARROW;
     setCanvasCursorCss(canvasElementId, "default");
+  }
+
+  @Override
+  @NotNull
+  public FlixelMouseCursor getCursor() {
+    return current;
   }
 
   @Override
@@ -73,9 +82,11 @@ public final class FlixelTeaVMMouseIconManager implements FlixelMouseIconManager
     };
   }
 
-  @JSBody(params = { "canvasId", "css" }, script = "var e=document.getElementById(canvasId);\n"
-      + "if (e !== null) {\n"
-      + "  e.style.cursor = css;\n"
-      + "}\n")
+  @JSBody(params = { "canvasId", "css" }, script = """
+      var e=document.getElementById(canvasId);
+      if (e !== null) {
+        e.style.cursor = css;
+      }
+      """)
   private static native void setCanvasCursorCss(String canvasId, String css);
 }

--- a/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideo.java
+++ b/flixelgdx-video-core/src/main/java/org/flixelgdx/video/FlixelVideo.java
@@ -118,8 +118,7 @@ public abstract class FlixelVideo extends FlixelBasic {
   private final LifecycleListener lifecycleListener = new LifecycleListener() {
     @Override
     public void pause() {
-      FlixelGame game = Flixel.getGame();
-      if (game == null || !game.autoPause || autoPaused || !isMediaPlaying()) {
+      if (Flixel.game == null || !Flixel.game.autoPause || autoPaused || !isMediaPlaying()) {
         return;
       }
       pauseMedia();

--- a/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcVideoHandler.java
+++ b/flixelgdx-video-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/video/FlixelVlcVideoHandler.java
@@ -148,7 +148,7 @@ public final class FlixelVlcVideoHandler implements FlixelVideoFactory {
   }
 
   private static void onFocusLost() {
-    FlixelGame game = Flixel.getGame();
+    FlixelGame game = Flixel.game;
     if (game == null || !game.autoPause) {
       return;
     }


### PR DESCRIPTION
## Description

This PR contains two focused refactors that clean up the debug overlay architecture and trim `Flixel` of wrapper methods that were not pulling their weight.

**Commit 1 - Move debug keybinds and overlay instance onto the manager and overlay:**

Previously, the six debug keybinds (toggle, draw-debug, pause, camera cycle left/right, camera pan button) lived as private fields on `Flixel` and were exposed via `Flixel.getDebugXxx()` getters. The overlay instance itself was also private on `Flixel`, gated behind `Flixel.getDebugOverlay()`, and `FlixelDebugManager` held its own `getOverlay()` accessor on top.

These are now moved to where they belong:
- The six keys are now `public` fields directly on `FlixelDebugOverlay`, pre-set to the same `Keybinds` defaults as before. Games can override them per-overlay instance without touching `Flixel` at all.
- The overlay instance is now `public FlixelDebugOverlay overlay` on `FlixelDebugManager`. Access it as `Flixel.debug.overlay`.
- All six `Flixel.getDebugXxx()` key getters, `Flixel.getDebugOverlay()`, and `FlixelDebugManager.getOverlay()` have been removed.
- All internal callers (`FlixelGame`, `FlixelKeyInputManager`, `FlixelMouseManager`, `FlixelImGuiDebugOverlay`) have been updated accordingly.
- Heap stats in `FlixelDebugOverlay` now use `Flixel.getJavaHeapUsedBytes() / (1024f * 1024f)` directly instead of the removed megabyte helpers.

**Commit 2 - Remove redundant unit-conversion and field-wrapper getters from Flixel:**

`Flixel` contained eight unit-conversion helpers (`getJavaHeapUsedMegabytes`, `getJavaHeapUsedGigabytes`, `getJavaHeapTotalMegabytes`, `getJavaHeapTotalGigabytes`, `getJavaHeapMaxMegabytes`, `getJavaHeapMaxGigabytes`, `getNativeHeapUsedMegabytes`, `getNativeHeapUsedGigabytes`) plus `getGame()` and `getState()` that simply returned the already-public `Flixel.game` and `Flixel.state` fields. These offered no value and were removed. All callers across the codebase were updated to use `Flixel.game` / `Flixel.state` directly.

## Type of Change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor / Optimization

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - pure refactor with no visual changes.