### PR TITLE
Added Gdx.app.getJavaHeap() support for web games to obtain the current JavaScript heap

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -23,7 +23,6 @@
  */
 package org.flixelgdx;
 
-import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 
@@ -1163,44 +1162,6 @@ public final class Flixel {
   }
 
   /**
-   * Returns the Java heap memory currently in use, in bytes.
-   *
-   * @return The Java heap memory currently in use, in bytes.
-   */
-  public static long getJavaHeapUsedBytes() {
-    Runtime rt = Runtime.getRuntime();
-    return rt.totalMemory() - rt.freeMemory();
-  }
-
-  /**
-   * Returns the total Java heap memory allocated by the JVM, in bytes.
-   *
-   * @return The total Java heap memory allocated by the JVM, in bytes.
-   */
-  public static long getJavaHeapTotalBytes() {
-    return Runtime.getRuntime().totalMemory();
-  }
-
-  /**
-   * Returns the maximum Java heap memory available to the JVM, in bytes.
-   *
-   * @return The maximum Java heap memory available to the JVM, in bytes.
-   */
-  public static long getJavaHeapMaxBytes() {
-    return Runtime.getRuntime().maxMemory();
-  }
-
-  /**
-   * Returns an estimate of the native heap usage in bytes as reported by libGDX.
-   *
-   * <p>This is not available on all platforms and may return the same number as the
-   * Java heap when unsupported.
-   */
-  public static long getNativeHeapUsedBytes() {
-    return Gdx.app != null ? Gdx.app.getNativeHeap() : 0L;
-  }
-
-  /**
    * The camera currently being drawn in {@link FlixelDrawable#draw(org.flixelgdx.graphics.FlixelBatch) FlixelGame.draw(Batch)},
    * or {@code null} if not in a camera pass.
    */
@@ -1241,6 +1202,8 @@ public final class Flixel {
   /**
    * Sets antialiasing to be applied to all {@link FlixelSprite} objects.
    * Automatically updates the current state.
+   *
+   * <p>Note that if you want this value to take effect
    *
    * @param enabled If antialiasing should be applied to all current and any future {@link FlixelSprite} objects.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -46,6 +46,7 @@ import org.flixelgdx.debug.FlixelHeadlessDebugOverlay;
 import org.flixelgdx.debug.FlixelNoopDebugOverlay;
 import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.functional.FlixelDrawable;
+import org.flixelgdx.graphics.FlixelBatch;
 import org.flixelgdx.group.FlixelGroupable;
 import org.flixelgdx.input.gamepad.FlixelGamepadManager;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
@@ -1152,7 +1153,7 @@ public final class Flixel {
 
   /**
    * Resets the debug overlay back to the inert noop after it has been disposed.
-   * {@link FlixelGame#dispose()} calls {@link org.flixelgdx.debug.FlixelDebugOverlay#destroy() FlixelDebugOverlay.destroy()}
+   * {@link FlixelGame#dispose()} calls {@link FlixelDebugOverlay#destroy() FlixelDebugOverlay.destroy()}
    * first; this method only resets the handle to avoid double-dispose.
    */
   static void clearDebugOverlay() {
@@ -1162,7 +1163,7 @@ public final class Flixel {
   }
 
   /**
-   * The camera currently being drawn in {@link FlixelDrawable#draw(org.flixelgdx.graphics.FlixelBatch) FlixelGame.draw(Batch)},
+   * The camera currently being drawn in {@link FlixelDrawable#draw(FlixelBatch)},
    * or {@code null} if not in a camera pass.
    */
   @Nullable
@@ -1200,12 +1201,14 @@ public final class Flixel {
   }
 
   /**
-   * Sets antialiasing to be applied to all {@link FlixelSprite} objects.
-   * Automatically updates the current state.
+   * Sets antialiasing to be applied to all {@link FlixelSprite} / {@link FlixelAntialiasable} objects.
    *
-   * <p>Note that if you want this value to take effect
+   * <p>Calling this function automatically updates the current state. Note that if you want this
+   * value to actually apply to any {@link FlixelSprite} / {@link FlixelAntialiasable} object being
+   * added to a {@link FlixelState}, set {@link #applyAntialiasingOnStateAdd} to {@code true}.
    *
-   * @param enabled If antialiasing should be applied to all current and any future {@link FlixelSprite} objects.
+   * @param enabled If antialiasing should be applied to all current
+   *     {@link FlixelSprite} / {@link FlixelAntialiasable} objects.
    */
   public static void setAntialiasing(boolean enabled) {
     if (enabled == antialiasing) {
@@ -1227,8 +1230,8 @@ public final class Flixel {
       if (member == null) {
         continue;
       }
-      if (member instanceof FlixelAntialiasable sprite) {
-        sprite.setAntialiasing(enabled);
+      if (member instanceof FlixelAntialiasable m) {
+        m.setAntialiasing(enabled);
       }
     }
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -332,8 +332,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
     if (statsTimer >= STATS_UPDATE_INTERVAL) {
       statsTimer = 0f;
       cachedFps = Gdx.graphics.getFramesPerSecond();
-      cachedHeapMegabytes = Flixel.getJavaHeapUsedBytes() / (1024f * 1024f);
-      cachedNativeMegabytes = Flixel.getNativeHeapUsedBytes() / (1024f * 1024f);
+      cachedHeapMegabytes = Gdx.app.getJavaHeap() / (1024f * 1024f);
+      cachedNativeMegabytes = Gdx.app.getNativeHeap() / (1024f * 1024f);
       cachedObjectCount = FlixelDebugUtil.countActiveMembers();
       cachedAssetCount = Flixel.assets != null ? Flixel.assets.getLoadedAssetCount() : 0;
     }
@@ -356,8 +356,8 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
   protected void pushPerfSample(float elapsed) {
     int idx = perfHead;
     perfFrameMs[idx] = elapsed * 1000f;
-    perfHeapMb[idx] = Flixel.getJavaHeapUsedBytes() / (1024f * 1024f);
-    perfNativeMb[idx] = Flixel.getNativeHeapUsedBytes() / (1024f * 1024f);
+    perfHeapMb[idx] = Gdx.app.getJavaHeap() / (1024f * 1024f);
+    perfNativeMb[idx] = Gdx.app.getNativeHeap() / (1024f * 1024f);
     perfFps[idx] = Gdx.graphics.getFramesPerSecond();
     perfRenderCalls[idx] = sampleRenderCallsNow();
     perfHead = (idx + 1) % PERF_HISTORY_SIZE;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelShader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelShader.java
@@ -48,7 +48,7 @@ import org.flixelgdx.FlixelCamera;
  *     libGDX {@link com.badlogic.gdx.graphics.g2d.SpriteBatch SpriteBatch} attribute contract.
  *     Fragment shaders receive the camera output as {@code uniform sampler2D u_texture} via
  *     the {@code v_texCoords} varying.</li>
- *   <li><b>HaxeFlixel mode} ({@link #fromHaxeFlixel(String)})</b>: write or copy a filter
+ *   <li><b>HaxeFlixel mode ({@link #fromHaxeFlixel(String)})</b>: write or copy a filter
  *     shader from HaxeFlixel using {@code #pragma header}, {@code #pragma body},
  *     {@code bitmap}, {@code openfl_TextureCoordv}, and {@code flixel_texture2D(...)}. The
  *     preprocessor rewrites those to libGDX-compatible names before compilation.</li>

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMLauncher.java
@@ -223,12 +223,25 @@ public class FlixelTeaVMLauncher {
       }
 
       @Override
+      public long getJavaHeap() {
+        return (long) jsHeapUsedBytes();
+      }
+
+      @Override
       public void exit() {
         super.exit();
         closeWindow();
       }
     };
   }
+
+  /**
+   * Returns the used JavaScript heap size in bytes as reported by {@code performance.memory},
+   * or 0 if the API is not available (non-Chromium browsers).
+   */
+  @JSBody(
+      script = "if (typeof performance !== 'undefined' && performance.memory) { return performance.memory.usedJSHeapSize; } return 0;")
+  private static native double jsHeapUsedBytes();
 
   /**
    * Calls the browser's {@code window.close()} to close the current tab.


### PR DESCRIPTION
## Description

Web games with the framework when accessing the total heap being used by their games would always return 0. While there's no JVM in the browser, it can still be unhelpful.

This PR adds a simple new addition to web games, allowing developers to access the current JavaScript heap when querying `Gdx.app.getJavaHeap()`.

It also removes the redundant heap/native methods from `Flixel`, as the `Gdx.app.*` methods should be used instead.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [ ] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Add screenshots or logs to help explain your changes.
