### PR TITLE
Expanded the host integration with clipboard access, screen wake lock, and exit confirmation

### DIFF
--- a/flixelgdx-android/build.gradle.kts
+++ b/flixelgdx-android/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
   }
   api(libs.gdx.backend.android)
   api(libs.gdx.controllers.android)
+  implementation(libs.jetbrains.annotations)
 }
 
 // Unpacks the .so files bundled at the root of libGDX's native platform jars into this

--- a/flixelgdx-android/src/main/java/org/flixelgdx/backend/android/FlixelAndroidHostIntegration.java
+++ b/flixelgdx-android/src/main/java/org/flixelgdx/backend/android/FlixelAndroidHostIntegration.java
@@ -1,0 +1,242 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.android;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.view.WindowManager;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Input.Keys;
+import com.badlogic.gdx.InputAdapter;
+import com.badlogic.gdx.InputMultiplexer;
+import com.badlogic.gdx.InputProcessor;
+
+import org.flixelgdx.backend.FlixelHostIntegration;
+import org.flixelgdx.util.signal.FlixelSignal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Android {@link FlixelHostIntegration}: system notifications via {@link NotificationManager},
+ * screen wake lock via {@code FLAG_KEEP_SCREEN_ON}, back-button exit confirmation via an
+ * {@link InputMultiplexer}, and text clipboard access via {@link ClipboardManager}.
+ *
+ * <p>Installed automatically by {@link FlixelAndroidLauncher}; game code should not need to
+ * instantiate this directly.
+ *
+ * <h2>Notification permission</h2>
+ *
+ * <p>Android 13 (API 33) and above require the {@code POST_NOTIFICATIONS} runtime permission
+ * before notifications are displayed. Call {@link #requestNotificationPermission()} early in your
+ * game, ideally during a loading screen or in response to a user gesture, and confirm
+ * {@link #supportsNotifications()} returns {@code true} before calling
+ * {@link #sendNotification(String, String)}.
+ *
+ * <p>You must also declare the permission in your {@code AndroidManifest.xml}:
+ *
+ * <pre>{@code
+ * <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+ * }</pre>
+ *
+ * <h2>Exit confirmation</h2>
+ *
+ * <p>When a message is set via {@link #setExitConfirmation(String)}, the hardware or gesture back
+ * action is caught by an {@link InputMultiplexer} inserted in front of any existing
+ * {@link InputProcessor}. Pressing back shows an {@link AlertDialog} with the message and an
+ * "Exit" button that calls {@code Gdx.app.exit()}. Passing {@code null} removes the guard and
+ * restores the previous processor.
+ */
+public class FlixelAndroidHostIntegration implements FlixelHostIntegration {
+
+  private static final int NOTIFICATION_ID = 0;
+  private static final String NOTIFICATION_CHANNEL_ID = "flixelgdx";
+  private static final String NOTIFICATION_CHANNEL_NAME = "Game Notifications";
+
+  private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
+  private final Activity activity;
+  private final NotificationManager notificationManager;
+  private final ClipboardManager clipboardManager;
+  private final InputAdapter backKeyHandler;
+
+  @Nullable
+  private String exitConfirmationMessage;
+  @Nullable
+  private InputProcessor previousProcessor;
+
+  FlixelAndroidHostIntegration(Activity activity) {
+    this.activity = activity;
+    this.notificationManager = (NotificationManager) activity.getSystemService(Context.NOTIFICATION_SERVICE);
+    this.clipboardManager = (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+    this.backKeyHandler = new InputAdapter() {
+      @Override
+      public boolean keyDown(int keycode) {
+        if (keycode == Keys.BACK && exitConfirmationMessage != null) {
+          showExitDialog(exitConfirmationMessage);
+          return true;
+        }
+        return false;
+      }
+    };
+    if (notificationManager != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      notificationManager.createNotificationChannel(new NotificationChannel(
+          NOTIFICATION_CHANNEL_ID, NOTIFICATION_CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT));
+    }
+  }
+
+  @Override
+  public void requestNotificationPermission() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        && activity.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+            != PackageManager.PERMISSION_GRANTED) {
+      activity.requestPermissions(new String[]{"android.permission.POST_NOTIFICATIONS"}, 0);
+    }
+  }
+
+  @Override
+  public void requestAttention() {}
+
+  @Override
+  public void keepScreenAwake(boolean awake) {
+    activity.runOnUiThread(() -> {
+      if (awake) {
+        activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+      } else {
+        activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+      }
+    });
+  }
+
+  @Override
+  public void setExitConfirmation(@Nullable String message) {
+    boolean wasActive = exitConfirmationMessage != null;
+    exitConfirmationMessage = message;
+    if (message != null && !wasActive) {
+      Gdx.input.setCatchKey(Keys.BACK, true);
+      InputProcessor current = Gdx.input.getInputProcessor();
+      previousProcessor = current;
+      InputMultiplexer multiplexer = new InputMultiplexer();
+      multiplexer.addProcessor(backKeyHandler);
+      if (current != null) {
+        multiplexer.addProcessor(current);
+      }
+      Gdx.input.setInputProcessor(multiplexer);
+    } else if (message == null && wasActive) {
+      Gdx.input.setCatchKey(Keys.BACK, false);
+      Gdx.input.setInputProcessor(previousProcessor);
+      previousProcessor = null;
+    }
+  }
+
+  @Override
+  public void sendNotification(@Nullable String title, @NotNull String message) {
+    Objects.requireNonNull(message, "message");
+    if (!supportsNotifications()) {
+      return;
+    }
+    notificationManager.notify(NOTIFICATION_ID, buildNotification(title != null ? title : "", message));
+  }
+
+  @Override
+  public void copyToClipboard(@NotNull String text) {
+    Objects.requireNonNull(text, "text");
+    if (!supportsClipboard()) {
+      return;
+    }
+    clipboardManager.setPrimaryClip(ClipData.newPlainText("", text));
+  }
+
+  @Override
+  public void pasteFromClipboard() {
+    if (!supportsClipboard()) {
+      return;
+    }
+    ClipData clip = clipboardManager.getPrimaryClip();
+    if (clip == null || clip.getItemCount() == 0) {
+      return;
+    }
+    CharSequence text = clip.getItemAt(0).coerceToText(activity);
+    if (text != null && text.length() > 0) {
+      onTextPasted.dispatch(text.toString());
+    }
+  }
+
+  @Override
+  public boolean supportsNotifications() {
+    return notificationManager != null && notificationManager.areNotificationsEnabled();
+  }
+
+  @Override
+  public boolean supportsWakeLock() {
+    return true;
+  }
+
+  @Override
+  public boolean supportsClipboard() {
+    return clipboardManager != null;
+  }
+
+  @Override
+  @NotNull
+  public FlixelSignal<String> onTextPasted() {
+    return onTextPasted;
+  }
+
+  @SuppressWarnings("deprecation")
+  private Notification buildNotification(String title, String message) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      return new Notification.Builder(activity, NOTIFICATION_CHANNEL_ID)
+          .setContentTitle(title)
+          .setContentText(message)
+          .setSmallIcon(android.R.drawable.ic_dialog_info)
+          .setAutoCancel(true)
+          .build();
+    }
+    return new Notification.Builder(activity)
+        .setContentTitle(title)
+        .setContentText(message)
+        .setSmallIcon(android.R.drawable.ic_dialog_info)
+        .setAutoCancel(true)
+        .build();
+  }
+
+  private void showExitDialog(String message) {
+    activity.runOnUiThread(() -> new AlertDialog.Builder(activity)
+        .setMessage(message)
+        .setPositiveButton("Exit", (dialog, which) -> Gdx.app.exit())
+        .setNegativeButton("Cancel", null)
+        .setCancelable(false)
+        .show());
+  }
+}

--- a/flixelgdx-android/src/main/java/org/flixelgdx/backend/android/FlixelAndroidLauncher.java
+++ b/flixelgdx-android/src/main/java/org/flixelgdx/backend/android/FlixelAndroidLauncher.java
@@ -104,6 +104,7 @@ public class FlixelAndroidLauncher {
       Runnable onBeforeInitialize) {
     FlixelCamera.viewportFactory = ExtendViewport::new;
     Flixel.alert = new FlixelAndroidAlerter(activity);
+    Flixel.host = new FlixelAndroidHostIntegration(activity);
     Flixel.haptics = new FlixelAndroidHaptics(activity);
     Flixel.stackTraceProvider = new FlixelDefaultStackTraceProvider();
     Flixel.logFileHandler = new FlixelJvmLogFileHandler();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -275,7 +275,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   private boolean fullscreenChangeInProgress = false;
 
   /**
-   * When {@code true}, {@link Flixel#getState()} was sent {@link FlixelState#pause()} for a paired app or window pause
+   * When {@code true}, {@link Flixel#state} was sent {@link FlixelState#pause()} for a paired app or window pause
    * and {@link FlixelState#resume()} has not yet been dispatched. Used so duplicate callbacks (such as minimize plus
    * focus lost) only run state hooks once.
    */
@@ -503,7 +503,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     }
     FlixelActionSets.update(elapsed);
 
-    if (!gamePaused) {
+    if (!gamePaused && !stateLifecyclePauseDispatched) {
       FlixelTween.updateTweens(elapsed);
       FlixelTimer.getGlobalManager().update(elapsed * Flixel.timeScale);
 
@@ -702,18 +702,18 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   }
 
   /**
-   * Updates the game's global and internal {@link #update(float)} and {@link FlixelDrawable#draw(FlixelBatch)} methods, with elapsed time clamped
-   * to the min and max values to prevent major lag spikes.
+   * Updates the game's global and internal {@link #update(float)} and {@link #draw(FlixelBatch)} methods, with
+   * elapsed time clamped to the min and max values to prevent major lag spikes.
    *
-   * <p>This method is called automatically by libGDX's {@link ApplicationListener#render()} method when the game is
-   * running, so it is not necessary to override this method in most cases. However, it can be overridden to
-   * perform custom updating/rendering before the game is updated/rendered.
+   * <p>This method is called automatically by libGDX's {@link ApplicationListener#render()} method when
+   * the game is running.
    *
-   * <p>You should not (and cannot) override this method. You are encouraged to override either {@link #update(float)}
-   * or {@link FlixelDrawable#draw(FlixelBatch)} instead, as they separate logic and rendering correctly.
+   * <p>You should not (and cannot) override this method. You are encouraged to override either
+   * {@link #update(float)} or {@link #draw(FlixelBatch)} instead, as they separate logic
+   * and rendering correctly.
    *
    * @see #update(float)
-   * @see FlixelDrawable#draw(FlixelBatch)
+   * @see #draw(FlixelBatch)
    * @see ApplicationListener#render()
    */
   @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -275,7 +275,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   private boolean fullscreenChangeInProgress = false;
 
   /**
-   * When {@code true}, {@link Flixel#getState()} was sent {@link FlixelState#pause()} for a paired app or window pause
+   * When {@code true}, {@link Flixel#state} was sent {@link FlixelState#pause()} for a paired app or window pause
    * and {@link FlixelState#resume()} has not yet been dispatched. Used so duplicate callbacks (such as minimize plus
    * focus lost) only run state hooks once.
    */
@@ -503,34 +503,32 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     }
     FlixelActionSets.update(elapsed);
 
-    if (!gamePaused) {
-      FlixelTween.updateTweens(elapsed);
-      FlixelTimer.getGlobalManager().update(elapsed * Flixel.timeScale);
+    FlixelTween.updateTweens(elapsed);
+    FlixelTimer.getGlobalManager().update(elapsed * Flixel.timeScale);
 
-      // Walk the state/substate chain. Each state in the chain is updated only
-      // if it is the active (innermost) state or if its persistentUpdate flag is true.
-      FlixelState current = Flixel.state;
-      while (current != null) {
-        FlixelState sub = current.getSubState();
-        boolean hasSubState = (sub != null);
+    // Walk the state/substate chain. Each state in the chain is updated only
+    // if it is the active (innermost) state or if its persistentUpdate flag is true.
+    FlixelState current = Flixel.state;
+    while (current != null) {
+      FlixelState sub = current.getSubState();
+      boolean hasSubState = (sub != null);
 
-        if (!hasSubState || current.persistentUpdate) {
-          current.update(elapsed);
-        }
-
-        current = sub;
+      if (!hasSubState || current.persistentUpdate) {
+        current.update(elapsed);
       }
 
-      // Update all cameras.
-      for (FlixelCamera camera : cameras) {
-        camera.update(elapsed);
-      }
+      current = sub;
+    }
 
-      if (overlayGroup != null && overlayEnabled) {
-        overlayGroup.update(elapsed);
-        if (overlayCamera != null) {
-          overlayCamera.update(elapsed);
-        }
+    // Update all cameras.
+    for (FlixelCamera camera : cameras) {
+      camera.update(elapsed);
+    }
+
+    if (overlayGroup != null && overlayEnabled) {
+      overlayGroup.update(elapsed);
+      if (overlayCamera != null) {
+        overlayCamera.update(elapsed);
       }
     }
 
@@ -726,7 +724,9 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     windowSize.y = Gdx.graphics.getHeight();
     fullscreen = Gdx.graphics.isFullscreen();
 
-    update(elapsed);
+    if (!gamePaused && !stateLifecyclePauseDispatched) {
+      update(elapsed);
+    }
     draw(batch);
 
     // Finalize input frame AFTER user update hooks run, so justPressed()/justReleased() checks

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -275,7 +275,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   private boolean fullscreenChangeInProgress = false;
 
   /**
-   * When {@code true}, {@link Flixel#state} was sent {@link FlixelState#pause()} for a paired app or window pause
+   * When {@code true}, {@link Flixel#getState()} was sent {@link FlixelState#pause()} for a paired app or window pause
    * and {@link FlixelState#resume()} has not yet been dispatched. Used so duplicate callbacks (such as minimize plus
    * focus lost) only run state hooks once.
    */
@@ -503,32 +503,34 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     }
     FlixelActionSets.update(elapsed);
 
-    FlixelTween.updateTweens(elapsed);
-    FlixelTimer.getGlobalManager().update(elapsed * Flixel.timeScale);
+    if (!gamePaused) {
+      FlixelTween.updateTweens(elapsed);
+      FlixelTimer.getGlobalManager().update(elapsed * Flixel.timeScale);
 
-    // Walk the state/substate chain. Each state in the chain is updated only
-    // if it is the active (innermost) state or if its persistentUpdate flag is true.
-    FlixelState current = Flixel.state;
-    while (current != null) {
-      FlixelState sub = current.getSubState();
-      boolean hasSubState = (sub != null);
+      // Walk the state/substate chain. Each state in the chain is updated only
+      // if it is the active (innermost) state or if its persistentUpdate flag is true.
+      FlixelState current = Flixel.state;
+      while (current != null) {
+        FlixelState sub = current.getSubState();
+        boolean hasSubState = (sub != null);
 
-      if (!hasSubState || current.persistentUpdate) {
-        current.update(elapsed);
+        if (!hasSubState || current.persistentUpdate) {
+          current.update(elapsed);
+        }
+
+        current = sub;
       }
 
-      current = sub;
-    }
+      // Update all cameras.
+      for (FlixelCamera camera : cameras) {
+        camera.update(elapsed);
+      }
 
-    // Update all cameras.
-    for (FlixelCamera camera : cameras) {
-      camera.update(elapsed);
-    }
-
-    if (overlayGroup != null && overlayEnabled) {
-      overlayGroup.update(elapsed);
-      if (overlayCamera != null) {
-        overlayCamera.update(elapsed);
+      if (overlayGroup != null && overlayEnabled) {
+        overlayGroup.update(elapsed);
+        if (overlayCamera != null) {
+          overlayCamera.update(elapsed);
+        }
       }
     }
 
@@ -724,9 +726,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     windowSize.y = Gdx.graphics.getHeight();
     fullscreen = Gdx.graphics.isFullscreen();
 
-    if (!gamePaused && !stateLifecyclePauseDispatched) {
-      update(elapsed);
-    }
+    update(elapsed);
     draw(batch);
 
     // Finalize input frame AFTER user update hooks run, so justPressed()/justReleased() checks

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
@@ -23,32 +23,111 @@
  */
 package org.flixelgdx.backend;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Host operating system integration, which allows desktop notifications and taskbar attention.
+ * Host platform integration for notifications, display management, and clipboard access.
  *
- * <p>This is separate from {@link FlixelAlerter FlixelAlerter}, which shows blocking
- * dialog popups. Use {@link org.flixelgdx.Flixel#host Flixel.host} from game code.
+ * <p>This is separate from {@link FlixelAlerter}, which shows blocking dialog popups.
+ * Use {@link Flixel#host Flixel.host} from game code.
  *
- * <p>Desktop LWJGL3 ships a full implementation (freedesktop {@code notify-send} on Linux rather than AWT for toasts,
- * GLFW plus AWT {@code java.awt.Taskbar} for attention where available). Mobile and web builds keep the safe no-op implementation.
+ * <p>Desktop LWJGL3 ships a full implementation: freedesktop {@code notify-send} on Linux,
+ * {@code osascript} on macOS, WinRT toasts via PowerShell on Windows, GLFW window attention,
+ * AWT clipboard, and platform-specific screen wake lock. Web (TeaVM) implements the Browser
+ * Notification API, tab-title attention, the Screen Wake Lock API, the {@code beforeunload}
+ * exit guard, and the Clipboard API. Mobile builds use the safe no-op implementation.
+ *
+ * <p><b>Web notification permission</b>
+ *
+ * <p>Browsers require explicit user permission before showing notifications. On the web backend,
+ * {@link #supportsDesktopNotification()} returns {@code false} until permission has been granted.
+ * Call {@link #requestNotificationPermission()} early - ideally during a loading screen or in
+ * response to a user gesture - before sending any notifications. On desktop, permission is implicit
+ * and {@link #requestNotificationPermission()} is a no-op.
+ *
+ * <p><b>Clipboard paste callbacks</b>
+ *
+ * <p>Paste operations are asynchronous. Register handlers on {@link #onTextPasted()} or
+ * {@link #onImagePasted()} before calling {@link #pasteFromClipboard()} or
+ * {@link #pasteImageFromClipboard()}. The signal fires once the platform has retrieved the data.
+ * Handlers may not be called on the GL thread - wrap any libGDX calls with
+ * {@code Gdx.app.postRunnable(...)}.
  *
  * <p>Example:
  *
  * <pre>{@code
- * Flixel.host.sendDesktopNotification("Ready", "Your level finished loading.");
- * Flixel.host.requestUserAttention();
+ * // Notifications
+ * Flixel.host.sendNotification("Ready", "Your level finished loading.");
+ * Flixel.host.requestAttention();
+ *
+ * // Clipboard - copy
+ * Flixel.host.copyToClipboard(saveCode);
+ *
+ * // Clipboard - paste
+ * Flixel.host.onTextPasted().add(text -> {
+ *     if (text != null) Gdx.app.postRunnable(() -> saveCodeField.setText(text));
+ * });
+ * Flixel.host.pasteFromClipboard();
  * }</pre>
  *
- * @see org.flixelgdx.Flixel#host
+ * @see Flixel#host
  */
 public interface FlixelHostIntegration {
 
   /**
-   * Shows a non-blocking desktop notification using the platform provider (Action Center on Windows,
-   * Notification Center on macOS, D-Bus or libnotify on Linux).
+   * Prompts the user to grant notification permission for this origin.
+   *
+   * <p>On the web backend this triggers the browser permission dialog. It must be called in
+   * response to a user gesture (button press, key press, etc.) or the browser will silently
+   * ignore it. Once granted, {@link #supportsDesktopNotification()} returns {@code true} and
+   * subsequent {@link #sendNotification(String, String)} calls will display toasts.
+   *
+   * <p>On desktop, permission is implicit and this method does nothing.
+   */
+  void requestNotificationPermission();
+
+  /**
+   * Asks the window manager to highlight this app (taskbar entry flash, dock bounce, and similar).
+   *
+   * <p>On the web backend, this flashes the browser tab title while the tab is in the background.
+   */
+  void requestAttention();
+
+  /**
+   * Prevents the display from sleeping while the game is running.
+   *
+   * <p>Pass {@code true} to acquire a wake lock and {@code false} to release it. On desktop this
+   * uses platform-specific inhibit commands ({@code caffeinate} on macOS,
+   * {@code systemd-inhibit} or {@code xdg-screensaver} on Linux). On the web backend this uses the
+   * Screen Wake Lock API. Has no effect on platforms where {@link #supportsWakeLock()} returns
+   * {@code false}.
+   *
+   * @param awake {@code true} to keep the screen on, {@code false} to release the lock.
+   */
+  void keepScreenAwake(boolean awake);
+
+  /**
+   * Sets a message shown to the user when they attempt to close or navigate away from the game.
+   *
+   * <p>On the web backend this hooks {@code window.beforeunload}. Pass {@code null} to remove the
+   * guard. On desktop this is a no-op since the OS already handles window-close confirmation at the
+   * application level.
+   *
+   * @param message The warning message, or {@code null} to clear the exit guard.
+   */
+  void setExitConfirmation(@Nullable String message);
+
+  /**
+   * Shows a non-blocking desktop notification using the platform provider (Action Center on
+   * Windows, Notification Center on macOS, D-Bus or libnotify on Linux, browser toasts on web).
+   *
+   * <p>On the web backend, notifications require prior permission. Call
+   * {@link #requestNotificationPermission()} first and confirm {@link #supportsDesktopNotification()}
+   * returns {@code true} before calling this method.
    *
    * @param title Short title, or {@code null} to use a blank title when the OS allows it.
    * @param message Body text; must not be {@code null}.
@@ -56,13 +135,91 @@ public interface FlixelHostIntegration {
   void sendNotification(@Nullable String title, @NotNull String message);
 
   /**
-   * Asks the window manager to highlight this app (taskbar entry flash, dock bounce, and similar).
+   * Copies {@code text} to the system clipboard.
+   *
+   * <p>Has no effect on platforms where {@link #supportsClipboard()} returns {@code false}.
+   *
+   * @param text The text to copy; must not be {@code null}.
    */
-  void requestAttention();
+  void copyToClipboard(@NotNull String text);
+
+  /**
+   * Copies {@code graphic} to the system clipboard as a PNG image.
+   *
+   * <p>Has no effect on platforms where {@link #supportsImageClipboard()} returns {@code false}.
+   *
+   * @param graphic The graphic to copy; must not be {@code null}.
+   */
+  void copyImageToClipboard(@NotNull FlixelGraphic graphic);
+
+  /**
+   * Requests a text read from the system clipboard.
+   *
+   * <p>The result is delivered asynchronously via {@link #onTextPasted()}. Register a handler
+   * on that signal before calling this method. If the clipboard is empty or does not contain
+   * text, the signal is not dispatched.
+   *
+   * <p>Has no effect on platforms where {@link #supportsClipboard()} returns {@code false}.
+   */
+  void pasteFromClipboard();
+
+  /**
+   * Requests an image read from the system clipboard.
+   *
+   * <p>The result is delivered asynchronously via {@link #onImagePasted()}. Register a handler
+   * on that signal before calling this method. The dispatched {@link FlixelGraphic} is an owned
+   * graphic with a reference count of zero - call {@link FlixelGraphic#retain()} if you intend
+   * to keep it, and {@link FlixelGraphic#release()} when done. If the clipboard does not contain
+   * an image, the signal is not dispatched.
+   *
+   * <p>Has no effect on platforms where {@link #supportsImageClipboard()} returns {@code false}.
+   */
+  void pasteImageFromClipboard();
 
   /**
    * @return {@code true} if {@link #sendNotification(String, String)} is expected to do useful
-   * work on this platform session.
+   *     work on this platform session. On the web backend, returns {@code true} only after
+   *     {@link #requestNotificationPermission()} has been granted by the user.
    */
   boolean supportsDesktopNotification();
+
+  /**
+   * @return {@code true} if {@link #keepScreenAwake(boolean)} is supported on this platform.
+   */
+  boolean supportsWakeLock();
+
+  /**
+   * @return {@code true} if text clipboard operations ({@link #copyToClipboard(String)} and
+   *     {@link #pasteFromClipboard()}) are supported on this platform.
+   */
+  boolean supportsClipboard();
+
+  /**
+   * @return {@code true} if image clipboard operations ({@link #copyImageToClipboard(FlixelGraphic)}
+   *     and {@link #pasteImageFromClipboard()}) are supported on this platform.
+   */
+  boolean supportsImageClipboard();
+
+  /**
+   * Signal dispatched when {@link #pasteFromClipboard()} resolves with text content.
+   *
+   * <p>The dispatched value is the pasted text. Handlers may be called off the GL thread -
+   * wrap any libGDX calls with {@code Gdx.app.postRunnable(...)}.
+   *
+   * @return The signal; never {@code null}.
+   */
+  @NotNull
+  FlixelSignal<String> onTextPasted();
+
+  /**
+   * Signal dispatched when {@link #pasteImageFromClipboard()} resolves with image content.
+   *
+   * <p>The dispatched {@link FlixelGraphic} is an owned graphic at reference count zero. Call
+   * {@link FlixelGraphic#retain()} to keep it alive past the handler. Handlers may be called
+   * off the GL thread - wrap any libGDX calls with {@code Gdx.app.postRunnable(...)}.
+   *
+   * @return The signal; never {@code null}.
+   */
+  @NotNull
+  FlixelSignal<FlixelGraphic> onImagePasted();
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
@@ -41,20 +41,20 @@ import org.jetbrains.annotations.Nullable;
  * Notification API, tab-title attention, the Screen Wake Lock API, the {@code beforeunload}
  * exit guard, and the Clipboard API. Mobile builds use the safe no-op implementation.
  *
- * <p><b>Web notification permission</b>
+ * <h2>Web notification permission</h2>
  *
  * <p>Browsers require explicit user permission before showing notifications. On the web backend,
  * {@link #supportsDesktopNotification()} returns {@code false} until permission has been granted.
- * Call {@link #requestNotificationPermission()} early - ideally during a loading screen or in
- * response to a user gesture - before sending any notifications. On desktop, permission is implicit
+ * Call {@link #requestNotificationPermission()} early, ideally during a loading screen or in
+ * response to a user gesture before sending any notifications. On desktop, permission is implicit
  * and {@link #requestNotificationPermission()} is a no-op.
  *
- * <p><b>Clipboard paste callbacks</b>
+ * <h2>Clipboard paste callbacks</h2>
  *
  * <p>Paste operations are asynchronous. Register handlers on {@link #onTextPasted()} or
  * {@link #onImagePasted()} before calling {@link #pasteFromClipboard()} or
  * {@link #pasteImageFromClipboard()}. The signal fires once the platform has retrieved the data.
- * Handlers may not be called on the GL thread - wrap any libGDX calls with
+ * Handlers may not be called on the GL thread; because of this, wrap any libGDX calls with
  * {@code Gdx.app.postRunnable(...)}.
  *
  * <p>Example:
@@ -64,12 +64,14 @@ import org.jetbrains.annotations.Nullable;
  * Flixel.host.sendNotification("Ready", "Your level finished loading.");
  * Flixel.host.requestAttention();
  *
- * // Clipboard - copy
+ * // Clipboard (copy).
  * Flixel.host.copyToClipboard(saveCode);
  *
- * // Clipboard - paste
+ * // Clipboard (paste).
  * Flixel.host.onTextPasted().add(text -> {
- *     if (text != null) Gdx.app.postRunnable(() -> saveCodeField.setText(text));
+ *   if (text != null) {
+ *     Gdx.app.postRunnable(() -> saveCodeField.setText(text));
+ *   }
  * });
  * Flixel.host.pasteFromClipboard();
  * }</pre>
@@ -114,8 +116,7 @@ public interface FlixelHostIntegration {
    * Sets a message shown to the user when they attempt to close or navigate away from the game.
    *
    * <p>On the web backend this hooks {@code window.beforeunload}. Pass {@code null} to remove the
-   * guard. On desktop this is a no-op since the OS already handles window-close confirmation at the
-   * application level.
+   * guard. On desktop this is a no-op.
    *
    * @param message The warning message, or {@code null} to clear the exit guard.
    */
@@ -203,8 +204,8 @@ public interface FlixelHostIntegration {
   /**
    * Signal dispatched when {@link #pasteFromClipboard()} resolves with text content.
    *
-   * <p>The dispatched value is the pasted text. Handlers may be called off the GL thread -
-   * wrap any libGDX calls with {@code Gdx.app.postRunnable(...)}.
+   * <p>The dispatched value is the pasted text. Handlers may be called off the GL thread.
+   * Wrap any libGDX calls with {@code Gdx.app.postRunnable(...)}.
    *
    * @return The signal; never {@code null}.
    */
@@ -216,7 +217,7 @@ public interface FlixelHostIntegration {
    *
    * <p>The dispatched {@link FlixelGraphic} is an owned graphic at reference count zero. Call
    * {@link FlixelGraphic#retain()} to keep it alive past the handler. Handlers may be called
-   * off the GL thread - wrap any libGDX calls with {@code Gdx.app.postRunnable(...)}.
+   * off the GL thread. Wrap any libGDX calls with {@code Gdx.app.postRunnable(...)}.
    *
    * @return The signal; never {@code null}.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
@@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
  * <h2>Web notification permission</h2>
  *
  * <p>Browsers require explicit user permission before showing notifications. On the web backend,
- * {@link #supportsDesktopNotification()} returns {@code false} until permission has been granted.
+ * {@link #supportsNotifications()} returns {@code false} until permission has been granted.
  * Call {@link #requestNotificationPermission()} early, ideally during a loading screen or in
  * response to a user gesture before sending any notifications. On desktop, permission is implicit
  * and {@link #requestNotificationPermission()} is a no-op.
@@ -83,7 +83,7 @@ public interface FlixelHostIntegration {
    *
    * <p>On the web backend this triggers the browser permission dialog. It must be called in
    * response to a user gesture (button press, key press, etc.) or the browser will silently
-   * ignore it. Once granted, {@link #supportsDesktopNotification()} returns {@code true} and
+   * ignore it. Once granted, {@link #supportsNotifications()} returns {@code true} and
    * subsequent {@link #sendNotification(String, String)} calls will display toasts.
    *
    * <p>On desktop, permission is implicit and this method does nothing.
@@ -125,7 +125,7 @@ public interface FlixelHostIntegration {
    * Windows, Notification Center on macOS, D-Bus or libnotify on Linux, browser toasts on web).
    *
    * <p>On the web backend, notifications require prior permission. Call
-   * {@link #requestNotificationPermission()} first and confirm {@link #supportsDesktopNotification()}
+   * {@link #requestNotificationPermission()} first and confirm {@link #supportsNotifications()}
    * returns {@code true} before calling this method.
    *
    * @param title Short title, or {@code null} to use a blank title when the OS allows it.
@@ -158,7 +158,7 @@ public interface FlixelHostIntegration {
    *     work on this platform session. On the web backend, returns {@code true} only after
    *     {@link #requestNotificationPermission()} has been granted by the user.
    */
-  boolean supportsDesktopNotification();
+  boolean supportsNotifications();
 
   /**
    * @return {@code true} if {@link #keepScreenAwake(boolean)} is supported on this platform.
@@ -181,5 +181,4 @@ public interface FlixelHostIntegration {
    */
   @NotNull
   FlixelSignal<String> onTextPasted();
-
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelHostIntegration.java
@@ -24,7 +24,6 @@
 package org.flixelgdx.backend;
 
 import org.flixelgdx.Flixel;
-import org.flixelgdx.graphics.FlixelGraphic;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -51,11 +50,10 @@ import org.jetbrains.annotations.Nullable;
  *
  * <h2>Clipboard paste callbacks</h2>
  *
- * <p>Paste operations are asynchronous. Register handlers on {@link #onTextPasted()} or
- * {@link #onImagePasted()} before calling {@link #pasteFromClipboard()} or
- * {@link #pasteImageFromClipboard()}. The signal fires once the platform has retrieved the data.
- * Handlers may not be called on the GL thread; because of this, wrap any libGDX calls with
- * {@code Gdx.app.postRunnable(...)}.
+ * <p>Paste operations are asynchronous. Register a handler on {@link #onTextPasted()} before
+ * calling {@link #pasteFromClipboard()}. The signal fires once the platform has retrieved the
+ * data. Handlers may not be called on the GL thread; because of this, wrap any libGDX calls
+ * with {@code Gdx.app.postRunnable(...)}.
  *
  * <p>Example:
  *
@@ -145,15 +143,6 @@ public interface FlixelHostIntegration {
   void copyToClipboard(@NotNull String text);
 
   /**
-   * Copies {@code graphic} to the system clipboard as a PNG image.
-   *
-   * <p>Has no effect on platforms where {@link #supportsImageClipboard()} returns {@code false}.
-   *
-   * @param graphic The graphic to copy; must not be {@code null}.
-   */
-  void copyImageToClipboard(@NotNull FlixelGraphic graphic);
-
-  /**
    * Requests a text read from the system clipboard.
    *
    * <p>The result is delivered asynchronously via {@link #onTextPasted()}. Register a handler
@@ -163,19 +152,6 @@ public interface FlixelHostIntegration {
    * <p>Has no effect on platforms where {@link #supportsClipboard()} returns {@code false}.
    */
   void pasteFromClipboard();
-
-  /**
-   * Requests an image read from the system clipboard.
-   *
-   * <p>The result is delivered asynchronously via {@link #onImagePasted()}. Register a handler
-   * on that signal before calling this method. The dispatched {@link FlixelGraphic} is an owned
-   * graphic with a reference count of zero - call {@link FlixelGraphic#retain()} if you intend
-   * to keep it, and {@link FlixelGraphic#release()} when done. If the clipboard does not contain
-   * an image, the signal is not dispatched.
-   *
-   * <p>Has no effect on platforms where {@link #supportsImageClipboard()} returns {@code false}.
-   */
-  void pasteImageFromClipboard();
 
   /**
    * @return {@code true} if {@link #sendNotification(String, String)} is expected to do useful
@@ -196,12 +172,6 @@ public interface FlixelHostIntegration {
   boolean supportsClipboard();
 
   /**
-   * @return {@code true} if image clipboard operations ({@link #copyImageToClipboard(FlixelGraphic)}
-   *     and {@link #pasteImageFromClipboard()}) are supported on this platform.
-   */
-  boolean supportsImageClipboard();
-
-  /**
    * Signal dispatched when {@link #pasteFromClipboard()} resolves with text content.
    *
    * <p>The dispatched value is the pasted text. Handlers may be called off the GL thread.
@@ -212,15 +182,4 @@ public interface FlixelHostIntegration {
   @NotNull
   FlixelSignal<String> onTextPasted();
 
-  /**
-   * Signal dispatched when {@link #pasteImageFromClipboard()} resolves with image content.
-   *
-   * <p>The dispatched {@link FlixelGraphic} is an owned graphic at reference count zero. Call
-   * {@link FlixelGraphic#retain()} to keep it alive past the handler. Handlers may be called
-   * off the GL thread. Wrap any libGDX calls with {@code Gdx.app.postRunnable(...)}.
-   *
-   * @return The signal; never {@code null}.
-   */
-  @NotNull
-  FlixelSignal<FlixelGraphic> onImagePasted();
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopHostIntegration.java
@@ -23,7 +23,6 @@
  */
 package org.flixelgdx.backend;
 
-import org.flixelgdx.graphics.FlixelGraphic;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,7 +41,6 @@ public enum FlixelNoopHostIntegration implements FlixelHostIntegration {
   INSTANCE;
 
   private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
-  private final FlixelSignal<FlixelGraphic> onImagePasted = new FlixelSignal<>();
 
   @Override
   public void requestNotificationPermission() {}
@@ -67,15 +65,7 @@ public enum FlixelNoopHostIntegration implements FlixelHostIntegration {
   }
 
   @Override
-  public void copyImageToClipboard(@NotNull FlixelGraphic graphic) {
-    Objects.requireNonNull(graphic, "graphic");
-  }
-
-  @Override
   public void pasteFromClipboard() {}
-
-  @Override
-  public void pasteImageFromClipboard() {}
 
   @Override
   public boolean supportsDesktopNotification() {
@@ -93,19 +83,8 @@ public enum FlixelNoopHostIntegration implements FlixelHostIntegration {
   }
 
   @Override
-  public boolean supportsImageClipboard() {
-    return false;
-  }
-
-  @Override
   @NotNull
   public FlixelSignal<String> onTextPasted() {
     return onTextPasted;
-  }
-
-  @Override
-  @NotNull
-  public FlixelSignal<FlixelGraphic> onImagePasted() {
-    return onImagePasted;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopHostIntegration.java
@@ -23,18 +23,38 @@
  */
 package org.flixelgdx.backend;
 
+import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 
 /**
- * Default {@link FlixelHostIntegration} used on platforms without desktop shell integration.
+ * Default {@link FlixelHostIntegration} used on platforms without host shell integration.
+ *
+ * <p>All operations are no-ops. Capability checks return {@code false}. Signals are live instances
+ * that never dispatch on their own, but callers may still add handlers to them safely.
  */
 public enum FlixelNoopHostIntegration implements FlixelHostIntegration {
 
   /** Shared no-op instance. */
   INSTANCE;
+
+  private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
+  private final FlixelSignal<FlixelGraphic> onImagePasted = new FlixelSignal<>();
+
+  @Override
+  public void requestNotificationPermission() {}
+
+  @Override
+  public void requestAttention() {}
+
+  @Override
+  public void keepScreenAwake(boolean awake) {}
+
+  @Override
+  public void setExitConfirmation(@Nullable String message) {}
 
   @Override
   public void sendNotification(@Nullable String title, @NotNull String message) {
@@ -42,10 +62,50 @@ public enum FlixelNoopHostIntegration implements FlixelHostIntegration {
   }
 
   @Override
-  public void requestAttention() {}
+  public void copyToClipboard(@NotNull String text) {
+    Objects.requireNonNull(text, "text");
+  }
+
+  @Override
+  public void copyImageToClipboard(@NotNull FlixelGraphic graphic) {
+    Objects.requireNonNull(graphic, "graphic");
+  }
+
+  @Override
+  public void pasteFromClipboard() {}
+
+  @Override
+  public void pasteImageFromClipboard() {}
 
   @Override
   public boolean supportsDesktopNotification() {
     return false;
+  }
+
+  @Override
+  public boolean supportsWakeLock() {
+    return false;
+  }
+
+  @Override
+  public boolean supportsClipboard() {
+    return false;
+  }
+
+  @Override
+  public boolean supportsImageClipboard() {
+    return false;
+  }
+
+  @Override
+  @NotNull
+  public FlixelSignal<String> onTextPasted() {
+    return onTextPasted;
+  }
+
+  @Override
+  @NotNull
+  public FlixelSignal<FlixelGraphic> onImagePasted() {
+    return onImagePasted;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopHostIntegration.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/backend/FlixelNoopHostIntegration.java
@@ -68,7 +68,7 @@ public enum FlixelNoopHostIntegration implements FlixelHostIntegration {
   public void pasteFromClipboard() {}
 
   @Override
-  public boolean supportsDesktopNotification() {
+  public boolean supportsNotifications() {
     return false;
   }
 

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
@@ -120,7 +120,7 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
   @Override
   public void sendNotification(@Nullable String title, @NotNull String message) {
     Objects.requireNonNull(message, "message");
-    if (!supportsDesktopNotification()) {
+    if (!supportsNotifications()) {
       return;
     }
     if (isLinux()) {
@@ -161,7 +161,7 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
   }
 
   @Override
-  public boolean supportsDesktopNotification() {
+  public boolean supportsNotifications() {
     return !GraphicsEnvironment.isHeadless();
   }
 

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
@@ -25,14 +25,8 @@ package org.flixelgdx.backend.lwjgl3;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.TextureData;
 
-import org.flixelgdx.Flixel;
-import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.backend.FlixelHostIntegration;
-import org.flixelgdx.graphics.FlixelGraphic;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -40,7 +34,6 @@ import org.lwjgl.glfw.GLFW;
 
 import java.awt.EventQueue;
 import java.awt.GraphicsEnvironment;
-import java.awt.Image;
 import java.awt.Taskbar;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -48,7 +41,6 @@ import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.awt.datatransfer.UnsupportedFlavorException;
-import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -58,7 +50,7 @@ import java.util.Objects;
 /**
  * Desktop {@link FlixelHostIntegration}: freedesktop or Zenity notifications on Linux,
  * {@code osascript} on macOS, WinRT toasts via PowerShell on Windows, GLFW window attention,
- * AWT {@link Taskbar} attention, platform screen wake lock, and AWT clipboard access.
+ * AWT {@link Taskbar} attention, platform screen wake lock, and AWT text clipboard access.
  */
 public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration {
 
@@ -66,7 +58,6 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
   private static final String OS = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
 
   private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
-  private final FlixelSignal<FlixelGraphic> onImagePasted = new FlixelSignal<>();
 
   @Nullable
   private Process wakeLockProcess;
@@ -152,20 +143,6 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
   }
 
   @Override
-  public void copyImageToClipboard(@NotNull FlixelGraphic graphic) {
-    Objects.requireNonNull(graphic, "graphic");
-    if (!supportsImageClipboard()) {
-      return;
-    }
-    BufferedImage image = toBufferedImage(graphic.getTexture());
-    if (image == null) {
-      return;
-    }
-    EventQueue.invokeLater(() -> Toolkit.getDefaultToolkit().getSystemClipboard()
-        .setContents(new TransferableImage(image), null));
-  }
-
-  @Override
   public void pasteFromClipboard() {
     if (!supportsClipboard()) {
       return;
@@ -178,31 +155,6 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
       }
       String text = (String) contents.getTransferData(DataFlavor.stringFlavor);
       onTextPasted.dispatch(text);
-    } catch (UnsupportedFlavorException | IOException ignored) {
-      // Ignored.
-    }
-  }
-
-  @Override
-  public void pasteImageFromClipboard() {
-    if (!supportsImageClipboard()) {
-      return;
-    }
-    try {
-      Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
-      Transferable contents = clipboard.getContents(null);
-      if (contents == null || !contents.isDataFlavorSupported(DataFlavor.imageFlavor)) {
-        return;
-      }
-      Image awtImage = (Image) contents.getTransferData(DataFlavor.imageFlavor);
-      BufferedImage buffered = toBufferedImageFromAwt(awtImage);
-      Pixmap pixmap = toPixmap(buffered);
-      Texture texture = new Texture(pixmap);
-      pixmap.dispose();
-      FlixelAssetManager assets = Flixel.ensureAssets();
-      FlixelGraphic graphic = new FlixelGraphic(assets, assets.allocateSyntheticKey(), texture);
-      assets.register(graphic);
-      onImagePasted.dispatch(graphic);
     } catch (UnsupportedFlavorException | IOException ignored) {
       // Ignored.
     }
@@ -224,24 +176,13 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
   }
 
   @Override
-  public boolean supportsImageClipboard() {
-    return !GraphicsEnvironment.isHeadless();
-  }
-
-  @Override
   @NotNull
   public FlixelSignal<String> onTextPasted() {
     return onTextPasted;
   }
 
-  @Override
-  @NotNull
-  public FlixelSignal<FlixelGraphic> onImagePasted() {
-    return onImagePasted;
-  }
-
   private static void notifyLinux(@Nullable String title, String message) {
-    String summary = truncateArg(title == null || title.isEmpty() ? " " : title, MAX_NOTIFY_ARG_LEN);
+    String summary = truncateArg(title == null || title.isEmpty() ? " " : title, MAX_NOTIFY_ARG_LEN);
     String body = truncateArg(message, MAX_NOTIFY_ARG_LEN);
     if (tryStartProcess(new ProcessBuilder("notify-send", summary, body))) {
       return;
@@ -291,75 +232,6 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
   }
 
   @Nullable
-  private static BufferedImage toBufferedImage(Texture texture) {
-    TextureData data = texture.getTextureData();
-    if (!data.isPrepared()) {
-      data.prepare();
-    }
-    Pixmap pixmap = null;
-    boolean disposePixmap = false;
-    if (data.getType() == TextureData.TextureDataType.Pixmap) {
-      pixmap = data.consumePixmap();
-      disposePixmap = data.disposePixmap();
-    }
-    if (pixmap == null) {
-      return null;
-    }
-    try {
-      return toBufferedImageFromPixmap(pixmap);
-    } finally {
-      if (disposePixmap) {
-        pixmap.dispose();
-      }
-    }
-  }
-
-  private static BufferedImage toBufferedImageFromPixmap(Pixmap pixmap) {
-    int w = pixmap.getWidth();
-    int h = pixmap.getHeight();
-    BufferedImage image = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
-    for (int y = 0; y < h; y++) {
-      for (int x = 0; x < w; x++) {
-        int rgba = pixmap.getPixel(x, y);
-        int r = (rgba >> 24) & 0xFF;
-        int g = (rgba >> 16) & 0xFF;
-        int b = (rgba >> 8) & 0xFF;
-        int a = rgba & 0xFF;
-        image.setRGB(x, y, (a << 24) | (r << 16) | (g << 8) | b);
-      }
-    }
-    return image;
-  }
-
-  private static BufferedImage toBufferedImageFromAwt(Image image) {
-    if (image instanceof BufferedImage bi && bi.getType() == BufferedImage.TYPE_INT_ARGB) {
-      return bi;
-    }
-    int w = image.getWidth(null);
-    int h = image.getHeight(null);
-    BufferedImage result = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
-    result.getGraphics().drawImage(image, 0, 0, null);
-    return result;
-  }
-
-  private static Pixmap toPixmap(BufferedImage image) {
-    int w = image.getWidth();
-    int h = image.getHeight();
-    Pixmap pixmap = new Pixmap(w, h, Pixmap.Format.RGBA8888);
-    for (int y = 0; y < h; y++) {
-      for (int x = 0; x < w; x++) {
-        int argb = image.getRGB(x, y);
-        int a = (argb >> 24) & 0xFF;
-        int r = (argb >> 16) & 0xFF;
-        int g = (argb >> 8) & 0xFF;
-        int b = argb & 0xFF;
-        pixmap.drawPixel(x, y, (r << 24) | (g << 16) | (b << 8) | a);
-      }
-    }
-    return pixmap;
-  }
-
-  @Nullable
   private static Process tryStartWakeLockProcess(ProcessBuilder pb) {
     try {
       pb.redirectError(ProcessBuilder.Redirect.DISCARD);
@@ -402,32 +274,5 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
 
   private static boolean isWindows() {
     return OS.contains("windows");
-  }
-
-  private static final class TransferableImage implements Transferable {
-
-    private final BufferedImage image;
-
-    TransferableImage(BufferedImage image) {
-      this.image = image;
-    }
-
-    @Override
-    public DataFlavor[] getTransferDataFlavors() {
-      return new DataFlavor[] { DataFlavor.imageFlavor };
-    }
-
-    @Override
-    public boolean isDataFlavorSupported(DataFlavor flavor) {
-      return DataFlavor.imageFlavor.equals(flavor);
-    }
-
-    @Override
-    public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
-      if (!isDataFlavorSupported(flavor)) {
-        throw new UnsupportedFlavorException(flavor);
-      }
-      return image;
-    }
   }
 }

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
@@ -46,6 +46,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Desktop {@link FlixelHostIntegration}: freedesktop or Zenity notifications on Linux,
@@ -61,6 +64,8 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
 
   @Nullable
   private Process wakeLockProcess;
+  @Nullable
+  private ScheduledExecutorService screensaverResetScheduler;
 
   @Override
   public void requestNotificationPermission() {}
@@ -95,7 +100,7 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
       return;
     }
     if (awake) {
-      if (wakeLockProcess != null) {
+      if (wakeLockProcess != null || screensaverResetScheduler != null) {
         return;
       }
       if (isMac()) {
@@ -105,8 +110,23 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
             "systemd-inhibit", "--what=idle:sleep",
             "--who=FlixelGDX", "--why=Game",
             "--mode=block", "sleep", "infinity"));
+        // systemd-inhibit prevents system sleep but does not reset the screensaver's own idle
+        // timer (e.g. cinnamon-screensaver runs independently). Poke xdg-screensaver reset
+        // periodically so the screensaver never reaches its activation threshold.
+        screensaverResetScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+          Thread t = new Thread(r, "flixelwakelock");
+          t.setDaemon(true);
+          return t;
+        });
+        screensaverResetScheduler.scheduleAtFixedRate(
+            () -> tryStartProcess(new ProcessBuilder("xdg-screensaver", "reset")),
+            0, 50, TimeUnit.SECONDS);
       }
     } else {
+      if (screensaverResetScheduler != null) {
+        screensaverResetScheduler.shutdownNow();
+        screensaverResetScheduler = null;
+      }
       if (wakeLockProcess != null) {
         wakeLockProcess.destroyForcibly();
         wakeLockProcess = null;

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/FlixelLwjgl3HostIntegration.java
@@ -25,15 +25,30 @@ package org.flixelgdx.backend.lwjgl3;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.TextureData;
 
+import org.flixelgdx.Flixel;
+import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.backend.FlixelHostIntegration;
+import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.glfw.GLFW;
 
 import java.awt.EventQueue;
 import java.awt.GraphicsEnvironment;
+import java.awt.Image;
 import java.awt.Taskbar;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.Transferable;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -41,28 +56,23 @@ import java.util.Locale;
 import java.util.Objects;
 
 /**
- * Desktop {@link FlixelHostIntegration}: freedesktop or Zenity notifications on Linux, {@code osascript} on macOS,
- * WinRT toasts via PowerShell on Windows, GLFW window attention, and AWT {@link Taskbar} attention where available.
+ * Desktop {@link FlixelHostIntegration}: freedesktop or Zenity notifications on Linux,
+ * {@code osascript} on macOS, WinRT toasts via PowerShell on Windows, GLFW window attention,
+ * AWT {@link Taskbar} attention, platform screen wake lock, and AWT clipboard access.
  */
 public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration {
 
   private static final int MAX_NOTIFY_ARG_LEN = 6000;
+  private static final String OS = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+
+  private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
+  private final FlixelSignal<FlixelGraphic> onImagePasted = new FlixelSignal<>();
+
+  @Nullable
+  private Process wakeLockProcess;
 
   @Override
-  public void sendNotification(@Nullable String title, @NotNull String message) {
-    Objects.requireNonNull(message, "message");
-    if (!supportsDesktopNotification()) {
-      return;
-    }
-    String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
-    if (os.contains("linux")) {
-      notifyLinux(title, message);
-    } else if (os.contains("mac")) {
-      notifyMac(title, message);
-    } else if (os.contains("windows")) {
-      notifyWindows(title, message);
-    }
-  }
+  public void requestNotificationPermission() {}
 
   @Override
   public void requestAttention() {
@@ -89,12 +99,149 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
   }
 
   @Override
+  public void keepScreenAwake(boolean awake) {
+    if (!supportsWakeLock()) {
+      return;
+    }
+    if (awake) {
+      if (wakeLockProcess != null) {
+        return;
+      }
+      if (isMac()) {
+        wakeLockProcess = tryStartWakeLockProcess(new ProcessBuilder("caffeinate", "-d", "-i"));
+      } else if (isLinux()) {
+        wakeLockProcess = tryStartWakeLockProcess(new ProcessBuilder(
+            "systemd-inhibit", "--what=idle:sleep",
+            "--who=FlixelGDX", "--why=Game",
+            "--mode=block", "sleep", "infinity"));
+      }
+    } else {
+      if (wakeLockProcess != null) {
+        wakeLockProcess.destroyForcibly();
+        wakeLockProcess = null;
+      }
+    }
+  }
+
+  @Override
+  public void setExitConfirmation(@Nullable String message) {}
+
+  @Override
+  public void sendNotification(@Nullable String title, @NotNull String message) {
+    Objects.requireNonNull(message, "message");
+    if (!supportsDesktopNotification()) {
+      return;
+    }
+    if (isLinux()) {
+      notifyLinux(title, message);
+    } else if (isMac()) {
+      notifyMac(title, message);
+    } else if (isWindows()) {
+      notifyWindows(title, message);
+    }
+  }
+
+  @Override
+  public void copyToClipboard(@NotNull String text) {
+    Objects.requireNonNull(text, "text");
+    if (!supportsClipboard()) {
+      return;
+    }
+    EventQueue.invokeLater(() -> Toolkit.getDefaultToolkit().getSystemClipboard()
+        .setContents(new StringSelection(text), null));
+  }
+
+  @Override
+  public void copyImageToClipboard(@NotNull FlixelGraphic graphic) {
+    Objects.requireNonNull(graphic, "graphic");
+    if (!supportsImageClipboard()) {
+      return;
+    }
+    BufferedImage image = toBufferedImage(graphic.getTexture());
+    if (image == null) {
+      return;
+    }
+    EventQueue.invokeLater(() -> Toolkit.getDefaultToolkit().getSystemClipboard()
+        .setContents(new TransferableImage(image), null));
+  }
+
+  @Override
+  public void pasteFromClipboard() {
+    if (!supportsClipboard()) {
+      return;
+    }
+    try {
+      Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+      Transferable contents = clipboard.getContents(null);
+      if (contents == null || !contents.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+        return;
+      }
+      String text = (String) contents.getTransferData(DataFlavor.stringFlavor);
+      onTextPasted.dispatch(text);
+    } catch (UnsupportedFlavorException | IOException ignored) {
+      // Ignored.
+    }
+  }
+
+  @Override
+  public void pasteImageFromClipboard() {
+    if (!supportsImageClipboard()) {
+      return;
+    }
+    try {
+      Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+      Transferable contents = clipboard.getContents(null);
+      if (contents == null || !contents.isDataFlavorSupported(DataFlavor.imageFlavor)) {
+        return;
+      }
+      Image awtImage = (Image) contents.getTransferData(DataFlavor.imageFlavor);
+      BufferedImage buffered = toBufferedImageFromAwt(awtImage);
+      Pixmap pixmap = toPixmap(buffered);
+      Texture texture = new Texture(pixmap);
+      pixmap.dispose();
+      FlixelAssetManager assets = Flixel.ensureAssets();
+      FlixelGraphic graphic = new FlixelGraphic(assets, assets.allocateSyntheticKey(), texture);
+      assets.register(graphic);
+      onImagePasted.dispatch(graphic);
+    } catch (UnsupportedFlavorException | IOException ignored) {
+      // Ignored.
+    }
+  }
+
+  @Override
   public boolean supportsDesktopNotification() {
     return !GraphicsEnvironment.isHeadless();
   }
 
+  @Override
+  public boolean supportsWakeLock() {
+    return !GraphicsEnvironment.isHeadless() && (isMac() || isLinux());
+  }
+
+  @Override
+  public boolean supportsClipboard() {
+    return !GraphicsEnvironment.isHeadless();
+  }
+
+  @Override
+  public boolean supportsImageClipboard() {
+    return !GraphicsEnvironment.isHeadless();
+  }
+
+  @Override
+  @NotNull
+  public FlixelSignal<String> onTextPasted() {
+    return onTextPasted;
+  }
+
+  @Override
+  @NotNull
+  public FlixelSignal<FlixelGraphic> onImagePasted() {
+    return onImagePasted;
+  }
+
   private static void notifyLinux(@Nullable String title, String message) {
-    String summary = truncateArg(title == null || title.isEmpty() ? "\u00a0" : title, MAX_NOTIFY_ARG_LEN);
+    String summary = truncateArg(title == null || title.isEmpty() ? " " : title, MAX_NOTIFY_ARG_LEN);
     String body = truncateArg(message, MAX_NOTIFY_ARG_LEN);
     if (tryStartProcess(new ProcessBuilder("notify-send", summary, body))) {
       return;
@@ -143,6 +290,86 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
         + "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('FlixelGDX').Show($n);";
   }
 
+  @Nullable
+  private static BufferedImage toBufferedImage(Texture texture) {
+    TextureData data = texture.getTextureData();
+    if (!data.isPrepared()) {
+      data.prepare();
+    }
+    Pixmap pixmap = null;
+    boolean disposePixmap = false;
+    if (data.getType() == TextureData.TextureDataType.Pixmap) {
+      pixmap = data.consumePixmap();
+      disposePixmap = data.disposePixmap();
+    }
+    if (pixmap == null) {
+      return null;
+    }
+    try {
+      return toBufferedImageFromPixmap(pixmap);
+    } finally {
+      if (disposePixmap) {
+        pixmap.dispose();
+      }
+    }
+  }
+
+  private static BufferedImage toBufferedImageFromPixmap(Pixmap pixmap) {
+    int w = pixmap.getWidth();
+    int h = pixmap.getHeight();
+    BufferedImage image = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+    for (int y = 0; y < h; y++) {
+      for (int x = 0; x < w; x++) {
+        int rgba = pixmap.getPixel(x, y);
+        int r = (rgba >> 24) & 0xFF;
+        int g = (rgba >> 16) & 0xFF;
+        int b = (rgba >> 8) & 0xFF;
+        int a = rgba & 0xFF;
+        image.setRGB(x, y, (a << 24) | (r << 16) | (g << 8) | b);
+      }
+    }
+    return image;
+  }
+
+  private static BufferedImage toBufferedImageFromAwt(Image image) {
+    if (image instanceof BufferedImage bi && bi.getType() == BufferedImage.TYPE_INT_ARGB) {
+      return bi;
+    }
+    int w = image.getWidth(null);
+    int h = image.getHeight(null);
+    BufferedImage result = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+    result.getGraphics().drawImage(image, 0, 0, null);
+    return result;
+  }
+
+  private static Pixmap toPixmap(BufferedImage image) {
+    int w = image.getWidth();
+    int h = image.getHeight();
+    Pixmap pixmap = new Pixmap(w, h, Pixmap.Format.RGBA8888);
+    for (int y = 0; y < h; y++) {
+      for (int x = 0; x < w; x++) {
+        int argb = image.getRGB(x, y);
+        int a = (argb >> 24) & 0xFF;
+        int r = (argb >> 16) & 0xFF;
+        int g = (argb >> 8) & 0xFF;
+        int b = argb & 0xFF;
+        pixmap.drawPixel(x, y, (r << 24) | (g << 16) | (b << 8) | a);
+      }
+    }
+    return pixmap;
+  }
+
+  @Nullable
+  private static Process tryStartWakeLockProcess(ProcessBuilder pb) {
+    try {
+      pb.redirectError(ProcessBuilder.Redirect.DISCARD);
+      pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
+      return pb.start();
+    } catch (IOException e) {
+      return null;
+    }
+  }
+
   private static boolean tryStartProcess(ProcessBuilder pb) {
     try {
       pb.redirectError(ProcessBuilder.Redirect.DISCARD);
@@ -163,5 +390,44 @@ public final class FlixelLwjgl3HostIntegration implements FlixelHostIntegration 
 
   private static String escapeOsascript(String s) {
     return s.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  private static boolean isMac() {
+    return OS.contains("mac");
+  }
+
+  private static boolean isLinux() {
+    return OS.contains("linux");
+  }
+
+  private static boolean isWindows() {
+    return OS.contains("windows");
+  }
+
+  private static final class TransferableImage implements Transferable {
+
+    private final BufferedImage image;
+
+    TransferableImage(BufferedImage image) {
+      this.image = image;
+    }
+
+    @Override
+    public DataFlavor[] getTransferDataFlavors() {
+      return new DataFlavor[] { DataFlavor.imageFlavor };
+    }
+
+    @Override
+    public boolean isDataFlavorSupported(DataFlavor flavor) {
+      return DataFlavor.imageFlavor.equals(flavor);
+    }
+
+    @Override
+    public Object getTransferData(DataFlavor flavor) throws UnsupportedFlavorException {
+      if (!isDataFlavorSupported(flavor)) {
+        throw new UnsupportedFlavorException(flavor);
+      }
+      return image;
+    }
   }
 }

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMHostIntegration.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMHostIntegration.java
@@ -23,37 +23,24 @@
  */
 package org.flixelgdx.backend.teavm;
 
-import com.badlogic.gdx.Gdx;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.graphics.glutils.FrameBuffer;
-import com.badlogic.gdx.math.Matrix4;
-
-import org.flixelgdx.Flixel;
-import org.flixelgdx.asset.FlixelAssetManager;
 import org.flixelgdx.backend.FlixelHostIntegration;
-import org.flixelgdx.graphics.FlixelGraphic;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.teavm.jso.JSBody;
 import org.teavm.jso.JSFunctor;
 import org.teavm.jso.JSObject;
-import org.teavm.jso.typedarrays.Int8Array;
 
-import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /**
  * Web (TeaVM) {@link FlixelHostIntegration}: Browser Notification API for toasts, tab-title
  * flashing for attention, Screen Wake Lock API, {@code beforeunload} exit guard, and the
- * Clipboard API for both text and image access.
+ * Clipboard API for text access.
  */
 final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
 
   private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
-  private final FlixelSignal<FlixelGraphic> onImagePasted = new FlixelSignal<>();
 
   @Override
   public void requestNotificationPermission() {
@@ -105,28 +92,6 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
   }
 
   @Override
-  public void copyImageToClipboard(@NotNull FlixelGraphic graphic) {
-    Objects.requireNonNull(graphic, "graphic");
-    if (!supportsImageClipboard()) {
-      return;
-    }
-    Texture texture = graphic.getTexture();
-    int w = texture.getWidth();
-    int h = texture.getHeight();
-    Pixmap pixmap = readTexturePixels(texture, w, h);
-    try {
-      ByteBuffer buf = pixmap.getPixels();
-      buf.rewind();
-      byte[] bytes = new byte[w * h * 4];
-      buf.get(bytes);
-      // glReadPixels returns rows bottom-to-top; jsCopyImageRgba flips them for canvas.
-      jsCopyImageRgba(Int8Array.fromJavaArray(bytes), w, h);
-    } finally {
-      pixmap.dispose();
-    }
-  }
-
-  @Override
   public void pasteFromClipboard() {
     if (!supportsClipboard()) {
       return;
@@ -136,27 +101,6 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
         onTextPasted.dispatch(text);
       }
     });
-  }
-
-  @Override
-  public void pasteImageFromClipboard() {
-    if (!supportsImageClipboard()) {
-      return;
-    }
-    jsReadImage((data, width, height) -> Gdx.app.postRunnable(() -> {
-      byte[] bytes = data.copyToJavaArray();
-      Pixmap pixmap = new Pixmap(width, height, Pixmap.Format.RGBA8888);
-      ByteBuffer buf = pixmap.getPixels();
-      buf.rewind();
-      buf.put(bytes);
-      buf.flip();
-      Texture texture = new Texture(pixmap);
-      pixmap.dispose();
-      FlixelAssetManager assets = Flixel.ensureAssets();
-      FlixelGraphic graphic = new FlixelGraphic(assets, assets.allocateSyntheticKey(), texture);
-      assets.register(graphic);
-      onImagePasted.dispatch(graphic);
-    }));
   }
 
   @Override
@@ -175,38 +119,9 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
   }
 
   @Override
-  public boolean supportsImageClipboard() {
-    return jsSupportsImageClipboard();
-  }
-
-  @Override
   @NotNull
   public FlixelSignal<String> onTextPasted() {
     return onTextPasted;
-  }
-
-  @Override
-  @NotNull
-  public FlixelSignal<FlixelGraphic> onImagePasted() {
-    return onImagePasted;
-  }
-
-  private static Pixmap readTexturePixels(Texture texture, int w, int h) {
-    FrameBuffer fbo = new FrameBuffer(Pixmap.Format.RGBA8888, w, h, false);
-    SpriteBatch batch = new SpriteBatch();
-    Matrix4 proj = new Matrix4().setToOrtho2D(0, 0, w, h);
-    batch.setProjectionMatrix(proj);
-    fbo.begin();
-    try {
-      batch.begin();
-      batch.draw(texture, 0, 0, w, h);
-      batch.end();
-      return Pixmap.createFromFrameBuffer(0, 0, w, h);
-    } finally {
-      fbo.end();
-      fbo.dispose();
-      batch.dispose();
-    }
   }
 
   @JSBody(script = "if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') {"
@@ -216,12 +131,12 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
   @JSBody(script = "var orig = document.title;"
       + "if (!document.hidden) return;"
       + "var on = false;"
-      + "var id = setInterval(function(){"
+      + "var id = setInterval(function() {"
       + "  on = !on;"
       + "  document.title = on ? '* ' + orig : orig;"
       + "}, 800);"
-      + "function stop(){"
-      + "  if (!document.hidden){"
+      + "function stop() {"
+      + "  if (!document.hidden) {"
       + "    clearInterval(id);"
       + "    document.title = orig;"
       + "    document.removeEventListener('visibilitychange', stop);"
@@ -259,54 +174,10 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
           + "navigator.clipboard.writeText(text).catch(function(){});}")
   private static native void jsCopyText(String text);
 
-  @JSBody(params = { "arr", "width", "height" },
-      script = "if (!navigator.clipboard || !navigator.clipboard.write || typeof ClipboardItem === 'undefined') return;"
-          + "var src = new Uint8ClampedArray(arr.buffer);"
-          + "var flipped = new Uint8ClampedArray(src.length);"
-          + "var row = width * 4;"
-          + "for (var y = 0; y < height; y++){"
-          + "  var s = (height - 1 - y) * row, d = y * row;"
-          + "  flipped.set(src.subarray(s, s + row), d);"
-          + "}"
-          + "var imgData = new ImageData(flipped, width, height);"
-          + "var c = document.createElement('canvas');"
-          + "c.width = width; c.height = height;"
-          + "c.getContext('2d').putImageData(imgData, 0, 0);"
-          + "c.toBlob(function(blob){"
-          + "  navigator.clipboard.write([new ClipboardItem({'image/png': blob})]).catch(function(){});"
-          + "}, 'image/png');")
-  private static native void jsCopyImageRgba(Int8Array arr, int width, int height);
-
   @JSBody(params = "callback",
       script = "if (!navigator.clipboard || !navigator.clipboard.readText) return;"
           + "navigator.clipboard.readText().then(function(t){ callback(t); }).catch(function(){});")
   private static native void jsReadText(StringPasteCallback callback);
-
-  @JSBody(params = "callback",
-      script = "if (!navigator.clipboard || !navigator.clipboard.read || typeof ClipboardItem === 'undefined') return;"
-          + "navigator.clipboard.read().then(function(items){"
-          + "  for (var i = 0; i < items.length; i++){"
-          + "    if (items[i].types.indexOf('image/png') !== -1){"
-          + "      items[i].getType('image/png').then(function(blob){"
-          + "        var url = URL.createObjectURL(blob);"
-          + "        var img = new Image();"
-          + "        img.onload = function(){"
-          + "          var c = document.createElement('canvas');"
-          + "          c.width = img.width; c.height = img.height;"
-          + "          var ctx = c.getContext('2d');"
-          + "          ctx.drawImage(img, 0, 0);"
-          + "          var d = ctx.getImageData(0, 0, img.width, img.height).data;"
-          + "          URL.revokeObjectURL(url);"
-          + "          callback(new Int8Array(d.buffer), img.width, img.height);"
-          + "        };"
-          + "        img.onerror = function(){ URL.revokeObjectURL(url); };"
-          + "        img.src = url;"
-          + "      });"
-          + "      break;"
-          + "    }"
-          + "  }"
-          + "}).catch(function(){});")
-  private static native void jsReadImage(ImagePasteCallback callback);
 
   @JSBody(script = "return typeof Notification !== 'undefined' && Notification.permission === 'granted';")
   private static native boolean jsNotificationGranted();
@@ -317,17 +188,8 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
   @JSBody(script = "return !!(navigator.clipboard && navigator.clipboard.readText);")
   private static native boolean jsSupportsClipboard();
 
-  @JSBody(
-      script = "return !!(navigator.clipboard && navigator.clipboard.read && typeof ClipboardItem !== 'undefined');")
-  private static native boolean jsSupportsImageClipboard();
-
   @JSFunctor
   interface StringPasteCallback extends JSObject {
     void call(String text);
-  }
-
-  @JSFunctor
-  interface ImagePasteCallback extends JSObject {
-    void call(Int8Array data, int width, int height);
   }
 }

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMHostIntegration.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMHostIntegration.java
@@ -1,0 +1,333 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.backend.teavm;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.glutils.FrameBuffer;
+import com.badlogic.gdx.math.Matrix4;
+
+import org.flixelgdx.Flixel;
+import org.flixelgdx.asset.FlixelAssetManager;
+import org.flixelgdx.backend.FlixelHostIntegration;
+import org.flixelgdx.graphics.FlixelGraphic;
+import org.flixelgdx.util.signal.FlixelSignal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.teavm.jso.JSBody;
+import org.teavm.jso.JSFunctor;
+import org.teavm.jso.JSObject;
+import org.teavm.jso.typedarrays.Int8Array;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Web (TeaVM) {@link FlixelHostIntegration}: Browser Notification API for toasts, tab-title
+ * flashing for attention, Screen Wake Lock API, {@code beforeunload} exit guard, and the
+ * Clipboard API for both text and image access.
+ */
+final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
+
+  private final FlixelSignal<String> onTextPasted = new FlixelSignal<>();
+  private final FlixelSignal<FlixelGraphic> onImagePasted = new FlixelSignal<>();
+
+  @Override
+  public void requestNotificationPermission() {
+    jsRequestNotificationPermission();
+  }
+
+  @Override
+  public void requestAttention() {
+    jsRequestAttention();
+  }
+
+  @Override
+  public void keepScreenAwake(boolean awake) {
+    if (!supportsWakeLock()) {
+      return;
+    }
+    if (awake) {
+      jsAcquireWakeLock();
+    } else {
+      jsReleaseWakeLock();
+    }
+  }
+
+  @Override
+  public void setExitConfirmation(@Nullable String message) {
+    if (message == null) {
+      jsClearExitConfirmation();
+    } else {
+      jsSetExitConfirmation(message);
+    }
+  }
+
+  @Override
+  public void sendNotification(@Nullable String title, @NotNull String message) {
+    Objects.requireNonNull(message, "message");
+    if (!supportsDesktopNotification()) {
+      return;
+    }
+    jsShowNotification(title == null ? "" : title, message);
+  }
+
+  @Override
+  public void copyToClipboard(@NotNull String text) {
+    Objects.requireNonNull(text, "text");
+    if (!supportsClipboard()) {
+      return;
+    }
+    jsCopyText(text);
+  }
+
+  @Override
+  public void copyImageToClipboard(@NotNull FlixelGraphic graphic) {
+    Objects.requireNonNull(graphic, "graphic");
+    if (!supportsImageClipboard()) {
+      return;
+    }
+    Texture texture = graphic.getTexture();
+    int w = texture.getWidth();
+    int h = texture.getHeight();
+    Pixmap pixmap = readTexturePixels(texture, w, h);
+    try {
+      ByteBuffer buf = pixmap.getPixels();
+      buf.rewind();
+      byte[] bytes = new byte[w * h * 4];
+      buf.get(bytes);
+      // glReadPixels returns rows bottom-to-top; jsCopyImageRgba flips them for canvas.
+      jsCopyImageRgba(Int8Array.fromJavaArray(bytes), w, h);
+    } finally {
+      pixmap.dispose();
+    }
+  }
+
+  @Override
+  public void pasteFromClipboard() {
+    if (!supportsClipboard()) {
+      return;
+    }
+    jsReadText(text -> {
+      if (text != null && !text.isEmpty()) {
+        onTextPasted.dispatch(text);
+      }
+    });
+  }
+
+  @Override
+  public void pasteImageFromClipboard() {
+    if (!supportsImageClipboard()) {
+      return;
+    }
+    jsReadImage((data, width, height) -> Gdx.app.postRunnable(() -> {
+      byte[] bytes = data.copyToJavaArray();
+      Pixmap pixmap = new Pixmap(width, height, Pixmap.Format.RGBA8888);
+      ByteBuffer buf = pixmap.getPixels();
+      buf.rewind();
+      buf.put(bytes);
+      buf.flip();
+      Texture texture = new Texture(pixmap);
+      pixmap.dispose();
+      FlixelAssetManager assets = Flixel.ensureAssets();
+      FlixelGraphic graphic = new FlixelGraphic(assets, assets.allocateSyntheticKey(), texture);
+      assets.register(graphic);
+      onImagePasted.dispatch(graphic);
+    }));
+  }
+
+  @Override
+  public boolean supportsDesktopNotification() {
+    return jsNotificationGranted();
+  }
+
+  @Override
+  public boolean supportsWakeLock() {
+    return jsSupportsWakeLock();
+  }
+
+  @Override
+  public boolean supportsClipboard() {
+    return jsSupportsClipboard();
+  }
+
+  @Override
+  public boolean supportsImageClipboard() {
+    return jsSupportsImageClipboard();
+  }
+
+  @Override
+  @NotNull
+  public FlixelSignal<String> onTextPasted() {
+    return onTextPasted;
+  }
+
+  @Override
+  @NotNull
+  public FlixelSignal<FlixelGraphic> onImagePasted() {
+    return onImagePasted;
+  }
+
+  private static Pixmap readTexturePixels(Texture texture, int w, int h) {
+    FrameBuffer fbo = new FrameBuffer(Pixmap.Format.RGBA8888, w, h, false);
+    SpriteBatch batch = new SpriteBatch();
+    Matrix4 proj = new Matrix4().setToOrtho2D(0, 0, w, h);
+    batch.setProjectionMatrix(proj);
+    fbo.begin();
+    try {
+      batch.begin();
+      batch.draw(texture, 0, 0, w, h);
+      batch.end();
+      return Pixmap.createFromFrameBuffer(0, 0, w, h);
+    } finally {
+      fbo.end();
+      fbo.dispose();
+      batch.dispose();
+    }
+  }
+
+  @JSBody(script = "if (typeof Notification !== 'undefined' && Notification.permission !== 'granted') {"
+      + "Notification.requestPermission();}")
+  private static native void jsRequestNotificationPermission();
+
+  @JSBody(script = "var orig = document.title;"
+      + "if (!document.hidden) return;"
+      + "var on = false;"
+      + "var id = setInterval(function(){"
+      + "  on = !on;"
+      + "  document.title = on ? '* ' + orig : orig;"
+      + "}, 800);"
+      + "function stop(){"
+      + "  if (!document.hidden){"
+      + "    clearInterval(id);"
+      + "    document.title = orig;"
+      + "    document.removeEventListener('visibilitychange', stop);"
+      + "  }"
+      + "}"
+      + "document.addEventListener('visibilitychange', stop);")
+  private static native void jsRequestAttention();
+
+  @JSBody(script = "if (!navigator.wakeLock) return;"
+      + "navigator.wakeLock.request('screen').then(function(s){ window.__flxWakeLock = s; }).catch(function(){});")
+  private static native void jsAcquireWakeLock();
+
+  @JSBody(script = "if (window.__flxWakeLock){"
+      + "window.__flxWakeLock.release();"
+      + "window.__flxWakeLock = null;}")
+  private static native void jsReleaseWakeLock();
+
+  @JSBody(params = "msg", script = "window.onbeforeunload = function(e){"
+      + "e.preventDefault();"
+      + "e.returnValue = msg;"
+      + "return msg;"
+      + "};")
+  private static native void jsSetExitConfirmation(String msg);
+
+  @JSBody(script = "window.onbeforeunload = null;")
+  private static native void jsClearExitConfirmation();
+
+  @JSBody(params = { "title", "body" },
+      script = "if (typeof Notification !== 'undefined' && Notification.permission === 'granted'){"
+          + "new Notification(title, {body: body});}")
+  private static native void jsShowNotification(String title, String body);
+
+  @JSBody(params = "text",
+      script = "if (navigator.clipboard && navigator.clipboard.writeText){"
+          + "navigator.clipboard.writeText(text).catch(function(){});}")
+  private static native void jsCopyText(String text);
+
+  @JSBody(params = { "arr", "width", "height" },
+      script = "if (!navigator.clipboard || !navigator.clipboard.write || typeof ClipboardItem === 'undefined') return;"
+          + "var src = new Uint8ClampedArray(arr.buffer);"
+          + "var flipped = new Uint8ClampedArray(src.length);"
+          + "var row = width * 4;"
+          + "for (var y = 0; y < height; y++){"
+          + "  var s = (height - 1 - y) * row, d = y * row;"
+          + "  flipped.set(src.subarray(s, s + row), d);"
+          + "}"
+          + "var imgData = new ImageData(flipped, width, height);"
+          + "var c = document.createElement('canvas');"
+          + "c.width = width; c.height = height;"
+          + "c.getContext('2d').putImageData(imgData, 0, 0);"
+          + "c.toBlob(function(blob){"
+          + "  navigator.clipboard.write([new ClipboardItem({'image/png': blob})]).catch(function(){});"
+          + "}, 'image/png');")
+  private static native void jsCopyImageRgba(Int8Array arr, int width, int height);
+
+  @JSBody(params = "callback",
+      script = "if (!navigator.clipboard || !navigator.clipboard.readText) return;"
+          + "navigator.clipboard.readText().then(function(t){ callback(t); }).catch(function(){});")
+  private static native void jsReadText(StringPasteCallback callback);
+
+  @JSBody(params = "callback",
+      script = "if (!navigator.clipboard || !navigator.clipboard.read || typeof ClipboardItem === 'undefined') return;"
+          + "navigator.clipboard.read().then(function(items){"
+          + "  for (var i = 0; i < items.length; i++){"
+          + "    if (items[i].types.indexOf('image/png') !== -1){"
+          + "      items[i].getType('image/png').then(function(blob){"
+          + "        var url = URL.createObjectURL(blob);"
+          + "        var img = new Image();"
+          + "        img.onload = function(){"
+          + "          var c = document.createElement('canvas');"
+          + "          c.width = img.width; c.height = img.height;"
+          + "          var ctx = c.getContext('2d');"
+          + "          ctx.drawImage(img, 0, 0);"
+          + "          var d = ctx.getImageData(0, 0, img.width, img.height).data;"
+          + "          URL.revokeObjectURL(url);"
+          + "          callback(new Int8Array(d.buffer), img.width, img.height);"
+          + "        };"
+          + "        img.onerror = function(){ URL.revokeObjectURL(url); };"
+          + "        img.src = url;"
+          + "      });"
+          + "      break;"
+          + "    }"
+          + "  }"
+          + "}).catch(function(){});")
+  private static native void jsReadImage(ImagePasteCallback callback);
+
+  @JSBody(script = "return typeof Notification !== 'undefined' && Notification.permission === 'granted';")
+  private static native boolean jsNotificationGranted();
+
+  @JSBody(script = "return 'wakeLock' in navigator;")
+  private static native boolean jsSupportsWakeLock();
+
+  @JSBody(script = "return !!(navigator.clipboard && navigator.clipboard.readText);")
+  private static native boolean jsSupportsClipboard();
+
+  @JSBody(
+      script = "return !!(navigator.clipboard && navigator.clipboard.read && typeof ClipboardItem !== 'undefined');")
+  private static native boolean jsSupportsImageClipboard();
+
+  @JSFunctor
+  interface StringPasteCallback extends JSObject {
+    void call(String text);
+  }
+
+  @JSFunctor
+  interface ImagePasteCallback extends JSObject {
+    void call(Int8Array data, int width, int height);
+  }
+}

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMHostIntegration.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMHostIntegration.java
@@ -76,7 +76,7 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
   @Override
   public void sendNotification(@Nullable String title, @NotNull String message) {
     Objects.requireNonNull(message, "message");
-    if (!supportsDesktopNotification()) {
+    if (!supportsNotifications()) {
       return;
     }
     jsShowNotification(title == null ? "" : title, message);
@@ -104,7 +104,7 @@ final class FlixelTeaVMHostIntegration implements FlixelHostIntegration {
   }
 
   @Override
-  public boolean supportsDesktopNotification() {
+  public boolean supportsNotifications() {
     return jsNotificationGranted();
   }
 

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -179,6 +179,7 @@ public class FlixelTeaVMLauncher {
       @Nullable Consumer<WebApplicationConfiguration> configCustomizer,
       @Nullable Runnable onBeforeInitialize) {
     Flixel.alert = new FlixelTeaVMAlerter();
+    Flixel.host = new FlixelTeaVMHostIntegration();
     Flixel.stackTraceProvider = new TeaVMStackTraceProvider();
     Flixel.logConsoleSink = FlixelTeaVMLogConsole::emit;
     Flixel.soundFactory = new FlixelTeaVMSoundHandler();

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -78,14 +78,22 @@ import java.util.function.Consumer;
  * <h2>Platform Notes</h2>
  *
  * <p>File logging is intentionally disabled on the web backend because browsers do not expose a host filesystem.
- * The {@link org.flixelgdx.logging.FlixelLogFileHandler FlixelLogFileHandler} is not registered, so {@link FlixelLogger#startFileLogging()} is a safe no-op.
- * Console output uses {@link Flixel#logConsoleSink} with a styled {@code console} writer so log lines appear with readable colors
- * in the browser; ANSI {@code System.out} is not used on web.
+ * The {@link org.flixelgdx.logging.FlixelLogFileHandler FlixelLogFileHandler} is not registered, so
+ * {@link FlixelLogger#startFileLogging()} is a safe no-op. Console output uses {@link Flixel#logConsoleSink} with
+ * a styled {@code console} writer so log lines appear with readable colors in the browser; ANSI {@code System.out}
+ * is not used on web.
  *
  * <p>When {@code Gdx.app.exit()} is called, the launcher overrides {@code exit()} to invoke the browser's
  * {@code window.close()}. Browsers only close the tab when it was opened programmatically via {@code window.open()};
  * for tabs the user opened directly, the browser silently ignores the request. This is a browser security
  * restriction and cannot be bypassed from JavaScript.
+ *
+ * <p>Web games always pause when their tab is hidden, regardless of the auto-pause setting. The underlying
+ * {@code WebApplication} hooks {@code visibilitychange} unconditionally, and browsers throttle
+ * {@code requestAnimationFrame} heavily in background tabs regardless. This is standard browser behavior
+ * and is not something FlixelGDX can override. If your game needs to account for time spent in the
+ * background (idle progression, session timers, and similar), record a timestamp in
+ * {@link FlixelGame#onFocusLost()} and compute the delta when {@link FlixelGame#onFocusGained()} fires.
  *
  * @see FlixelGame
  * @see WebApplicationConfiguration


### PR DESCRIPTION
## Description

Expands `FlixelHostIntegration` with three new capability areas that were previously missing entirely, and adds a real web implementation (`FlixelTeaVMHostIntegration`) to replace the no-op the TeaVM backend was falling back to.

**Clipboard** - Text and image copy/paste using a signal-based async API. Paste operations trigger `onTextPasted()` or `onImagePasted()` signals rather than taking a callback parameter, so multiple subscribers can listen and the trigger is cleanly separated from the handler. Desktop uses AWT clipboard with `DataFlavor` for both text and image. Web uses `navigator.clipboard` with `@JSFunctor` callbacks; image paste decodes via an offscreen canvas and transfers RGBA bytes using `Int8Array.copyToJavaArray()` to avoid per-byte iteration overhead.

**Screen wake lock** - `keepScreenAwake(boolean)` prevents display sleep during gameplay. Desktop spawns `caffeinate` (macOS) or `systemd-inhibit` (Linux) as a background process; releasing kills it. Web uses the Screen Wake Lock API. Windows is not supported (`supportsWakeLock()` returns `false`).

**Exit confirmation** - `setExitConfirmation(@Nullable String)` warns players before they navigate away mid-session. Web hooks `window.onbeforeunload`; desktop is a no-op since the OS handles window-close confirmation at the application level.

**Web notification permission** - `requestNotificationPermission()` added as the documented entry point for web games. `supportsDesktopNotification()` now returns `false` on web until the browser permission dialog has been accepted. Desktop permission is implicit so the method is a no-op there.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - backend integration changes with no visual output.