### PR TITLE
Changed debug overlay panel colors to red instead of the default ImGui blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,26 @@
-# FlixelGDX
+<div align="center">
+    
+    # FlixelGDX
 
-<img src="markdown-assets/readme/flxgdx.png" width="500" alt="FlixelGDX logo">
-
-### Logo Artist: [LeoThM](https://www.instagram.com/leoxthm_/)
-
-[![CI](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml/badge.svg)](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml)
-[![Maven Central](https://img.shields.io/maven-central/v/org.flixelgdx/flixelgdx-core)](https://central.sonatype.com/artifact/org.flixelgdx/flixelgdx-core)
-[![JitPack](https://jitpack.io/v/flixelgdx/flixelgdx.svg)](https://jitpack.io/#flixelgdx/flixelgdx)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Website](https://img.shields.io/badge/website-flixelgdx.org-blue)](https://flixelgdx.org)
-[![Stars](https://img.shields.io/github/stars/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/stargazers)
-[![Forks](https://img.shields.io/github/forks/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/forks)
-[![Issues](https://img.shields.io/github/issues/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/issues)
-[![Pull Requests](https://img.shields.io/github/issues-pr/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/pulls)
-[![Last Commit](https://img.shields.io/github/last-commit/flixelgdx/flixelgdx/develop)](https://github.com/flixelgdx/flixelgdx/commits/develop)
-[![Contributors](https://img.shields.io/github/contributors/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/graphs/contributors)
-[![Java 17+](https://img.shields.io/badge/Java-17%2B-orange)](https://adoptium.net/temurin/releases?version=17&os=any&arch=any)
-[![libGDX 1.14.0](https://img.shields.io/badge/libGDX-1.14.0-red)](https://libgdx.com/)
-[![Platforms](https://img.shields.io/badge/platforms-Desktop%20%7C%20Web-brightgreen)](https://flixelgdx.org)
+    <img src="markdown-assets/readme/flxgdx.png" width="500" alt="FlixelGDX logo">
+    
+    **Logo Artist: [LeoThM](https://www.instagram.com/leoxthm_/)**
+    
+    [![CI](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml/badge.svg)](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml)
+    [![Maven Central](https://img.shields.io/maven-central/v/org.flixelgdx/flixelgdx-core)](https://central.sonatype.com/artifact/org.flixelgdx/flixelgdx-core)
+    [![JitPack](https://jitpack.io/v/flixelgdx/flixelgdx.svg)](https://jitpack.io/#flixelgdx/flixelgdx)
+    [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+    [![Website](https://img.shields.io/badge/website-flixelgdx.org-blue)](https://flixelgdx.org)
+    [![Stars](https://img.shields.io/github/stars/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/stargazers)
+    [![Forks](https://img.shields.io/github/forks/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/forks)
+    [![Issues](https://img.shields.io/github/issues/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/issues)
+    [![Pull Requests](https://img.shields.io/github/issues-pr/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/pulls)
+    [![Last Commit](https://img.shields.io/github/last-commit/flixelgdx/flixelgdx/develop)](https://github.com/flixelgdx/flixelgdx/commits/develop)
+    [![Contributors](https://img.shields.io/github/contributors/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/graphs/contributors)
+    [![Java 17+](https://img.shields.io/badge/Java-17%2B-orange)](https://adoptium.net/temurin/releases?version=17&os=any&arch=any)
+    [![libGDX 1.14.0](https://img.shields.io/badge/libGDX-1.14.0-red)](https://libgdx.com/)
+    [![Platforms](https://img.shields.io/badge/platforms-Desktop%20%7C%20Web-brightgreen)](https://flixelgdx.org)
+</div>
 
 FlixelGDX is a featherweight powerhouse of a Java game framework built on top of [libGDX](https://libgdx.com/). It brings a clean, state-based game architecture inspired by [HaxeFlixel](https://haxeflixel.com/) and the original ActionScript [Flixel](http://www.flixel.org/) into the Java ecosystem, while keeping the full platform reach and rendering power of libGDX underneath.
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,18 @@
 <div align="center">
-    
-    # FlixelGDX
+  <img src="markdown-assets/readme/flxgdx.png" width="500" alt="FlixelGDX logo">
 
-    <img src="markdown-assets/readme/flxgdx.png" width="500" alt="FlixelGDX logo">
+  # FlixelGDX
     
-    **Logo Artist: [LeoThM](https://www.instagram.com/leoxthm_/)**
-    
-    [![CI](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml/badge.svg)](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml)
-    [![Maven Central](https://img.shields.io/maven-central/v/org.flixelgdx/flixelgdx-core)](https://central.sonatype.com/artifact/org.flixelgdx/flixelgdx-core)
-    [![JitPack](https://jitpack.io/v/flixelgdx/flixelgdx.svg)](https://jitpack.io/#flixelgdx/flixelgdx)
-    [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-    [![Website](https://img.shields.io/badge/website-flixelgdx.org-blue)](https://flixelgdx.org)
-    [![Stars](https://img.shields.io/github/stars/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/stargazers)
-    [![Forks](https://img.shields.io/github/forks/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/forks)
-    [![Issues](https://img.shields.io/github/issues/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/issues)
-    [![Pull Requests](https://img.shields.io/github/issues-pr/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/pulls)
-    [![Last Commit](https://img.shields.io/github/last-commit/flixelgdx/flixelgdx/develop)](https://github.com/flixelgdx/flixelgdx/commits/develop)
-    [![Contributors](https://img.shields.io/github/contributors/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/graphs/contributors)
-    [![Java 17+](https://img.shields.io/badge/Java-17%2B-orange)](https://adoptium.net/temurin/releases?version=17&os=any&arch=any)
-    [![libGDX 1.14.0](https://img.shields.io/badge/libGDX-1.14.0-red)](https://libgdx.com/)
-    [![Platforms](https://img.shields.io/badge/platforms-Desktop%20%7C%20Web-brightgreen)](https://flixelgdx.org)
+  **Logo Artist: [LeoThM](https://www.instagram.com/leoxthm_/)**
+
+  [![CI](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml/badge.svg)](https://github.com/flixelgdx/flixelgdx/actions/workflows/ci_build.yml)
+  [![Maven Central](https://img.shields.io/maven-central/v/org.flixelgdx/flixelgdx-core)](https://central.sonatype.com/artifact/org.flixelgdx/flixelgdx-core)
+  [![JitPack](https://jitpack.io/v/flixelgdx/flixelgdx.svg)](https://jitpack.io/#flixelgdx/flixelgdx)
+  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+  [![Website](https://img.shields.io/badge/website-flixelgdx.org-blue)](https://flixelgdx.org)
+  [![Stars](https://img.shields.io/github/stars/flixelgdx/flixelgdx)](https://github.com/flixelgdx/flixelgdx/stargazers)
+  [![Java 17+](https://img.shields.io/badge/Java-17%2B-orange)](https://adoptium.net/temurin/releases?version=17&os=any&arch=any)
+  [![Platforms](https://img.shields.io/badge/platforms-Desktop%20%7C%20Android%20%7C%20Web-brightgreen)](https://flixelgdx.org)
 </div>
 
 FlixelGDX is a featherweight powerhouse of a Java game framework built on top of [libGDX](https://libgdx.com/). It brings a clean, state-based game architecture inspired by [HaxeFlixel](https://haxeflixel.com/) and the original ActionScript [Flixel](http://www.flixel.org/) into the Java ecosystem, while keeping the full platform reach and rendering power of libGDX underneath.

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -100,9 +100,9 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private static final float[] COLOR_INFO = { 0.85f, 0.85f, 0.85f, 1f };
   private static final float[] COLOR_WARN = { 1.00f, 0.80f, 0.20f, 1f };
   private static final float[] COLOR_ERROR = { 1.00f, 0.30f, 0.30f, 1f };
-  private static final float[] COLOR_KEY = { 0.55f, 0.85f, 1.00f, 1f };
+  private static final float[] COLOR_KEY = { 0.9f, 0.2f, 0.2f, 1f };
   private static final float[] COLOR_VALUE = { 0.95f, 0.95f, 0.95f, 1f };
-  private static final float[] COLOR_HEADER = { 0.65f, 0.85f, 1.00f, 1f };
+  private static final float[] COLOR_HEADER = { 0.9f, 0.2f, 0.2f, 1f };
   private static final float[] COLOR_OK = { 0.30f, 0.95f, 0.55f, 1f };
   private static final float[] COLOR_PAUSED = { 1.00f, 0.70f, 0.20f, 1f };
   private static final float[] COLOR_HINT = { 0.65f, 0.65f, 0.65f, 1f };

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -23,6 +23,7 @@
  */
 package org.flixelgdx.backend.lwjgl3.debug;
 
+import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.backends.lwjgl3.Lwjgl3Graphics;
@@ -37,6 +38,7 @@ import org.flixelgdx.backend.FlixelRuntimeMode;
 import org.flixelgdx.debug.FlixelDebugOverlay;
 import org.flixelgdx.debug.FlixelDebugTrackerEntry;
 import org.flixelgdx.input.keyboard.FlixelKey;
+import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import org.flixelgdx.logging.FlixelLogLevel;
 import org.lwjgl.glfw.GLFW;
 
@@ -121,6 +123,9 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private static final float[] COLOR_COLLAPSING_HEADER = { 0.55f, 0.08f, 0.08f, 0.31f };
   private static final float[] COLOR_COLLAPSING_HEADER_HOVERED = { 0.68f, 0.11f, 0.11f, 0.80f };
   private static final float[] COLOR_COLLAPSING_HEADER_ACTIVE = { 0.78f, 0.13f, 0.13f, 1f };
+  private static final float[] COLOR_RESIZE_GRIP = { 0.65f, 0.10f, 0.10f, 0.20f };
+  private static final float[] COLOR_RESIZE_GRIP_HOVERED = { 0.80f, 0.15f, 0.15f, 0.67f };
+  private static final float[] COLOR_RESIZE_GRIP_ACTIVE = { 0.92f, 0.20f, 0.20f, 0.95f };
 
   /** Empty-state copy for the Watch panel (must match {@link #drawWatchWindow()}). */
   private static final String WATCH_EMPTY_HINT = "No watches registered. Use Flixel.watch.add(...) to track values.";
@@ -295,7 +300,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
    * GL state), then the GLFW backend (which removes its callback chain), and finally the imgui
    * context itself. Each call is wrapped in its own try/catch because the LWJGL window is
    * already partway through its own destruction by the time libGDX invokes
-   * {@link com.badlogic.gdx.ApplicationListener#dispose()}, and a stray crash here was triggering
+   * {@link ApplicationListener#dispose()}, and a stray crash here was triggering
    * the framework's uncaught-exception handler with the audio system still alive (the symptom:
    * "OK" closes the alert but music keeps playing).
    */
@@ -356,9 +361,9 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
    * suppress gameplay input.
    *
    * <p>Note that the debug overlay's own toggle keys (F2 by default, etc.) read raw input from
-   * {@link org.flixelgdx.input.keyboard.FlixelKeyInputManager#rawJustPressed(int) FlixelKeyInputManager.rawJustPressed(int)},
-   * so they continue to work while a text field is focused except for keys that are suppressed as
-   * typable command-line input (see {@link #shouldSuppressDebugRawKeybind(int)} on this class).
+   * {@link FlixelKeyInputManager#rawJustPressed(int)}, so they continue to work while a text field
+   * is focused except for keys that are suppressed as typable command-line input (see
+   * {@link #shouldSuppressDebugRawKeybind(int)} on this class).
    */
   @Override
   public boolean isKeyboardCapturedByUI() {
@@ -388,9 +393,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     ImGui.newFrame();
 
     // Passthrough dockspace covers the whole viewport with a transparent central node so the
-    // game keeps rendering through the empty space between/around docked windows. Without the
-    // PassthruCentralNode flag the dockspace fills the screen with the imgui background color,
-    // which is the "gray screen" symptom you would otherwise see after toggling the overlay.
+    // game keeps rendering through the empty space between/around docked windows.
     ImGui.dockSpaceOverViewport(0, ImGui.getMainViewport(), ImGuiDockNodeFlags.PassthruCentralNode);
 
     drawMainMenuBar();
@@ -672,6 +675,12 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
         COLOR_COLLAPSING_HEADER_HOVERED[2], COLOR_COLLAPSING_HEADER_HOVERED[3]);
     style.setColor(ImGuiCol.HeaderActive, COLOR_COLLAPSING_HEADER_ACTIVE[0], COLOR_COLLAPSING_HEADER_ACTIVE[1],
         COLOR_COLLAPSING_HEADER_ACTIVE[2], COLOR_COLLAPSING_HEADER_ACTIVE[3]);
+    style.setColor(ImGuiCol.ResizeGrip, COLOR_RESIZE_GRIP[0], COLOR_RESIZE_GRIP[1],
+        COLOR_RESIZE_GRIP[2], COLOR_RESIZE_GRIP[3]);
+    style.setColor(ImGuiCol.ResizeGripHovered, COLOR_RESIZE_GRIP_HOVERED[0], COLOR_RESIZE_GRIP_HOVERED[1],
+        COLOR_RESIZE_GRIP_HOVERED[2], COLOR_RESIZE_GRIP_HOVERED[3]);
+    style.setColor(ImGuiCol.ResizeGripActive, COLOR_RESIZE_GRIP_ACTIVE[0], COLOR_RESIZE_GRIP_ACTIVE[1],
+        COLOR_RESIZE_GRIP_ACTIVE[2], COLOR_RESIZE_GRIP_ACTIVE[3]);
 
     ImFontAtlas fonts = io.getFonts();
     fonts.addFontDefault();

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -35,6 +35,7 @@ import org.flixelgdx.FlixelObject;
 import org.flixelgdx.FlixelSprite;
 import org.flixelgdx.backend.FlixelRuntimeMode;
 import org.flixelgdx.debug.FlixelDebugOverlay;
+import org.flixelgdx.debug.FlixelDebugTrackerEntry;
 import org.flixelgdx.input.keyboard.FlixelKey;
 import org.flixelgdx.logging.FlixelLogLevel;
 import org.lwjgl.glfw.GLFW;
@@ -106,10 +107,20 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private static final float[] COLOR_PAUSED = { 1.00f, 0.70f, 0.20f, 1f };
   private static final float[] COLOR_HINT = { 0.65f, 0.65f, 0.65f, 1f };
 
-  // Panel title-bar color constants (red theme replacing the default ImGui blue).
-  private static final float[] COLOR_TITLE_BG = { 0.30f, 0.04f, 0.04f, 1f };
-  private static final float[] COLOR_TITLE_BG_ACTIVE = { 0.55f, 0.08f, 0.08f, 1f };
-  private static final float[] COLOR_TITLE_BG_COLLAPSED = { 0.20f, 0.04f, 0.04f, 0.75f };
+  // Widget color constants (red theme replacing the default ImGui blue).
+  private static final float[] COLOR_TITLE_BG = { 0.45f, 0.07f, 0.07f, 1f };
+  private static final float[] COLOR_TITLE_BG_ACTIVE = { 0.72f, 0.10f, 0.10f, 1f };
+  private static final float[] COLOR_TITLE_BG_COLLAPSED = { 0.30f, 0.05f, 0.05f, 0.75f };
+  private static final float[] COLOR_FRAME_BG = { 0.28f, 0.05f, 0.05f, 0.54f };
+  private static final float[] COLOR_FRAME_BG_HOVERED = { 0.50f, 0.08f, 0.08f, 0.40f };
+  private static final float[] COLOR_FRAME_BG_ACTIVE = { 0.62f, 0.10f, 0.10f, 0.67f };
+  private static final float[] COLOR_CHECK_MARK = { 1.00f, 0.60f, 0.60f, 1f };
+  private static final float[] COLOR_BUTTON = { 0.65f, 0.10f, 0.10f, 0.60f };
+  private static final float[] COLOR_BUTTON_HOVERED = { 0.80f, 0.15f, 0.15f, 1f };
+  private static final float[] COLOR_BUTTON_ACTIVE = { 0.92f, 0.20f, 0.20f, 1f };
+  private static final float[] COLOR_COLLAPSING_HEADER = { 0.55f, 0.08f, 0.08f, 0.31f };
+  private static final float[] COLOR_COLLAPSING_HEADER_HOVERED = { 0.68f, 0.11f, 0.11f, 0.80f };
+  private static final float[] COLOR_COLLAPSING_HEADER_ACTIVE = { 0.78f, 0.13f, 0.13f, 1f };
 
   /** Empty-state copy for the Watch panel (must match {@link #drawWatchWindow()}). */
   private static final String WATCH_EMPTY_HINT = "No watches registered. Use Flixel.watch.add(...) to track values.";
@@ -542,15 +553,6 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   }
 
   /**
-   * Picks a GLSL version string compatible with the OpenGL context libGDX created. macOS only
-   * exposes core profiles (>= 3.2), so we always feed it {@code "#version 150"}; on Linux/Windows
-   * the same string works against the default libGDX 3.2 context as well.
-   */
-  private static String resolveGlslVersion() {
-    return "#version 150";
-  }
-
-  /**
    * @return {@code true} for keys that should keep working as debug shortcuts while the command field is focused.
    */
   private static boolean isNonTypableSystemDebugKey(int keycode) {
@@ -652,13 +654,31 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
         COLOR_TITLE_BG_ACTIVE[3]);
     style.setColor(ImGuiCol.TitleBgCollapsed, COLOR_TITLE_BG_COLLAPSED[0], COLOR_TITLE_BG_COLLAPSED[1],
         COLOR_TITLE_BG_COLLAPSED[2], COLOR_TITLE_BG_COLLAPSED[3]);
+    style.setColor(ImGuiCol.FrameBg, COLOR_FRAME_BG[0], COLOR_FRAME_BG[1], COLOR_FRAME_BG[2], COLOR_FRAME_BG[3]);
+    style.setColor(ImGuiCol.FrameBgHovered, COLOR_FRAME_BG_HOVERED[0], COLOR_FRAME_BG_HOVERED[1],
+        COLOR_FRAME_BG_HOVERED[2], COLOR_FRAME_BG_HOVERED[3]);
+    style.setColor(ImGuiCol.FrameBgActive, COLOR_FRAME_BG_ACTIVE[0], COLOR_FRAME_BG_ACTIVE[1],
+        COLOR_FRAME_BG_ACTIVE[2], COLOR_FRAME_BG_ACTIVE[3]);
+    style.setColor(ImGuiCol.CheckMark, COLOR_CHECK_MARK[0], COLOR_CHECK_MARK[1], COLOR_CHECK_MARK[2],
+        COLOR_CHECK_MARK[3]);
+    style.setColor(ImGuiCol.Button, COLOR_BUTTON[0], COLOR_BUTTON[1], COLOR_BUTTON[2], COLOR_BUTTON[3]);
+    style.setColor(ImGuiCol.ButtonHovered, COLOR_BUTTON_HOVERED[0], COLOR_BUTTON_HOVERED[1], COLOR_BUTTON_HOVERED[2],
+        COLOR_BUTTON_HOVERED[3]);
+    style.setColor(ImGuiCol.ButtonActive, COLOR_BUTTON_ACTIVE[0], COLOR_BUTTON_ACTIVE[1], COLOR_BUTTON_ACTIVE[2],
+        COLOR_BUTTON_ACTIVE[3]);
+    style.setColor(ImGuiCol.Header, COLOR_COLLAPSING_HEADER[0], COLOR_COLLAPSING_HEADER[1], COLOR_COLLAPSING_HEADER[2],
+        COLOR_COLLAPSING_HEADER[3]);
+    style.setColor(ImGuiCol.HeaderHovered, COLOR_COLLAPSING_HEADER_HOVERED[0], COLOR_COLLAPSING_HEADER_HOVERED[1],
+        COLOR_COLLAPSING_HEADER_HOVERED[2], COLOR_COLLAPSING_HEADER_HOVERED[3]);
+    style.setColor(ImGuiCol.HeaderActive, COLOR_COLLAPSING_HEADER_ACTIVE[0], COLOR_COLLAPSING_HEADER_ACTIVE[1],
+        COLOR_COLLAPSING_HEADER_ACTIVE[2], COLOR_COLLAPSING_HEADER_ACTIVE[3]);
 
     ImFontAtlas fonts = io.getFonts();
     fonts.addFontDefault();
     fonts.build();
 
     imGuiGlfw.init(windowHandle, true);
-    imGuiGl3.init(resolveGlslVersion());
+    imGuiGl3.init("#version 150");
 
     imguiInitialized = true;
     forceRefreshOnNextUpdate();
@@ -1214,7 +1234,7 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   }
 
   /**
-   * Renders the Tracker panel, a collapsible header per registered {@link org.flixelgdx.debug.FlixelDebugTrackerEntry FlixelDebugTrackerEntry},
+   * Renders the Tracker panel, a collapsible header per registered {@link FlixelDebugTrackerEntry},
    * each containing a {@code name -> value} table (just like the Watch panel). Shown by default; when no
    * trackers are registered it stays visible with a hint, mirroring the Watch panel's empty state.
    */

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -106,6 +106,11 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private static final float[] COLOR_PAUSED = { 1.00f, 0.70f, 0.20f, 1f };
   private static final float[] COLOR_HINT = { 0.65f, 0.65f, 0.65f, 1f };
 
+  // Panel title-bar color constants (red theme replacing the default ImGui blue).
+  private static final float[] COLOR_TITLE_BG = { 0.30f, 0.04f, 0.04f, 1f };
+  private static final float[] COLOR_TITLE_BG_ACTIVE = { 0.55f, 0.08f, 0.08f, 1f };
+  private static final float[] COLOR_TITLE_BG_COLLAPSED = { 0.20f, 0.04f, 0.04f, 0.75f };
+
   /** Empty-state copy for the Watch panel (must match {@link #drawWatchWindow()}). */
   private static final String WATCH_EMPTY_HINT = "No watches registered. Use Flixel.watch.add(...) to track values.";
 
@@ -640,6 +645,13 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     io.setIniFilename(null);
     io.addConfigFlags(ImGuiConfigFlags.NavEnableKeyboard);
     io.addConfigFlags(ImGuiConfigFlags.DockingEnable);
+
+    var style = ImGui.getStyle();
+    style.setColor(ImGuiCol.TitleBg, COLOR_TITLE_BG[0], COLOR_TITLE_BG[1], COLOR_TITLE_BG[2], COLOR_TITLE_BG[3]);
+    style.setColor(ImGuiCol.TitleBgActive, COLOR_TITLE_BG_ACTIVE[0], COLOR_TITLE_BG_ACTIVE[1], COLOR_TITLE_BG_ACTIVE[2],
+        COLOR_TITLE_BG_ACTIVE[3]);
+    style.setColor(ImGuiCol.TitleBgCollapsed, COLOR_TITLE_BG_COLLAPSED[0], COLOR_TITLE_BG_COLLAPSED[1],
+        COLOR_TITLE_BG_COLLAPSED[2], COLOR_TITLE_BG_COLLAPSED[3]);
 
     ImFontAtlas fonts = io.getFonts();
     fonts.addFontDefault();


### PR DESCRIPTION
## Description

Changes the default panel title bar color in `FlixelImGuiDebugOverlay` from Dear ImGui's default blue theme to red. Three new color constants (`COLOR_TITLE_BG`, `COLOR_TITLE_BG_ACTIVE`, `COLOR_TITLE_BG_COLLAPSED`) are defined alongside the existing label color constants, and applied once in `initImGui()` via `ImGuiStyle.setColor(...)` after the context is created. This means the style is set globally at initialization time with no per-frame overhead.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

N/A - visual change only; verify by running the game in DEBUG mode and toggling the overlay (F2 by default).