### PR TITLE
Added {} placeholder formatting to FlixelLogger for cleaner log calls

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -955,8 +955,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void debug(Object message, Object... args) {
-    log.debug(message, args);
+  public static void debugf(Object message, Object... args) {
+    log.debugf(message, args);
   }
 
   /**
@@ -967,8 +967,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void debug(String tag, Object message, Object... args) {
-    log.debug(tag, message, args);
+  public static void debugf(String tag, Object message, Object... args) {
+    log.debugf(tag, message, args);
   }
 
   /**
@@ -999,8 +999,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void info(Object message, Object... args) {
-    log.info(message, args);
+  public static void infof(Object message, Object... args) {
+    log.infof(message, args);
   }
 
   /**
@@ -1011,8 +1011,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void info(String tag, Object message, Object... args) {
-    log.info(tag, message, args);
+  public static void infof(String tag, Object message, Object... args) {
+    log.infof(tag, message, args);
   }
 
   /**
@@ -1043,8 +1043,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void warn(Object message, Object... args) {
-    log.warn(message, args);
+  public static void warnf(Object message, Object... args) {
+    log.warnf(message, args);
   }
 
   /**
@@ -1055,8 +1055,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void warn(String tag, Object message, Object... args) {
-    log.warn(tag, message, args);
+  public static void warnf(String tag, Object message, Object... args) {
+    log.warnf(tag, message, args);
   }
 
   /**
@@ -1110,8 +1110,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void error(Object message, Object... args) {
-    log.error(message, args);
+  public static void errorf(Object message, Object... args) {
+    log.errorf(message, args);
   }
 
   /**
@@ -1122,8 +1122,8 @@ public final class Flixel {
    * @param throwable The throwable to log.
    * @param args The arguments to substitute into the message.
    */
-  public static void error(Object message, Throwable throwable, Object... args) {
-    log.error(message, throwable, args);
+  public static void errorf(Object message, Throwable throwable, Object... args) {
+    log.errorf(message, throwable, args);
   }
 
   /**
@@ -1134,8 +1134,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void error(String tag, Object message, Object... args) {
-    log.error(tag, message, args);
+  public static void errorf(String tag, Object message, Object... args) {
+    log.errorf(tag, message, args);
   }
 
   /**
@@ -1147,8 +1147,8 @@ public final class Flixel {
    * @param throwable The throwable to log.
    * @param args The arguments to substitute into the message.
    */
-  public static void error(String tag, Object message, Throwable throwable, Object... args) {
-    log.error(tag, message, throwable, args);
+  public static void errorf(String tag, Object message, Throwable throwable, Object... args) {
+    log.errorf(tag, message, throwable, args);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -949,17 +949,6 @@ public final class Flixel {
   }
 
   /**
-   * Logs a debug message using the default tag, replacing each {@code {}} placeholder with
-   * the corresponding argument in order.
-   *
-   * @param message The format string, where each {@code {}} is replaced by the next argument.
-   * @param args The arguments to substitute into the message.
-   */
-  public static void debug(Object message, Object... args) {
-    log.debug(message, args);
-  }
-
-  /**
    * Logs a debug message under a custom tag, replacing each {@code {}} placeholder with
    * the corresponding argument in order.
    *
@@ -990,17 +979,6 @@ public final class Flixel {
    */
   public static void info(String tag, Object message) {
     log.info(tag, message);
-  }
-
-  /**
-   * Logs an informational message using the default tag, replacing each {@code {}} placeholder
-   * with the corresponding argument in order.
-   *
-   * @param message The format string, where each {@code {}} is replaced by the next argument.
-   * @param args The arguments to substitute into the message.
-   */
-  public static void info(Object message, Object... args) {
-    log.info(message, args);
   }
 
   /**
@@ -1101,17 +1079,6 @@ public final class Flixel {
    */
   public static void error(String tag, Object message, Throwable throwable) {
     log.error(tag, message, throwable);
-  }
-
-  /**
-   * Logs an error message using the default tag, replacing each {@code {}} placeholder with
-   * the corresponding argument in order.
-   *
-   * @param message The format string, where each {@code {}} is replaced by the next argument.
-   * @param args The arguments to substitute into the message.
-   */
-  public static void error(Object message, Object... args) {
-    log.error(message, args);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -930,6 +930,48 @@ public final class Flixel {
   }
 
   /**
+   * Logs a debug message using the default tag.
+   *
+   * @param message The message to log.
+   */
+  public static void debug(Object message) {
+    log.debug(message);
+  }
+
+  /**
+   * Logs a debug message under a custom tag.
+   *
+   * @param tag The tag to log the message under.
+   * @param message The message to log.
+   */
+  public static void debug(String tag, Object message) {
+    log.debug(tag, message);
+  }
+
+  /**
+   * Logs a debug message using the default tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void debug(Object message, Object... args) {
+    log.debug(message, args);
+  }
+
+  /**
+   * Logs a debug message under a custom tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order.
+   *
+   * @param tag The tag to log the message under.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void debug(String tag, Object message, Object... args) {
+    log.debug(tag, message, args);
+  }
+
+  /**
    * Logs a generic informational message. This is likely the method you'll use the most,
    * as it's for general messages that don't fit into the other log methods.
    *
@@ -951,8 +993,31 @@ public final class Flixel {
   }
 
   /**
+   * Logs an informational message using the default tag, replacing each {@code {}} placeholder
+   * with the corresponding argument in order.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void info(Object message, Object... args) {
+    log.info(message, args);
+  }
+
+  /**
+   * Logs an informational message under a custom tag, replacing each {@code {}} placeholder
+   * with the corresponding argument in order.
+   *
+   * @param tag The tag to log the message under.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void info(String tag, Object message, Object... args) {
+    log.info(tag, message, args);
+  }
+
+  /**
    * Logs a generic warning message. This is for messages that are not errors, but are
-   *  still important to note.
+   * still important to note.
    *
    * @param message The message to log.
    */
@@ -961,8 +1026,8 @@ public final class Flixel {
   }
 
   /**
-   * Logs a warning message, with yellow highlighting, with a custom tag. This is for
-   * messages that are not errors but are still important to note.
+   * Logs a warning message with a custom tag. This is for messages that are not errors
+   * but are still important to note.
    *
    * @param tag The tag to log the message under.
    * @param message The message to log.
@@ -972,29 +1037,63 @@ public final class Flixel {
   }
 
   /**
-   * Logs an error message, with red highlighting (and the file location underlined), with a custom tag.
+   * Logs a warning message using the default tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void warn(Object message, Object... args) {
+    log.warn(message, args);
+  }
+
+  /**
+   * Logs a warning message under a custom tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order.
+   *
+   * @param tag The tag to log the message under.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void warn(String tag, Object message, Object... args) {
+    log.warn(tag, message, args);
+  }
+
+  /**
+   * Logs an error message with red highlighting (and the file location underlined).
    * This is for events that are typically not recoverable.
    *
    * @param message The message to log.
    */
   public static void error(String message) {
-    error(log.getDefaultTag(), message, null);
+    log.error(message);
   }
 
   /**
-   * Logs an error message, with red highlighting (and the file location underlined), with a custom tag.
-   * This is for events that are typically not recoverable.
+   * Logs an error message with red highlighting (and the file location underlined), including
+   * the throwable's string representation.
+   *
+   * @param message The message to log.
+   * @param throwable The throwable to log.
+   */
+  public static void error(Object message, Throwable throwable) {
+    log.error(message, throwable);
+  }
+
+  /**
+   * Logs an error message with red highlighting (and the file location underlined) under
+   * a custom tag.
    *
    * @param tag The tag to log the message under.
    * @param message The message to log.
    */
   public static void error(String tag, Object message) {
-    error(tag, message, null);
+    log.error(tag, message);
   }
 
   /**
-   * Logs an error message, with red highlighting (and the file location underlined), with a custom tag.
-   * This is for events that are typically not recoverable.
+   * Logs an error message with red highlighting (and the file location underlined) under
+   * a custom tag, including the throwable's string representation.
    *
    * @param tag The tag to log the message under.
    * @param message The message to log.
@@ -1002,6 +1101,54 @@ public final class Flixel {
    */
   public static void error(String tag, Object message, Throwable throwable) {
     log.error(tag, message, throwable);
+  }
+
+  /**
+   * Logs an error message using the default tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void error(Object message, Object... args) {
+    log.error(message, args);
+  }
+
+  /**
+   * Logs an error message using the default tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order, including the throwable's string representation.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param throwable The throwable to log.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void error(Object message, Throwable throwable, Object... args) {
+    log.error(message, throwable, args);
+  }
+
+  /**
+   * Logs an error message under a custom tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order.
+   *
+   * @param tag The tag to log the message under.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void error(String tag, Object message, Object... args) {
+    log.error(tag, message, args);
+  }
+
+  /**
+   * Logs an error message under a custom tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order, including the throwable's string representation.
+   *
+   * @param tag The tag to log the message under.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param throwable The throwable to log.
+   * @param args The arguments to substitute into the message.
+   */
+  public static void error(String tag, Object message, Throwable throwable, Object... args) {
+    log.error(tag, message, throwable, args);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -955,8 +955,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void debugf(Object message, Object... args) {
-    log.debugf(message, args);
+  public static void debug(Object message, Object... args) {
+    log.debug(message, args);
   }
 
   /**
@@ -967,8 +967,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void debugf(String tag, Object message, Object... args) {
-    log.debugf(tag, message, args);
+  public static void debug(String tag, Object message, Object... args) {
+    log.debug(tag, message, args);
   }
 
   /**
@@ -999,8 +999,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void infof(Object message, Object... args) {
-    log.infof(message, args);
+  public static void info(Object message, Object... args) {
+    log.info(message, args);
   }
 
   /**
@@ -1011,8 +1011,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void infof(String tag, Object message, Object... args) {
-    log.infof(tag, message, args);
+  public static void info(String tag, Object message, Object... args) {
+    log.info(tag, message, args);
   }
 
   /**
@@ -1043,8 +1043,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void warnf(Object message, Object... args) {
-    log.warnf(message, args);
+  public static void warn(Object message, Object... args) {
+    log.warn(message, args);
   }
 
   /**
@@ -1055,8 +1055,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void warnf(String tag, Object message, Object... args) {
-    log.warnf(tag, message, args);
+  public static void warn(String tag, Object message, Object... args) {
+    log.warn(tag, message, args);
   }
 
   /**
@@ -1110,8 +1110,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void errorf(Object message, Object... args) {
-    log.errorf(message, args);
+  public static void error(Object message, Object... args) {
+    log.error(message, args);
   }
 
   /**
@@ -1122,8 +1122,8 @@ public final class Flixel {
    * @param throwable The throwable to log.
    * @param args The arguments to substitute into the message.
    */
-  public static void errorf(Object message, Throwable throwable, Object... args) {
-    log.errorf(message, throwable, args);
+  public static void error(Object message, Throwable throwable, Object... args) {
+    log.error(message, throwable, args);
   }
 
   /**
@@ -1134,8 +1134,8 @@ public final class Flixel {
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public static void errorf(String tag, Object message, Object... args) {
-    log.errorf(tag, message, args);
+  public static void error(String tag, Object message, Object... args) {
+    log.error(tag, message, args);
   }
 
   /**
@@ -1147,8 +1147,8 @@ public final class Flixel {
    * @param throwable The throwable to log.
    * @param args The arguments to substitute into the message.
    */
-  public static void errorf(String tag, Object message, Throwable throwable, Object... args) {
-    log.errorf(tag, message, throwable, args);
+  public static void error(String tag, Object message, Throwable throwable, Object... args) {
+    log.error(tag, message, throwable, args);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
@@ -248,13 +248,13 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a debug message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.debugf("there are {} enemies and {} coins", enemyCount, coinCount)}.
+   * <p>For example: {@code Flixel.log.debug("there are {} enemies and {} coins", enemyCount, coinCount)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void debugf(Object message, Object... args) {
+  public void debug(Object message, Object... args) {
     outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.DEBUG, false, null, 0, null, null);
   }
 
@@ -262,14 +262,14 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a debug message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.debugf("Enemy", "there are {} enemies left", enemyCount)}.
+   * <p>For example: {@code Flixel.log.debug("Enemy", "there are {} enemies left", enemyCount)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void debugf(String tag, Object message, Object... args) {
+  public void debug(String tag, Object message, Object... args) {
     outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.DEBUG, false, null, 0, null, null);
   }
 
@@ -350,13 +350,13 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs an informational message using the default tag, replacing each {@code {}} placeholder
    * with the corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.infof("loaded {} assets in {}ms", count, elapsed)}.
+   * <p>For example: {@code Flixel.log.info("loaded {} assets in {}ms", count, elapsed)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void infof(Object message, Object... args) {
+  public void info(Object message, Object... args) {
     outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.INFO, false, null, 0, null, null);
   }
 
@@ -364,14 +364,14 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs an informational message under a custom tag, replacing each {@code {}} placeholder with
    * the corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.infof("Assets", "loaded {} assets in {}ms", count, elapsed)}.
+   * <p>For example: {@code Flixel.log.info("Assets", "loaded {} assets in {}ms", count, elapsed)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void infof(String tag, Object message, Object... args) {
+  public void info(String tag, Object message, Object... args) {
     outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.INFO, false, null, 0, null, null);
   }
 
@@ -452,13 +452,13 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a warning message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.warnf("pool exhausted, {} objects dropped", dropped)}.
+   * <p>For example: {@code Flixel.log.warn("pool exhausted, {} objects dropped", dropped)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void warnf(Object message, Object... args) {
+  public void warn(Object message, Object... args) {
     outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.WARN, false, null, 0, null, null);
   }
 
@@ -466,14 +466,14 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a warning message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.warnf("Pool", "pool exhausted, {} objects dropped", dropped)}.
+   * <p>For example: {@code Flixel.log.warn("Pool", "pool exhausted, {} objects dropped", dropped)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void warnf(String tag, Object message, Object... args) {
+  public void warn(String tag, Object message, Object... args) {
     outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.WARN, false, null, 0, null, null);
   }
 
@@ -579,51 +579,51 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, with no throwable.
    *
-   * <p>For example: {@code Flixel.log.errorf("failed to load {} of {} assets", failed, total)}.
+   * <p>For example: {@code Flixel.log.error("failed to load {} of {} assets", failed, total)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void errorf(Object message, Object... args) {
-    errorf(defaultTag, message, (Throwable) null, args);
+  public void error(Object message, Object... args) {
+    error(defaultTag, message, (Throwable) null, args);
   }
 
   /**
    * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, including the throwable's string representation.
    *
-   * <p>For example: {@code Flixel.log.errorf("failed to load {} assets", e, count)}.
+   * <p>For example: {@code Flixel.log.error("failed to load {} assets", e, count)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param throwable The exception to append to the log output.
    * @param args The arguments to substitute into the message.
    */
-  public void errorf(Object message, Throwable throwable, Object... args) {
-    errorf(defaultTag, message, throwable, args);
+  public void error(Object message, Throwable throwable, Object... args) {
+    error(defaultTag, message, throwable, args);
   }
 
   /**
    * Logs an error message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, with no throwable.
    *
-   * <p>For example: {@code Flixel.log.errorf("Assets", "failed to load {} of {} assets", failed, total)}.
+   * <p>For example: {@code Flixel.log.error("Assets", "failed to load {} of {} assets", failed, total)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void errorf(String tag, Object message, Object... args) {
-    errorf(tag, message, (Throwable) null, args);
+  public void error(String tag, Object message, Object... args) {
+    error(tag, message, (Throwable) null, args);
   }
 
   /**
    * Logs an error message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, including the throwable's string representation.
    *
-   * <p>For example: {@code Flixel.log.errorf("Assets", "failed to load {} assets", e, count)}.
+   * <p>For example: {@code Flixel.log.error("Assets", "failed to load {} assets", e, count)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
@@ -631,7 +631,7 @@ public class FlixelLogger implements ApplicationLogger {
    * @param throwable The exception to append to the log output, or {@code null} if none.
    * @param args The arguments to substitute into the message.
    */
-  public void errorf(String tag, Object message, Throwable throwable, Object... args) {
+  public void error(String tag, Object message, Throwable throwable, Object... args) {
     String msg = evaluateMessage(message, args);
     if (throwable != null) {
       msg = msg + " | Exception: " + throwable;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
@@ -78,6 +78,9 @@ public class FlixelLogger implements ApplicationLogger {
   /** Reused for plain file lines. */
   private final FlixelString fileLine = new FlixelString(512);
 
+  /** Reused for building formatted messages when {@code {}} args are supplied. */
+  private final FlixelString formattedMessage = new FlixelString(512);
+
   /**
    * Whether to write logs to a file when {@link #startFileLogging()} is called.
    *
@@ -242,6 +245,35 @@ public class FlixelLogger implements ApplicationLogger {
   }
 
   /**
+   * Logs a debug message using the default tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order.
+   *
+   * <p>For example: {@code Flixel.log.debug("there are {} enemies and {} coins", enemyCount, coinCount)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void debug(Object message, Object... args) {
+    outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.DEBUG, false, null, 0, null, null);
+  }
+
+  /**
+   * Logs a debug message under a custom tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order.
+   *
+   * <p>For example: {@code Flixel.log.debug("Enemy", "there are {} enemies left", enemyCount)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param tag The tag to associate with this log entry.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void debug(String tag, Object message, Object... args) {
+    outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.DEBUG, false, null, 0, null, null);
+  }
+
+  /**
    * Logs a debug message using the default tag with an explicit call site.
    *
    * <p>Typically invoked by the {@code flixelgdx-logging-plugin} bytecode weaver so file and line do not rely on
@@ -312,6 +344,35 @@ public class FlixelLogger implements ApplicationLogger {
    */
   public void info(String tag, Object message) {
     outputLog(tag, evaluateMessage(message), FlixelLogLevel.INFO, false, null, 0, null, null);
+  }
+
+  /**
+   * Logs an informational message using the default tag, replacing each {@code {}} placeholder
+   * with the corresponding argument in order.
+   *
+   * <p>For example: {@code Flixel.log.info("loaded {} assets in {}ms", count, elapsed)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void info(Object message, Object... args) {
+    outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.INFO, false, null, 0, null, null);
+  }
+
+  /**
+   * Logs an informational message under a custom tag, replacing each {@code {}} placeholder with
+   * the corresponding argument in order.
+   *
+   * <p>For example: {@code Flixel.log.info("Assets", "loaded {} assets in {}ms", count, elapsed)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param tag The tag to associate with this log entry.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void info(String tag, Object message, Object... args) {
+    outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.INFO, false, null, 0, null, null);
   }
 
   /**
@@ -388,6 +449,35 @@ public class FlixelLogger implements ApplicationLogger {
   }
 
   /**
+   * Logs a warning message using the default tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order.
+   *
+   * <p>For example: {@code Flixel.log.warn("pool exhausted, {} objects dropped", dropped)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void warn(Object message, Object... args) {
+    outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.WARN, false, null, 0, null, null);
+  }
+
+  /**
+   * Logs a warning message under a custom tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order.
+   *
+   * <p>For example: {@code Flixel.log.warn("Pool", "pool exhausted, {} objects dropped", dropped)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param tag The tag to associate with this log entry.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void warn(String tag, Object message, Object... args) {
+    outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.WARN, false, null, 0, null, null);
+  }
+
+  /**
    * Logs a warning message using the default tag with an explicit call site.
    *
    * <p>Typically invoked by the {@code flixelgdx-logging-plugin} bytecode weaver so file and line do not rely on
@@ -447,7 +537,7 @@ public class FlixelLogger implements ApplicationLogger {
    * @param message The message to log (converted via {@code toString()}).
    */
   public void error(Object message) {
-    error(defaultTag, message, null);
+    error(defaultTag, message, (Throwable) null);
   }
 
   /**
@@ -468,7 +558,7 @@ public class FlixelLogger implements ApplicationLogger {
    * @param message The message to log (converted via {@code toString()}).
    */
   public void error(String tag, Object message) {
-    error(tag, message, null);
+    error(tag, message, (Throwable) null);
   }
 
   /**
@@ -482,6 +572,70 @@ public class FlixelLogger implements ApplicationLogger {
   public void error(String tag, Object message, Throwable throwable) {
     String msg =
         (throwable != null) ? (evaluateMessage(message) + " | Exception: " + throwable) : evaluateMessage(message);
+    outputLog(tag, msg, FlixelLogLevel.ERROR, false, null, 0, null, null);
+  }
+
+  /**
+   * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order, with no throwable.
+   *
+   * <p>For example: {@code Flixel.log.error("failed to load {} of {} assets", failed, total)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void error(Object message, Object... args) {
+    error(defaultTag, message, (Throwable) null, args);
+  }
+
+  /**
+   * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order, including the throwable's string representation.
+   *
+   * <p>For example: {@code Flixel.log.error("failed to load {} assets", e, count)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param throwable The exception to append to the log output.
+   * @param args The arguments to substitute into the message.
+   */
+  public void error(Object message, Throwable throwable, Object... args) {
+    error(defaultTag, message, throwable, args);
+  }
+
+  /**
+   * Logs an error message under a custom tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order, with no throwable.
+   *
+   * <p>For example: {@code Flixel.log.error("Assets", "failed to load {} of {} assets", failed, total)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param tag The tag to associate with this log entry.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param args The arguments to substitute into the message.
+   */
+  public void error(String tag, Object message, Object... args) {
+    error(tag, message, (Throwable) null, args);
+  }
+
+  /**
+   * Logs an error message under a custom tag, replacing each {@code {}} placeholder with the
+   * corresponding argument in order, including the throwable's string representation.
+   *
+   * <p>For example: {@code Flixel.log.error("Assets", "failed to load {} assets", e, count)}.
+   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
+   *
+   * @param tag The tag to associate with this log entry.
+   * @param message The format string, where each {@code {}} is replaced by the next argument.
+   * @param throwable The exception to append to the log output, or {@code null} if none.
+   * @param args The arguments to substitute into the message.
+   */
+  public void error(String tag, Object message, Throwable throwable, Object... args) {
+    String msg = evaluateMessage(message, args);
+    if (throwable != null) {
+      msg = msg + " | Exception: " + throwable;
+    }
     outputLog(tag, msg, FlixelLogLevel.ERROR, false, null, 0, null, null);
   }
 
@@ -677,10 +831,10 @@ public class FlixelLogger implements ApplicationLogger {
 
     // Apply the color and underlining based on the level.
     String color = switch (level) {
-      case DEBUG -> FlixelAsciiCodes.BLUE;
       case INFO -> FlixelAsciiCodes.WHITE;
       case WARN -> FlixelAsciiCodes.YELLOW;
       case ERROR -> FlixelAsciiCodes.RED;
+      case DEBUG -> FlixelAsciiCodes.BLUE;
     };
     boolean underlineFile = (level == FlixelLogLevel.ERROR);
 
@@ -783,6 +937,35 @@ public class FlixelLogger implements ApplicationLogger {
     return message != null ? message.toString() : "null";
   }
 
+  /**
+   * Evaluates a format message by replacing each {@code {}} placeholder with the next argument.
+   * Placeholders with no corresponding argument are left as {@code {}}.
+   */
+  private String evaluateMessage(Object message, Object... args) {
+    String raw = evaluateMessage(message);
+    if (args == null || args.length == 0) {
+      return raw;
+    }
+    formattedMessage.clear();
+    int argIndex = 0;
+    int len = raw.length();
+    for (int i = 0; i < len; i++) {
+      char c = raw.charAt(i);
+      if (c == '{' && i + 1 < len && raw.charAt(i + 1) == '}') {
+        if (argIndex < args.length) {
+          Object arg = args[argIndex++];
+          formattedMessage.concat(arg != null ? arg.toString() : "null");
+        } else {
+          formattedMessage.concat("{}");
+        }
+        i++;
+      } else {
+        formattedMessage.concat(c);
+      }
+    }
+    return formattedMessage.copyContentToNewString();
+  }
+
   public String getDefaultTag() {
     return defaultTag;
   }
@@ -803,7 +986,7 @@ public class FlixelLogger implements ApplicationLogger {
 
   @Override
   public void error(String tag, String message) {
-    error(tag, message, null);
+    error(tag, message, (Throwable) null);
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
@@ -245,20 +245,6 @@ public class FlixelLogger implements ApplicationLogger {
   }
 
   /**
-   * Logs a debug message using the default tag, replacing each {@code {}} placeholder with the
-   * corresponding argument in order.
-   *
-   * <p>For example: {@code Flixel.log.debug("there are {} enemies and {} coins", enemyCount, coinCount)}.
-   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
-   *
-   * @param message The format string, where each {@code {}} is replaced by the next argument.
-   * @param args The arguments to substitute into the message.
-   */
-  public void debug(Object message, Object... args) {
-    outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.DEBUG, false, null, 0, null, null);
-  }
-
-  /**
    * Logs a debug message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
@@ -344,20 +330,6 @@ public class FlixelLogger implements ApplicationLogger {
    */
   public void info(String tag, Object message) {
     outputLog(tag, evaluateMessage(message), FlixelLogLevel.INFO, false, null, 0, null, null);
-  }
-
-  /**
-   * Logs an informational message using the default tag, replacing each {@code {}} placeholder
-   * with the corresponding argument in order.
-   *
-   * <p>For example: {@code Flixel.log.info("loaded {} assets in {}ms", count, elapsed)}.
-   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
-   *
-   * @param message The format string, where each {@code {}} is replaced by the next argument.
-   * @param args The arguments to substitute into the message.
-   */
-  public void info(Object message, Object... args) {
-    outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.INFO, false, null, 0, null, null);
   }
 
   /**
@@ -577,20 +549,6 @@ public class FlixelLogger implements ApplicationLogger {
 
   /**
    * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
-   * corresponding argument in order, with no throwable.
-   *
-   * <p>For example: {@code Flixel.log.error("failed to load {} of {} assets", failed, total)}.
-   * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
-   *
-   * @param message The format string, where each {@code {}} is replaced by the next argument.
-   * @param args The arguments to substitute into the message.
-   */
-  public void error(Object message, Object... args) {
-    error(defaultTag, message, (Throwable) null, args);
-  }
-
-  /**
-   * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, including the throwable's string representation.
    *
    * <p>For example: {@code Flixel.log.error("failed to load {} assets", e, count)}.
@@ -616,7 +574,7 @@ public class FlixelLogger implements ApplicationLogger {
    * @param args The arguments to substitute into the message.
    */
   public void error(String tag, Object message, Object... args) {
-    error(tag, message, (Throwable) null, args);
+    error(tag, message, null, args);
   }
 
   /**
@@ -841,8 +799,14 @@ public class FlixelLogger implements ApplicationLogger {
     String ts = LocalDateTime.now().format(LOG_TIMESTAMP);
 
     FlixelLogConsoleSink consoleSink = Flixel.logConsoleSink;
+    String safeTag = tag != null ? tag : defaultTag;
+
+    String levelPart = "[" + level + "]";
+    String tagPart = "[" + safeTag + "]";
+    String filePart = "[" + file + "]";
+    String methodPart = "[" + method + "]";
+
     if (consoleSink != null) {
-      String safeTag = tag != null ? tag : defaultTag;
       consoleSink.emit(level, safeTag, rawMessage, simpleFile + ":", file, method, ts,
           logMode == FlixelLogMode.DETAILED);
     } else {
@@ -853,12 +817,8 @@ public class FlixelLogger implements ApplicationLogger {
         consoleLine.concat(' ');
         appendColored(consoleLine, rawMessage, color, false, true, false);
       } else {
-        String levelTag = "[" + level + "]";
-        String tagPart = "[" + tag + "]";
-        String filePart = "[" + file + "]";
-        String methodPart = "[" + method + "]";
         appendColored(consoleLine, ts + " ", color, false, false, underlineFile);
-        appendColored(consoleLine, levelTag + " ", color, true, false, underlineFile);
+        appendColored(consoleLine, levelPart + " ", color, true, false, underlineFile);
         appendColored(consoleLine, tagPart + " ", color, true, false, underlineFile);
         appendColored(consoleLine, filePart + " ", color, true, false, underlineFile);
         appendColored(consoleLine, methodPart, color, false, false, underlineFile);
@@ -869,7 +829,7 @@ public class FlixelLogger implements ApplicationLogger {
 
     // Notify in-game log listeners (e.g. the debug overlay console).
     if (!logListeners.isEmpty()) {
-      FlixelLogEntry entry = new FlixelLogEntry(level, tag, rawMessage);
+      FlixelLogEntry entry = new FlixelLogEntry(level, safeTag, rawMessage);
       for (Consumer<FlixelLogEntry> listener : logListeners) {
         listener.accept(entry);
       }
@@ -878,14 +838,10 @@ public class FlixelLogger implements ApplicationLogger {
     // File: always detailed (plain, no ANSI).
     FlixelLogFileHandler fileHandler = Flixel.logFileHandler;
     if (fileHandler != null && fileHandler.isActive()) {
-      String levelTag = "[" + level + "]";
-      String tagPart = "[" + tag + "]";
-      String filePart = "[" + file + "]";
-      String methodPart = "[" + method + "]";
       fileLine.clear();
       fileLine.concat(ts);
       fileLine.concat(' ');
-      fileLine.concat(levelTag);
+      fileLine.concat(levelPart);
       fileLine.concat(' ');
       fileLine.concat(tagPart);
       fileLine.concat(' ');

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
@@ -248,13 +248,13 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a debug message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.debug("there are {} enemies and {} coins", enemyCount, coinCount)}.
+   * <p>For example: {@code Flixel.log.debugf("there are {} enemies and {} coins", enemyCount, coinCount)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void debug(Object message, Object... args) {
+  public void debugf(Object message, Object... args) {
     outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.DEBUG, false, null, 0, null, null);
   }
 
@@ -262,14 +262,14 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a debug message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.debug("Enemy", "there are {} enemies left", enemyCount)}.
+   * <p>For example: {@code Flixel.log.debugf("Enemy", "there are {} enemies left", enemyCount)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void debug(String tag, Object message, Object... args) {
+  public void debugf(String tag, Object message, Object... args) {
     outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.DEBUG, false, null, 0, null, null);
   }
 
@@ -350,13 +350,13 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs an informational message using the default tag, replacing each {@code {}} placeholder
    * with the corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.info("loaded {} assets in {}ms", count, elapsed)}.
+   * <p>For example: {@code Flixel.log.infof("loaded {} assets in {}ms", count, elapsed)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void info(Object message, Object... args) {
+  public void infof(Object message, Object... args) {
     outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.INFO, false, null, 0, null, null);
   }
 
@@ -364,14 +364,14 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs an informational message under a custom tag, replacing each {@code {}} placeholder with
    * the corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.info("Assets", "loaded {} assets in {}ms", count, elapsed)}.
+   * <p>For example: {@code Flixel.log.infof("Assets", "loaded {} assets in {}ms", count, elapsed)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void info(String tag, Object message, Object... args) {
+  public void infof(String tag, Object message, Object... args) {
     outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.INFO, false, null, 0, null, null);
   }
 
@@ -452,13 +452,13 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a warning message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.warn("pool exhausted, {} objects dropped", dropped)}.
+   * <p>For example: {@code Flixel.log.warnf("pool exhausted, {} objects dropped", dropped)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void warn(Object message, Object... args) {
+  public void warnf(Object message, Object... args) {
     outputLog(defaultTag, evaluateMessage(message, args), FlixelLogLevel.WARN, false, null, 0, null, null);
   }
 
@@ -466,14 +466,14 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs a warning message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order.
    *
-   * <p>For example: {@code Flixel.log.warn("Pool", "pool exhausted, {} objects dropped", dropped)}.
+   * <p>For example: {@code Flixel.log.warnf("Pool", "pool exhausted, {} objects dropped", dropped)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void warn(String tag, Object message, Object... args) {
+  public void warnf(String tag, Object message, Object... args) {
     outputLog(tag, evaluateMessage(message, args), FlixelLogLevel.WARN, false, null, 0, null, null);
   }
 
@@ -579,51 +579,51 @@ public class FlixelLogger implements ApplicationLogger {
    * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, with no throwable.
    *
-   * <p>For example: {@code Flixel.log.error("failed to load {} of {} assets", failed, total)}.
+   * <p>For example: {@code Flixel.log.errorf("failed to load {} of {} assets", failed, total)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void error(Object message, Object... args) {
-    error(defaultTag, message, (Throwable) null, args);
+  public void errorf(Object message, Object... args) {
+    errorf(defaultTag, message, (Throwable) null, args);
   }
 
   /**
    * Logs an error message using the default tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, including the throwable's string representation.
    *
-   * <p>For example: {@code Flixel.log.error("failed to load {} assets", e, count)}.
+   * <p>For example: {@code Flixel.log.errorf("failed to load {} assets", e, count)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param throwable The exception to append to the log output.
    * @param args The arguments to substitute into the message.
    */
-  public void error(Object message, Throwable throwable, Object... args) {
-    error(defaultTag, message, throwable, args);
+  public void errorf(Object message, Throwable throwable, Object... args) {
+    errorf(defaultTag, message, throwable, args);
   }
 
   /**
    * Logs an error message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, with no throwable.
    *
-   * <p>For example: {@code Flixel.log.error("Assets", "failed to load {} of {} assets", failed, total)}.
+   * <p>For example: {@code Flixel.log.errorf("Assets", "failed to load {} of {} assets", failed, total)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
    * @param message The format string, where each {@code {}} is replaced by the next argument.
    * @param args The arguments to substitute into the message.
    */
-  public void error(String tag, Object message, Object... args) {
-    error(tag, message, (Throwable) null, args);
+  public void errorf(String tag, Object message, Object... args) {
+    errorf(tag, message, (Throwable) null, args);
   }
 
   /**
    * Logs an error message under a custom tag, replacing each {@code {}} placeholder with the
    * corresponding argument in order, including the throwable's string representation.
    *
-   * <p>For example: {@code Flixel.log.error("Assets", "failed to load {} assets", e, count)}.
+   * <p>For example: {@code Flixel.log.errorf("Assets", "failed to load {} assets", e, count)}.
    * If there are fewer arguments than placeholders, the remaining {@code {}} tokens are left as-is.
    *
    * @param tag The tag to associate with this log entry.
@@ -631,7 +631,7 @@ public class FlixelLogger implements ApplicationLogger {
    * @param throwable The exception to append to the log output, or {@code null} if none.
    * @param args The arguments to substitute into the message.
    */
-  public void error(String tag, Object message, Throwable throwable, Object... args) {
+  public void errorf(String tag, Object message, Throwable throwable, Object... args) {
     String msg = evaluateMessage(message, args);
     if (throwable != null) {
       msg = msg + " | Exception: " + throwable;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/logging/FlixelLogger.java
@@ -842,7 +842,7 @@ public class FlixelLogger implements ApplicationLogger {
 
     FlixelLogConsoleSink consoleSink = Flixel.logConsoleSink;
     if (consoleSink != null) {
-      String safeTag = tag != null ? tag : "";
+      String safeTag = tag != null ? tag : defaultTag;
       consoleSink.emit(level, safeTag, rawMessage, simpleFile + ":", file, method, ts,
           logMode == FlixelLogMode.DETAILED);
     } else {


### PR DESCRIPTION
## Description

Adds Gradle/SLF4J-style `{}` placeholder support to `FlixelLogger`, so log calls can embed values without manual string concatenation:

```java
Flixel.log.info("EnemyTag", "there are {} enemies left", enemyCount);
Flixel.log.warn("Pool", "pool exhausted, {} objects dropped", dropped);
Flixel.log.error("Assets", "failed to load {} of {} assets", failed, total);
```

Each `{}` in the message is replaced in order by the corresponding argument. Surplus placeholders with no matching argument are left as-is. The replacement is done via the reused `formattedMessage` `FlixelString` field to avoid per-call heap allocations.

New overloads were added for all four levels (`debug`, `info`, `warn`, `error`), each in both the default-tag and custom-tag forms. The `error` level also gains throwable+args variants. Existing `null`-throwable delegates were tightened with an explicit `(Throwable) null` cast to resolve the ambiguity introduced by the new varargs overloads.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).

## Screenshots / Evidence (if applicable)

N/A - logger change with no visual output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)