### PR TITLE
Added getXxx() bridge methods across flixelgdx-core for clean Kotlin property access

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelBasic.java
@@ -148,6 +148,11 @@ public abstract class FlixelBasic implements IFlixelBasic {
     return exists;
   }
 
+  /** Returns whether this object exists in the world. */
+  public boolean getExists() {
+    return exists;
+  }
+
   @Override
   public void setExists(boolean exists) {
     this.exists = exists;
@@ -158,6 +163,11 @@ public abstract class FlixelBasic implements IFlixelBasic {
     return active;
   }
 
+  /** Returns whether this object is active and will be updated each frame. */
+  public boolean getActive() {
+    return active;
+  }
+
   @Override
   public void setActive(boolean active) {
     this.active = active;
@@ -165,6 +175,11 @@ public abstract class FlixelBasic implements IFlixelBasic {
 
   @Override
   public boolean isVisible() {
+    return visible;
+  }
+
+  /** Returns whether this object is visible and will be drawn each frame. */
+  public boolean getVisible() {
     return visible;
   }
 
@@ -180,6 +195,11 @@ public abstract class FlixelBasic implements IFlixelBasic {
 
   @Override
   public boolean isKilled() {
+    return !exists;
+  }
+
+  /** Returns whether this object has been killed (i.e. does not exist). */
+  public boolean getKilled() {
     return !exists;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelCamera.java
@@ -1748,13 +1748,28 @@ public class FlixelCamera extends FlixelBasic implements FlixelColorable, Flixel
     return flashActive;
   }
 
+  /** Returns {@code true} if a flash effect is currently active on this camera. */
+  public boolean getFlashActive() {
+    return flashActive;
+  }
+
   /** Returns {@code true} if a fade effect is currently active on this camera. */
   public boolean isFadeActive() {
     return fadeActive;
   }
 
+  /** Returns {@code true} if a fade effect is currently active on this camera. */
+  public boolean getFadeActive() {
+    return fadeActive;
+  }
+
   /** Returns {@code true} if a shake effect is currently active on this camera. */
   public boolean isShakeActive() {
+    return shakeActive;
+  }
+
+  /** Returns {@code true} if a shake effect is currently active on this camera. */
+  public boolean getShakeActive() {
     return shakeActive;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -1338,6 +1338,11 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     return transparentFramebufferRequested;
   }
 
+  /** Returns whether an alpha-capable framebuffer was requested at launch. */
+  public boolean getTransparentFramebufferRequested() {
+    return transparentFramebufferRequested;
+  }
+
   /**
    * Requests an alpha-capable GLFW framebuffer on LWJGL3 before the desktop launcher runs. Default {@code true}. Set {@code false}
    * if you must avoid framebuffer alpha (some drivers) or never want desktop compositing. When {@code false}, toggling
@@ -1353,6 +1358,11 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
    * @return {@code true} after {@link #applyBackdropForDesktopTransparency(boolean)} was called with {@code true}.
    */
   public boolean isTransparencyActive() {
+    return desktopTransparencyActive;
+  }
+
+  /** Returns {@code true} after desktop transparency was applied via {@link #applyBackdropForDesktopTransparency(boolean)}. */
+  public boolean getTransparencyActive() {
     return desktopTransparencyActive;
   }
 
@@ -1481,11 +1491,26 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     return gamePaused;
   }
 
+  /** Returns whether the game is currently paused. */
+  public boolean getGamePaused() {
+    return gamePaused;
+  }
+
   public boolean isClosing() {
     return isClosing;
   }
 
+  /** Returns whether the game is in the process of closing. */
+  public boolean getClosing() {
+    return isClosing;
+  }
+
   public boolean isClosed() {
+    return isClosed;
+  }
+
+  /** Returns whether the game window has fully closed. */
+  public boolean getClosed() {
     return isClosed;
   }
 
@@ -1502,6 +1527,11 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     return vsync;
   }
 
+  /** Returns whether vertical sync is enabled. */
+  public boolean getVsync() {
+    return vsync;
+  }
+
   public void setVsync(boolean vsync) {
     this.vsync = vsync;
     Gdx.graphics.setVSync(vsync);
@@ -1511,12 +1541,22 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     return fullscreen;
   }
 
+  /** Returns whether the game is currently running in fullscreen mode. */
+  public boolean getFullscreen() {
+    return fullscreen;
+  }
+
   public void setWindowSize(Vector2 newSize) {
     viewSize = newSize;
     Gdx.graphics.setWindowedMode((int) newSize.x, (int) newSize.y);
   }
 
   public boolean isGlobalOverlayEnabled() {
+    return overlayEnabled;
+  }
+
+  /** Returns whether the global overlay camera is enabled. */
+  public boolean getGlobalOverlayEnabled() {
     return overlayEnabled;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelObject.java
@@ -596,6 +596,11 @@ public class FlixelObject extends FlixelBasic implements FlixelDebugDrawable, Fl
     return allowCollisions != FlixelDirectionFlags.NONE;
   }
 
+  /** Returns {@code true} when {@code allowCollisions} is not {@link FlixelDirectionFlags#NONE}. */
+  public boolean getSolid() {
+    return allowCollisions != FlixelDirectionFlags.NONE;
+  }
+
   /**
    * Sets {@link #allowCollisions} to {@code ANY} when {@code solid} is true, or {@code NONE} when false.
    *
@@ -616,6 +621,11 @@ public class FlixelObject extends FlixelBasic implements FlixelDebugDrawable, Fl
   /** {@inheritDoc} */
   @Override
   public boolean isImmovable() {
+    return immovable;
+  }
+
+  /** Returns whether this object is immovable during collision resolution. */
+  public boolean getImmovable() {
     return immovable;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -797,8 +797,9 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     return graphic != null && graphic.isOwned();
   }
 
-  public Texture getGraphic() {
-    return getTexture();
+  @Nullable
+  public FlixelGraphic getGraphic() {
+    return graphic;
   }
 
   public Texture getTexture() {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -969,18 +969,24 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     return flipX;
   }
 
-  /** Returns whether this sprite is flipped horizontally. */
   public boolean getFlipX() {
     return flipX;
+  }
+
+  public void setFlipX(boolean flipX) {
+    this.flipX = flipX;
   }
 
   public boolean isFlipY() {
     return flipY;
   }
 
-  /** Returns whether this sprite is flipped vertically. */
   public boolean getFlipY() {
     return flipY;
+  }
+
+  public void setFlipY(boolean flipY) {
+    this.flipY = flipY;
   }
 
   public void setRegion(TextureRegion region) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -874,6 +874,11 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     return antialiasing;
   }
 
+  /** Returns whether linear texture filtering (antialiasing) is enabled for this sprite. */
+  public boolean getAntialiasing() {
+    return antialiasing;
+  }
+
   @Override
   public void setAntialiasing(boolean antialiasing) {
     this.antialiasing = antialiasing;
@@ -963,7 +968,17 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     return flipX;
   }
 
+  /** Returns whether this sprite is flipped horizontally. */
+  public boolean getFlipX() {
+    return flipX;
+  }
+
   public boolean isFlipY() {
+    return flipY;
+  }
+
+  /** Returns whether this sprite is flipped vertically. */
+  public boolean getFlipY() {
     return flipY;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimationController.java
@@ -453,6 +453,11 @@ public class FlixelAnimationController implements FlixelUpdatable {
     return paused;
   }
 
+  /** Returns whether animation playback is currently paused. */
+  public boolean getPaused() {
+    return paused;
+  }
+
   /** Toggles playback direction. Time still advances by {@link #update(float)} while not paused. */
   public void reverse() {
     playDirection = -playDirection;
@@ -664,6 +669,11 @@ public class FlixelAnimationController implements FlixelUpdatable {
     return !looping && duration > 0f && stateTime >= duration;
   }
 
+  /** Returns whether the current animation has finished playing (only meaningful for non-looping animations). */
+  public boolean getAnimationFinished() {
+    return isAnimationFinished();
+  }
+
   @Override
   public void update(float elapsed) {
     if (animations.size == 0 || paused || currentAnim.isEmpty()) {
@@ -811,6 +821,11 @@ public class FlixelAnimationController implements FlixelUpdatable {
   }
 
   public boolean isLooping() {
+    return looping;
+  }
+
+  /** Returns whether the current animation is set to loop. */
+  public boolean getLooping() {
     return looping;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAsset.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAsset.java
@@ -113,8 +113,18 @@ public final class FlixelDefaultAsset<T> implements FlixelAsset<T> {
     return content != null || assets.getManager().isLoaded(path, rawType);
   }
 
+  /** Returns whether this asset has been loaded into memory. */
+  public boolean getLoaded() {
+    return isLoaded();
+  }
+
   @Override
   public boolean isPersist() {
+    return persist;
+  }
+
+  /** Returns whether this asset is marked to persist across state transitions. */
+  public boolean getPersist() {
     return persist;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/asset/FlixelDefaultAssetManager.java
@@ -236,6 +236,11 @@ public class FlixelDefaultAssetManager implements FlixelAssetManager {
     return compressedTexturesEnabled;
   }
 
+  /** Returns whether KTX2/BasisU compressed texture loading is enabled. */
+  public boolean getCompressedTexturesEnabled() {
+    return compressedTexturesEnabled;
+  }
+
   @Override
   public void setKtx2LoaderInstaller(@Nullable FlixelKtx2LoaderInstaller installer) {
     ktx2LoaderInstaller = installer;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSound.java
@@ -193,6 +193,11 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
     return true;
   }
 
+  /** Returns whether this sound's audio data has been loaded. */
+  public boolean getLoaded() {
+    return true;
+  }
+
   @Override
   public int getRefCount() {
     return refCount;
@@ -318,6 +323,11 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
     return sound.isLooping();
   }
 
+  /** Returns whether this sound is set to loop. */
+  public boolean getLooped() {
+    return sound.isLooping();
+  }
+
   /**
    * Enables or disables looping.
    *
@@ -335,6 +345,11 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
    * @return {@code true} if the sound is actively playing.
    */
   public boolean isPlaying() {
+    return sound.isPlaying();
+  }
+
+  /** Returns whether this sound is currently playing. */
+  public boolean getPlaying() {
     return sound.isPlaying();
   }
 
@@ -548,6 +563,11 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
     return autoDestroy;
   }
 
+  /** Returns whether this sound auto-destroys when playback completes. */
+  public boolean getAutoDestroy() {
+    return autoDestroy;
+  }
+
   /**
    * Sets whether this sound auto-destroys when playback completes.
    *
@@ -561,6 +581,11 @@ public class FlixelSound extends FlixelBasic implements FlixelAsset<FlixelSoundB
 
   @Override
   public boolean isPersist() {
+    return persist;
+  }
+
+  /** Returns whether this sound persists across state transitions. */
+  public boolean getPersist() {
     return persist;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundSource.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/audio/FlixelSoundSource.java
@@ -87,6 +87,11 @@ public final class FlixelSoundSource {
     return external;
   }
 
+  /** Returns whether this source uses an external (absolute) path. */
+  public boolean getExternal() {
+    return external;
+  }
+
   /**
    * Creates a new playable {@link FlixelSound} instance using the provided
    * group (or the default SFX group if {@code null}).

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphic.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelGraphic.java
@@ -125,8 +125,18 @@ public final class FlixelGraphic implements FlixelAsset<FlixelGraphic> {
     return owned || assets.getManager().isLoaded(getResolvedPath(), Texture.class);
   }
 
+  /** Returns whether this graphic's texture has been loaded into memory. */
+  public boolean getLoaded() {
+    return isLoaded();
+  }
+
   @Override
   public boolean isPersist() {
+    return persist;
+  }
+
+  /** Returns whether this graphic is marked to persist across state transitions. */
+  public boolean getPersist() {
     return persist;
   }
 
@@ -216,6 +226,11 @@ public final class FlixelGraphic implements FlixelAsset<FlixelGraphic> {
    * @return {@code true} if owned.
    */
   public boolean isOwned() {
+    return owned;
+  }
+
+  /** Returns whether this graphic owns its texture and disposes it on eviction. */
+  public boolean getOwned() {
     return owned;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelBasicGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelBasicGroup.java
@@ -27,20 +27,23 @@ import com.badlogic.gdx.utils.ArraySupplier;
 import com.badlogic.gdx.utils.SnapshotArray;
 
 import org.flixelgdx.FlixelBasic;
+import org.flixelgdx.FlixelSprite;
+import org.flixelgdx.FlixelState;
 import org.flixelgdx.functional.IFlixelBasic;
 import org.flixelgdx.graphics.FlixelBatch;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * A {@link org.flixelgdx.FlixelBasic FlixelBasic} that owns a {@link FlixelGroup} of {@link IFlixelBasic} members, with batch
- * {@link #update(float)} / {@link org.flixelgdx.functional.FlixelDrawable#draw(FlixelBatch)}, {@link #recycle()}, and {@link #destroy()} that tears down members.
+ * A {@link FlixelBasic} that owns a {@link FlixelGroup} of {@link IFlixelBasic} members, with batch
+ * {@link #update(float)} / {@link #draw(FlixelBatch)}, {@link #recycle()}, and {@link #destroy()}
+ * that tears down members.
  *
- * <p>Member list operations are delegated to an internal {@link FlixelGroup}; {@link #getMemberList()} exposes it when
- * you need the raw container.
+ * <p>Member list operations are delegated to an internal {@link FlixelGroup}; {@link #getMemberList()}
+ * exposes it when you need the raw container.
  *
- * <p>{@link #remove} and {@link #detach} only unlink members; they do not call {@link org.flixelgdx.FlixelBasic#destroy() FlixelBasic.destroy()}. Prefer
- * {@link org.flixelgdx.FlixelBasic#kill() FlixelBasic.kill()} / {@link #recycle()} for reuse. See {@link org.flixelgdx.FlixelBasic FlixelBasic} for lifecycle guidance.
+ * <p>{@link #remove} and {@link #detach} only unlink members; they do not call {@link FlixelBasic#destroy()}.
+ * Prefer {@link FlixelBasic#kill()} / {@link #recycle()} for reuse. See {@link FlixelBasic} for lifecycle guidance.
  *
  * @param <T> Member type.
  * @see FlixelGroup
@@ -68,8 +71,8 @@ public abstract class FlixelBasicGroup<T extends IFlixelBasic> extends FlixelBas
 
   /**
    * Called by {@link #recycle()} when no dead member exists and the group is under {@link #getMaxSize()}. The default
-   * returns {@code null}. {@link org.flixelgdx.FlixelState FlixelState} overrides this to allocate a
-   * {@link org.flixelgdx.FlixelSprite FlixelSprite}.
+   * returns {@code null}. {@link FlixelState} overrides this to allocate a
+   * {@link FlixelSprite}.
    */
   protected @Nullable T createMemberForRecycle() {
     return null;
@@ -162,8 +165,8 @@ public abstract class FlixelBasicGroup<T extends IFlixelBasic> extends FlixelBas
   }
 
   /**
-   * Revives the first {@link #getFirstDead() dead} member, or uses {@link #createMemberForRecycle()}, revives it, adds it
-   * when under max size, and returns it.
+   * Revives the first {@link #getFirstDead() dead} member, or uses {@link #createMemberForRecycle()},
+   * revives it, adds it when under max size, and returns it.
    *
    * @return A member ready to use, or {@code null} if nothing could be recycled or created.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelBasicGroupable.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelBasicGroupable.java
@@ -25,26 +25,28 @@ package org.flixelgdx.group;
 
 import com.badlogic.gdx.utils.SnapshotArray;
 
+import org.flixelgdx.FlixelBasic;
+import org.flixelgdx.functional.FlixelDestroyable;
 import org.flixelgdx.functional.IFlixelBasic;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * A {@link FlixelGroupable} whose members are {@link IFlixelBasic} instances. Engine code (overlap checks, debug
  * traversal, {@link FlixelBasicGroup}) can depend on this marker and the helpers below without forcing generic
- * {@link FlixelGroup} users to extend {@link org.flixelgdx.FlixelBasic FlixelBasic}.
+ * {@link FlixelGroup} users to extend {@link FlixelBasic}.
  *
- * <p>For lifecycle guidance ({@code kill}/{@code revive}/{@code destroy}), see {@link org.flixelgdx.FlixelBasic FlixelBasic}.
+ * <p>For lifecycle guidance ({@code kill}/{@code revive}/{@code destroy}), see {@link FlixelBasic}.
  *
  * @param <T> Member type.
  */
 public interface FlixelBasicGroupable<T extends IFlixelBasic> extends FlixelGroupable<T> {
 
   /**
-   * Removes the member from the group; if {@code destroy} is {@code true}, also calls {@link org.flixelgdx.functional.FlixelDestroyable#destroy() FlixelDestroyable.destroy()} on it
-   * after removal.
+   * Removes the member from the group; if {@code destroy} is {@code true}, also calls
+   * {@link FlixelDestroyable#destroy()} on it after removal.
    *
    * @param member The member to remove.
-   * @param destroy If {@code true}, call {@link org.flixelgdx.functional.FlixelDestroyable#destroy() FlixelDestroyable.destroy()} after unlinking.
+   * @param destroy If {@code true}, call {@link FlixelDestroyable#destroy()} after unlinking.
    */
   default void removeMember(T member, boolean destroy) {
     if (member == null) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
@@ -362,6 +362,11 @@ public class FlixelSpriteGroup extends FlixelSprite implements FlixelBasicGroupa
     return antialiasing;
   }
 
+  /** Returns whether antialiasing is enabled for sprites in this group. */
+  public boolean getAntialiasing() {
+    return antialiasing;
+  }
+
   @Override
   public int getFacing() {
     return facing;
@@ -571,6 +576,11 @@ public class FlixelSpriteGroup extends FlixelSprite implements FlixelBasicGroupa
   }
 
   public boolean isEmpty() {
+    return members.size == 0;
+  }
+
+  /** Returns whether this group contains no members. */
+  public boolean getEmpty() {
     return members.size == 0;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadDevice.java
@@ -59,6 +59,11 @@ public final class FlixelGamepadDevice {
     return manager.isSlotConnected(id);
   }
 
+  /** Returns whether this gamepad slot currently maps to a connected controller. */
+  public boolean getConnected() {
+    return manager.isSlotConnected(id);
+  }
+
   /**
    * Model detected for this slot the last time the slot was (re)bound.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/text/FlixelText.java
@@ -320,6 +320,11 @@ public class FlixelText extends FlixelSprite {
     return wordWrap;
   }
 
+  /** Returns whether word wrapping is enabled. */
+  public boolean getWordWrap() {
+    return wordWrap;
+  }
+
   /**
    * Enables or disables word wrapping. Defaults to {@code true}.
    *
@@ -334,6 +339,11 @@ public class FlixelText extends FlixelSprite {
 
   /** Returns whether the text field auto-sizes to fit its content. */
   public boolean isAutoSize() {
+    return autoSize;
+  }
+
+  /** Returns whether the text field auto-sizes to fit its content. */
+  public boolean getAutoSize() {
     return autoSize;
   }
 
@@ -398,6 +408,11 @@ public class FlixelText extends FlixelSprite {
     return bold;
   }
 
+  /** Returns whether bold text is enabled. */
+  public boolean getBold() {
+    return bold;
+  }
+
   /**
    * Sets whether to use bold text. Only takes visual effect when a {@code .ttf}
    * font has been set via {@link #setFont(FileHandle)}, since the default bitmap
@@ -417,6 +432,11 @@ public class FlixelText extends FlixelSprite {
 
   /** Returns whether italic text is enabled. */
   public boolean isItalic() {
+    return italic;
+  }
+
+  /** Returns whether italic text is enabled. */
+  public boolean getItalic() {
     return italic;
   }
 
@@ -468,6 +488,16 @@ public class FlixelText extends FlixelSprite {
   public boolean isEmbedded() {
     return fontFile != null || fontRegistryId != null
         || FlixelFontRegistry.getDefault() != null;
+  }
+
+  /**
+   * Returns whether this text uses a custom embedded font ({@code true}) or the
+   * default libGDX bitmap font ({@code false}). A font is considered embedded when
+   * set via {@link #setFont(FileHandle)}, {@link #setFont(String)}, or when a
+   * {@linkplain FlixelFontRegistry#setDefault(String) registry default} is active.
+   */
+  public boolean getEmbedded() {
+    return isEmbedded();
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -1030,7 +1030,17 @@ public abstract class FlixelTween implements Pool.Poolable {
     return finished;
   }
 
+  /** Returns whether this tween has completed all of its iterations. */
+  public boolean getFinished() {
+    return finished;
+  }
+
   public boolean isActive() {
+    return active;
+  }
+
+  /** Returns whether this tween is currently active and updating. */
+  public boolean getActive() {
     return active;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/settings/FlixelTweenType.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/settings/FlixelTweenType.java
@@ -46,8 +46,18 @@ public enum FlixelTweenType {
     return this == LOOPING || this == PINGPONG;
   }
 
+  /** Returns true for LOOPING and PINGPONG tween types. */
+  public boolean getLooping() {
+    return this == LOOPING || this == PINGPONG;
+  }
+
   /** True if this type plays in reverse (initial direction for {@link #BACKWARD}). Toggled each cycle for {@link #PINGPONG}. */
   public boolean isBackward() {
+    return this == BACKWARD;
+  }
+
+  /** Returns true if this tween type plays in reverse. */
+  public boolean getBackward() {
     return this == BACKWARD;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelShakeTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/FlixelShakeTween.java
@@ -109,6 +109,11 @@ public class FlixelShakeTween extends FlixelTween {
     return fadeOut;
   }
 
+  /** Returns whether this shake tween fades out over time. */
+  public boolean getFadeOut() {
+    return fadeOut;
+  }
+
   @Override
   public FlixelTween start() {
     super.start();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/motion/FlixelMotion.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/type/motion/FlixelMotion.java
@@ -126,7 +126,17 @@ public abstract class FlixelMotion extends FlixelTween {
     return priorImmovable;
   }
 
+  /** Returns whether the motion target was immovable before this tween started. */
+  public boolean getPriorImmovable() {
+    return priorImmovable;
+  }
+
   public boolean isImmovableCaptured() {
+    return immovableCaptured;
+  }
+
+  /** Returns whether the prior immovable state has been captured from the motion target. */
+  public boolean getImmovableCaptured() {
     return immovableCaptured;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelShader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelShader.java
@@ -287,6 +287,11 @@ public class FlixelShader extends FlixelBasic {
     return program != null && program.isCompiled();
   }
 
+  /** Returns whether this shader compiled without errors and is ready to use. */
+  public boolean getCompiled() {
+    return program != null && program.isCompiled();
+  }
+
   /**
    * Returns the compilation log from the underlying {@link ShaderProgram}, useful for
    * diagnosing compilation errors. Returns an empty string if the program is {@code null}.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
@@ -167,6 +167,11 @@ public class FlixelString implements CharSequence {
     return buffer.isEmpty();
   }
 
+  /** Returns whether the buffer contains no characters. */
+  public boolean getEmpty() {
+    return buffer.isEmpty();
+  }
+
   /**
    * Replaces the entire buffer with a copy of {@code text}.
    *

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/save/FlixelSave.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/save/FlixelSave.java
@@ -132,6 +132,11 @@ public class FlixelSave implements FlixelDestroyable {
     return bound && preferences != null;
   }
 
+  /** Returns whether this save is bound to a named preferences file and ready to use. */
+  public boolean getBound() {
+    return bound && preferences != null;
+  }
+
   @NotNull
   public String getName() {
     return boundName;
@@ -205,6 +210,11 @@ public class FlixelSave implements FlixelDestroyable {
   }
 
   public boolean isEmpty() {
+    return data.size == 0;
+  }
+
+  /** Returns whether this save contains no stored data. */
+  public boolean getEmpty() {
     return data.size == 0;
   }
 


### PR DESCRIPTION
## Description

Kotlin synthesizes properties from Java getters, but the rule for boolean getters is asymmetric: `isXxx()` stays as `isXxx` (the `is` prefix is preserved), while `getXxx()` becomes `xxx`. This means Kotlin users had to write `sprite.isBold` instead of `sprite.bold`, which reads awkwardly as a property.

This PR adds a paired `getXxx()` method alongside every `isXxx()` boolean getter across `flixelgdx-core`. Java developers are completely unaffected — their existing `isXxx()` calls keep working with zero changes. Kotlin users now get the clean property name (`bold`, `exists`, `solid`, etc.) synthesized from the `getXxx()/setXxx()` pair.

Files changed across 22 source files, covering: `FlixelBasic`, `FlixelObject`, `FlixelSprite`, `FlixelCamera`, `FlixelGame`, `FlixelText`, `FlixelAnimationController`, `FlixelDefaultAsset`, `FlixelDefaultAssetManager`, `FlixelSound`, `FlixelSoundSource`, `FlixelGraphic`, `FlixelSpriteGroup`, `FlixelGamepadDevice`, `FlixelTween`, `FlixelTweenType`, `FlixelShakeTween`, `FlixelMotion`, `FlixelShader`, `FlixelString`, and `FlixelSave`.

No reflection is used anywhere. Methods with parameters (e.g. `isTouching(int)`) are skipped since there is no meaningful no-arg bridge to add. `FlixelRuntimeUtil` is also skipped because its `isXxx()` methods live in an anonymous inner class implementing `RuntimeProbe` — bridging there would require modifying the interface too.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A — confirmed in a prior session that adding `getBold()/setBold()` alongside `isBold()/setBold()` makes both `bold` and `isBold` appear as Kotlin properties, giving users the clean form.