### PR TITLE
Added global time scale to the update loop with a debug overlay Controls slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 ## Gradle:
 .gradle/
+**/.kotlin/
 gradle-app.setting
 **/build/
 **/nbbuild/

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -721,7 +721,7 @@ public final class Flixel {
    * <p>{@code 1f} is normal speed; values below {@code 1f} slow the game down, values above {@code 1f} speed it up.
    * The raw platform delta is clamped to [{@link #MIN_ELAPSED}, {@link #MAX_ELAPSED}] first, then multiplied by
    * this value before being stored in {@link #elapsed} and passed to {@code update()}. All systems that read
-   * {@link #getElapsed()} -- physics, animations, tweens, timers, and camera follow -- are affected uniformly.
+   * {@link #getElapsed()} (such as physics, animations, tweens, timers, and camera follow) are affected uniformly.
    *
    * <p>The debug overlay's Controls panel exposes a slider for this value at runtime (range 0.1x to 4.0x).
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -716,9 +716,14 @@ public final class Flixel {
   public static FlixelHaptics haptics = FlixelNoopHaptics.INSTANCE;
 
   /**
-   * Global timescale for frame-based timers ({@link org.flixelgdx.util.timer.FlixelTimer FlixelTimer}).
+   * Global time scale applied to the game's update loop each frame.
    *
-   * <p>{@code 1f} is normal speed; lower slows timers, higher speeds them up. Does not change {@link #elapsed} itself.
+   * <p>{@code 1f} is normal speed; values below {@code 1f} slow the game down, values above {@code 1f} speed it up.
+   * The raw platform delta is clamped to [{@link #MIN_ELAPSED}, {@link #MAX_ELAPSED}] first, then multiplied by
+   * this value before being stored in {@link #elapsed} and passed to {@code update()}. All systems that read
+   * {@link #getElapsed()} -- physics, animations, tweens, timers, and camera follow -- are affected uniformly.
+   *
+   * <p>The debug overlay's Controls panel exposes a slider for this value at runtime (range 0.1x to 4.0x).
    */
   public static float timeScale = 1f;
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -730,6 +730,9 @@ public final class Flixel {
   /** The capped elapsed time for the current frame. Set by {@link FlixelGame} after clamping the raw libGDX delta. */
   static float elapsed = 0f;
 
+  /** The raw clamped platform delta before {@link #timeScale} is applied. Set by {@link FlixelGame} each frame. */
+  static float rawElapsed = 0f;
+
   /** Has the global manager been initialized yet? */
   static boolean initialized = false;
 
@@ -1181,6 +1184,15 @@ public final class Flixel {
    */
   public static float getElapsed() {
     return elapsed;
+  }
+
+  /**
+   * Returns the raw platform delta (in seconds) for the current frame, clamped to
+   * [{@link #MIN_ELAPSED}, {@link #MAX_ELAPSED}] but not multiplied by {@link #timeScale}.
+   * Use this when you need actual wall-clock frame time regardless of the active time scale.
+   */
+  public static float getRawElapsed() {
+    return rawElapsed;
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -721,6 +721,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     float rawDelta = Gdx.graphics != null ? Gdx.graphics.getDeltaTime() : Flixel.MIN_ELAPSED;
     float rawClamped = Math.max(Flixel.MIN_ELAPSED, Math.min(rawDelta, Flixel.MAX_ELAPSED));
     float elapsed = rawClamped * Flixel.timeScale;
+    Flixel.rawElapsed = rawClamped;
     Flixel.elapsed = elapsed;
 
     windowSize.x = Gdx.graphics.getWidth();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -505,7 +505,7 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
 
     if (!gamePaused && !stateLifecyclePauseDispatched) {
       FlixelTween.updateTweens(elapsed);
-      FlixelTimer.getGlobalManager().update(elapsed * Flixel.timeScale);
+      FlixelTimer.getGlobalManager().update(elapsed);
 
       // Walk the state/substate chain. Each state in the chain is updated only
       // if it is the active (innermost) state or if its persistentUpdate flag is true.
@@ -719,7 +719,8 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
   @Override
   public final void render() {
     float rawDelta = Gdx.graphics != null ? Gdx.graphics.getDeltaTime() : Flixel.MIN_ELAPSED;
-    float elapsed = Math.max(Flixel.MIN_ELAPSED, Math.min(rawDelta, Flixel.MAX_ELAPSED));
+    float rawClamped = Math.max(Flixel.MIN_ELAPSED, Math.min(rawDelta, Flixel.MAX_ELAPSED));
+    float elapsed = rawClamped * Flixel.timeScale;
     Flixel.elapsed = elapsed;
 
     windowSize.x = Gdx.graphics.getWidth();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/debug/FlixelDebugOverlay.java
@@ -351,11 +351,14 @@ public abstract class FlixelDebugOverlay implements FlixelUpdatable, FlixelDestr
    * Appends one sample to each performance ring buffer. The buffers are primitive {@code float[]}
    * arrays sized at {@link #PERF_HISTORY_SIZE}, so this method is allocation-free.
    *
-   * @param elapsed Real wall-clock seconds since the last frame (used for the frame-time series).
+   * <p>The frame-time series always reads {@link Flixel#getRawElapsed()} so it reflects actual
+   * wall-clock time regardless of the active {@link Flixel#timeScale}.
+   *
+   * @param elapsed Scaled elapsed time passed by the update loop (kept for subclass compatibility).
    */
   protected void pushPerfSample(float elapsed) {
     int idx = perfHead;
-    perfFrameMs[idx] = elapsed * 1000f;
+    perfFrameMs[idx] = Flixel.getRawElapsed() * 1000f;
     perfHeapMb[idx] = Gdx.app.getJavaHeap() / (1024f * 1024f);
     perfNativeMb[idx] = Gdx.app.getNativeHeap() / (1024f * 1024f);
     perfFps[idx] = Gdx.graphics.getFramesPerSecond();

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -127,6 +127,8 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   private static final float[] COLOR_RESIZE_GRIP = { 0.65f, 0.10f, 0.10f, 0.20f };
   private static final float[] COLOR_RESIZE_GRIP_HOVERED = { 0.80f, 0.15f, 0.15f, 0.67f };
   private static final float[] COLOR_RESIZE_GRIP_ACTIVE = { 0.92f, 0.20f, 0.20f, 0.95f };
+  private static final float[] COLOR_SLIDER_GRAB = { 0.92f, 0.20f, 0.20f, 0.95f };
+  private static final float[] COLOR_SLIDER_GRAB_ACTIVE = { 0.92f, 0.30f, 0.30f, 0.95f };
 
   /** Empty-state copy for the Watch panel (must match {@link #drawWatchWindow()}). */
   private static final String WATCH_EMPTY_HINT = "No watches registered. Use Flixel.watch.add(...) to track values.";
@@ -685,6 +687,10 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
         COLOR_RESIZE_GRIP_HOVERED[2], COLOR_RESIZE_GRIP_HOVERED[3]);
     style.setColor(ImGuiCol.ResizeGripActive, COLOR_RESIZE_GRIP_ACTIVE[0], COLOR_RESIZE_GRIP_ACTIVE[1],
         COLOR_RESIZE_GRIP_ACTIVE[2], COLOR_RESIZE_GRIP_ACTIVE[3]);
+    style.setColor(ImGuiCol.SliderGrab, COLOR_SLIDER_GRAB[0], COLOR_SLIDER_GRAB[1], COLOR_SLIDER_GRAB[2],
+        COLOR_SLIDER_GRAB[3]);
+    style.setColor(ImGuiCol.SliderGrabActive, COLOR_SLIDER_GRAB_ACTIVE[0], COLOR_SLIDER_GRAB_ACTIVE[1],
+        COLOR_SLIDER_GRAB_ACTIVE[2], COLOR_SLIDER_GRAB_ACTIVE[3]);
 
     ImFontAtlas fonts = io.getFonts();
     fonts.addFontDefault();
@@ -1107,12 +1113,12 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     }
 
     ImGui.separator();
+    text(COLOR_HEADER, "Time scale");
     timeScaleSliderBuf[0] = Flixel.timeScale;
     ImGui.pushItemWidth(-100f);
-    if (ImGui.sliderFloat("Time scale", timeScaleSliderBuf, 0.1f, 4.0f, "%.2fx")) {
+    if (ImGui.sliderFloat("##timescale", timeScaleSliderBuf, 0.1f, 4.0f, "%.2fx")) {
       Flixel.timeScale = timeScaleSliderBuf[0];
     }
-    ImGui.popItemWidth();
     ImGui.sameLine();
     if (ImGui.button("Reset##timescale")) {
       Flixel.timeScale = 1f;

--- a/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
+++ b/flixelgdx-lwjgl3/src/main/java/org/flixelgdx/backend/lwjgl3/debug/FlixelImGuiDebugOverlay.java
@@ -215,8 +215,9 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
   /** Last non-empty UTF-8 bytes from the command field (ImGui may clear the buffer when Run is pressed). */
   private final byte[] commandLineUtf8Scratch = new byte[512];
 
-  // Reused float buffer fed to ImGui.sliderFloat() so the zoom control stays allocation-free.
+  // Reused float buffers fed to ImGui.sliderFloat() so the controls stay allocation-free.
   private final float[] textureViewerZoomBuf = new float[1];
+  private final float[] timeScaleSliderBuf = new float[1];
 
   // Watch caches mirroring cachedWatchKeys / cachedWatchValues as java String.
   private String[] watchKeyStr = new String[0];
@@ -1103,6 +1104,18 @@ public class FlixelImGuiDebugOverlay extends FlixelDebugOverlay {
     boolean paused = Flixel.game.isGamePaused();
     if (ImGui.checkbox("Pause game loop", paused)) {
       Flixel.game.setGamePaused(!paused);
+    }
+
+    ImGui.separator();
+    timeScaleSliderBuf[0] = Flixel.timeScale;
+    ImGui.pushItemWidth(-100f);
+    if (ImGui.sliderFloat("Time scale", timeScaleSliderBuf, 0.1f, 4.0f, "%.2fx")) {
+      Flixel.timeScale = timeScaleSliderBuf[0];
+    }
+    ImGui.popItemWidth();
+    ImGui.sameLine();
+    if (ImGui.button("Reset##timescale")) {
+      Flixel.timeScale = 1f;
     }
 
     ImGui.separator();


### PR DESCRIPTION
## Description

`Flixel.timeScale` previously only scaled `FlixelTimer` elapsed time. This PR makes it a true global time scale: the clamped platform delta is now multiplied by `timeScale` in `FlixelGame.render()` before being stored in `Flixel.elapsed`, so every system that reads elapsed (physics, animations, tweens, timers, camera follow) is affected uniformly. The now-redundant `* Flixel.timeScale` in the `FlixelTimer` update call has been removed to prevent double-application.

The `FlixelImGuiDebugOverlay` Controls panel gains a time scale slider (0.1x to 4.0x) with an inline Reset button that snaps the value back to 1.0x without any per-frame allocation.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

> **Note:** Code that relied on `timeScale` only affecting `FlixelTimer` and not the broader update loop will now behave differently. The vast majority of games won't be affected since `timeScale` defaults to `1f`.

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).