### PR TITLE
Added variable decimal place support to FlixelString's rounded float formatting methods

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
@@ -274,7 +274,7 @@ public class FlixelString implements CharSequence {
    * @return {@code this} for chaining.
    */
   @NotNull
-  public FlixelString concat(@NotNull CharSequence other) {
+  public FlixelString concat(@Nullable CharSequence other) {
     buffer.append(other != null ? other : "null");
     return this;
   }
@@ -464,7 +464,7 @@ public class FlixelString implements CharSequence {
    * no decimal point is written. Fractional digits are zero-padded on the left so the output
    * always contains exactly {@code decimals} digits after the decimal point.
    *
-   * @param value    Value to format; non-finite values fall back to {@link CharArray#append(float)}.
+   * @param value Value to format; non-finite values fall back to {@link CharArray#append(float)}.
    * @param decimals Number of digits after the decimal point; values of zero or less produce an
    *                 integer with no decimal point.
    * @return {@code this} for chaining.
@@ -480,7 +480,7 @@ public class FlixelString implements CharSequence {
    * Clears the buffer and writes {@code value} rounded to one decimal place (tenths). Convenience
    * wrapper for {@link #setFloatRounded(float, int)} with {@code decimals = 1}.
    *
-   * @param value Value to format; non-finite values fall back to {@link CharArray#append(float)}.
+   * @param value Value to format. Non-finite values fall back to {@link CharArray#append(float)}.
    * @return {@code this} for chaining.
    */
   @NotNull
@@ -520,7 +520,7 @@ public class FlixelString implements CharSequence {
    * {@inheritDoc}
    *
    * <p><strong>Allocation warning:</strong> Builds a new {@link String}. Do not use on hot paths; pass this
-   * instance as a {@link CharSequence} instead.
+   * instance as a {@link CharSequence} instead where possible.
    */
   @Override
   @NotNull

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelString.java
@@ -50,10 +50,12 @@ import java.util.function.Supplier;
  *
  * <h2>Allocation-free float formatting</h2>
  *
- * <p>{@link #setFloatRoundedOneDecimal(float)} and {@link #concatFloatRoundedOneDecimal(float)}
- * delegate to {@link FlixelStringUtil#appendFloatRoundedOneDecimal(CharArray, float)}, which
- * formats a float to one decimal place using only integer arithmetic, meaning no {@link String} is
- * created at any point.
+ * <p>{@link #setFloatRounded(float, int)} and {@link #concatFloatRounded(float, int)} delegate to
+ * {@link FlixelStringUtil#appendFloatRounded(CharArray, float, int)}, which formats a float to any
+ * number of decimal places using only integer arithmetic, meaning no {@link String} is created at
+ * any point. {@link #setFloatRoundedOneDecimal(float)} and
+ * {@link #concatFloatRoundedOneDecimal(float)} are convenience variants for exactly one decimal
+ * place.
  *
  * <h2>Passing to libGDX drawing APIs</h2>
  *
@@ -386,16 +388,35 @@ public class FlixelString implements CharSequence {
   }
 
   /**
-   * Appends {@code value} rounded to one decimal place (tenths) using the same rules as
-   * {@link FlixelStringUtil#appendFloatRoundedOneDecimal(CharArray, float)}. Does not clear the buffer first.
+   * Appends {@code value} rounded to {@code decimals} decimal places using the same rules as
+   * {@link FlixelStringUtil#appendFloatRounded(CharArray, float, int)}. Does not clear the buffer
+   * first.
+   *
+   * <p>When {@code decimals} is zero or negative, the value is rounded to the nearest integer and
+   * no decimal point is written. Fractional digits are zero-padded on the left so the output
+   * always contains exactly {@code decimals} digits after the decimal point.
+   *
+   * @param value    Value to append (non-finite values use {@link CharArray#append(float)}).
+   * @param decimals Number of digits after the decimal point; values of zero or less produce an
+   *                 integer with no decimal point.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  public FlixelString concatFloatRounded(float value, int decimals) {
+    FlixelStringUtil.appendFloatRounded(buffer, value, decimals);
+    return this;
+  }
+
+  /**
+   * Appends {@code value} rounded to one decimal place (tenths). Convenience wrapper for
+   * {@link #concatFloatRounded(float, int)} with {@code decimals = 1}.
    *
    * @param value Value to append (non-finite values use {@link CharArray#append(float)}).
    * @return {@code this} for chaining.
    */
   @NotNull
   public FlixelString concatFloatRoundedOneDecimal(float value) {
-    FlixelStringUtil.appendFloatRoundedOneDecimal(buffer, value);
-    return this;
+    return concatFloatRounded(value, 1);
   }
 
   /**
@@ -435,19 +456,36 @@ public class FlixelString implements CharSequence {
   }
 
   /**
-   * Appends {@code value} rounded to one decimal place (tenths), using only {@link CharArray} integer appenders.
-   * This avoids {@link Float#toString(float)} and similar helpers that allocate {@link String} instances.
+   * Clears the buffer and writes {@code value} rounded to {@code decimals} decimal places using
+   * only {@link CharArray} primitive appenders, avoiding {@link Float#toString(float)} and similar
+   * helpers that allocate {@link String} instances.
    *
-   * <p>The buffer is cleared before formatting.
+   * <p>When {@code decimals} is zero or negative, the value is rounded to the nearest integer and
+   * no decimal point is written. Fractional digits are zero-padded on the left so the output
+   * always contains exactly {@code decimals} digits after the decimal point.
    *
-   * @param value Finite input; non-finite values fall back to {@link CharArray#append(float)}.
+   * @param value    Value to format; non-finite values fall back to {@link CharArray#append(float)}.
+   * @param decimals Number of digits after the decimal point; values of zero or less produce an
+   *                 integer with no decimal point.
+   * @return {@code this} for chaining.
+   */
+  @NotNull
+  public FlixelString setFloatRounded(float value, int decimals) {
+    buffer.clear();
+    FlixelStringUtil.appendFloatRounded(buffer, value, decimals);
+    return this;
+  }
+
+  /**
+   * Clears the buffer and writes {@code value} rounded to one decimal place (tenths). Convenience
+   * wrapper for {@link #setFloatRounded(float, int)} with {@code decimals = 1}.
+   *
+   * @param value Value to format; non-finite values fall back to {@link CharArray#append(float)}.
    * @return {@code this} for chaining.
    */
   @NotNull
   public FlixelString setFloatRoundedOneDecimal(float value) {
-    buffer.clear();
-    FlixelStringUtil.appendFloatRoundedOneDecimal(buffer, value);
-    return this;
+    return setFloatRounded(value, 1);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.util;
 
 import com.badlogic.gdx.utils.CharArray;
+
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
@@ -84,6 +84,9 @@ public final class FlixelStringUtil {
    *     integer with no decimal point.
    */
   public static void appendFloatRounded(@NotNull CharArray out, float value, int decimals) {
+    if (out == null) {
+      return;
+    }
     if (Float.isNaN(value) || Float.isInfinite(value)) {
       out.append(value);
       return;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
@@ -24,9 +24,10 @@
 package org.flixelgdx.util;
 
 import com.badlogic.gdx.utils.CharArray;
+import org.jetbrains.annotations.NotNull;
 
 /**
- * Handy utility class for handling strings more efficiently.
+ * Handy utility class for manipulating strings more efficiently.
  */
 public final class FlixelStringUtil {
 
@@ -74,18 +75,14 @@ public final class FlixelStringUtil {
    * <p>Because this method uses {@code long} arithmetic internally, meaningful precision is still
    * limited to roughly seven significant digits (the range of a {@code float}).
    *
-   * @param out      Destination buffer; for {@link FlixelString} callers prefer
-   *                 {@link FlixelString#concatFloatRounded(float, int)} or
-   *                 {@link FlixelString#setFloatRounded(float, int)} instead of reaching for a raw
-   *                 {@link CharArray}.
-   * @param value    Value to format.
+   * @param out Destination buffer. For {@link FlixelString} callers, prefer
+   *     {@link FlixelString#concatFloatRounded(float, int)} or {@link FlixelString#setFloatRounded(float, int)}
+   *     instead of reaching for a raw {@link CharArray}.
+   * @param value Value to format.
    * @param decimals Number of digits after the decimal point; values of zero or less produce an
-   *                 integer with no decimal point.
+   *     integer with no decimal point.
    */
-  public static void appendFloatRounded(CharArray out, float value, int decimals) {
-    if (out == null) {
-      return;
-    }
+  public static void appendFloatRounded(@NotNull CharArray out, float value, int decimals) {
     if (Float.isNaN(value) || Float.isInfinite(value)) {
       out.append(value);
       return;
@@ -123,13 +120,12 @@ public final class FlixelStringUtil {
    *
    * <p>Non-finite values fall back to {@link CharArray#append(float)}.
    *
-   * @param out   Destination buffer; for {@link FlixelString} callers prefer
-   *              {@link FlixelString#concatFloatRoundedOneDecimal(float)} or
-   *              {@link FlixelString#setFloatRoundedOneDecimal(float)} instead of reaching for a raw
-   *              {@link CharArray}.
+   * @param out Destination buffer. For {@link FlixelString}, callers prefer
+   *     {@link FlixelString#concatFloatRoundedOneDecimal(float)} or
+   *     {@link FlixelString#setFloatRoundedOneDecimal(float)} instead of reaching for a raw {@link CharArray}.
    * @param value Value to format.
    */
-  public static void appendFloatRoundedOneDecimal(CharArray out, float value) {
+  public static void appendFloatRoundedOneDecimal(@NotNull CharArray out, float value) {
     appendFloatRounded(out, value, 1);
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelStringUtil.java
@@ -59,16 +59,30 @@ public final class FlixelStringUtil {
   }
 
   /**
-   * Appends {@code value} rounded to one decimal place (nearest tenth) using only {@link CharArray} primitive
+   * Appends {@code value} rounded to {@code decimals} decimal places using only {@link CharArray} primitive
    * appenders, avoiding {@link Float#toString(float)} and other helpers that allocate {@link String} objects.
    *
-   * <p>Non-finite values are appended via {@link CharArray#append(float)} as a fallback.
+   * <p>Non-finite values fall back to {@link CharArray#append(float)}.
    *
-   * @param out Destination buffer; for {@link FlixelString} callers prefer {@link FlixelString#concatFloatRoundedOneDecimal(float)}
-   *   or {@link FlixelString#setFloatRoundedOneDecimal(float)} instead of reaching for a raw {@link CharArray}.
-   * @param value Value to format.
+   * <p>When {@code decimals} is zero or negative, the value is rounded to the nearest integer and no
+   * decimal point is written.
+   *
+   * <p>Fractional digits are zero-padded on the left so the output always has exactly {@code decimals}
+   * digits after the decimal point (for example, {@code 3.05f} with {@code decimals = 2} produces
+   * {@code "3.05"}, not {@code "3.5"}).
+   *
+   * <p>Because this method uses {@code long} arithmetic internally, meaningful precision is still
+   * limited to roughly seven significant digits (the range of a {@code float}).
+   *
+   * @param out      Destination buffer; for {@link FlixelString} callers prefer
+   *                 {@link FlixelString#concatFloatRounded(float, int)} or
+   *                 {@link FlixelString#setFloatRounded(float, int)} instead of reaching for a raw
+   *                 {@link CharArray}.
+   * @param value    Value to format.
+   * @param decimals Number of digits after the decimal point; values of zero or less produce an
+   *                 integer with no decimal point.
    */
-  public static void appendFloatRoundedOneDecimal(CharArray out, float value) {
+  public static void appendFloatRounded(CharArray out, float value, int decimals) {
     if (out == null) {
       return;
     }
@@ -76,16 +90,47 @@ public final class FlixelStringUtil {
       out.append(value);
       return;
     }
-    int tenths = Math.round(value * 10f);
-    if (tenths < 0) {
-      out.append('-');
-      tenths = -tenths;
+    if (decimals <= 0) {
+      out.append(Math.round((double) value));
+      return;
     }
-    int whole = tenths / 10;
-    int frac = tenths % 10;
+    long scale = 1;
+    for (int i = 0; i < decimals; i++) {
+      scale *= 10;
+    }
+    long units = Math.round((double) value * scale);
+    if (units < 0) {
+      out.append('-');
+      units = -units;
+    }
+    long whole = units / scale;
+    long frac = units % scale;
     out.append(whole);
     out.append('.');
-    out.append((char) ('0' + frac));
+    long fracScale = scale / 10;
+    while (fracScale > frac && fracScale >= 1) {
+      out.append('0');
+      fracScale /= 10;
+    }
+    if (frac > 0) {
+      out.append(frac);
+    }
+  }
+
+  /**
+   * Appends {@code value} rounded to one decimal place (nearest tenth). Convenience wrapper for
+   * {@link #appendFloatRounded(CharArray, float, int)} with {@code decimals = 1}.
+   *
+   * <p>Non-finite values fall back to {@link CharArray#append(float)}.
+   *
+   * @param out   Destination buffer; for {@link FlixelString} callers prefer
+   *              {@link FlixelString#concatFloatRoundedOneDecimal(float)} or
+   *              {@link FlixelString#setFloatRoundedOneDecimal(float)} instead of reaching for a raw
+   *              {@link CharArray}.
+   * @param value Value to format.
+   */
+  public static void appendFloatRoundedOneDecimal(CharArray out, float value) {
+    appendFloatRounded(out, value, 1);
   }
 
   private FlixelStringUtil() {}

--- a/flixelgdx-test/src/test/java/org/flixelgdx/util/FlixelStringTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/util/FlixelStringTest.java
@@ -184,6 +184,63 @@ class FlixelStringTest {
   }
 
   @Test
+  void setFloatRoundedTwoDecimalsRoundsUp() {
+    FlixelString fs = new FlixelString();
+    fs.setFloatRounded(3.456f, 2);
+    assertEquals("3.46", fs.toString());
+  }
+
+  @Test
+  void setFloatRoundedTwoDecimalsRoundsDown() {
+    FlixelString fs = new FlixelString();
+    fs.setFloatRounded(3.454f, 2);
+    assertEquals("3.45", fs.toString());
+  }
+
+  @Test
+  void setFloatRoundedTwoDecimalsLeadingZeroInFraction() {
+    // 3.05 rounded to 2 places must produce "3.05", not "3.5".
+    FlixelString fs = new FlixelString();
+    fs.setFloatRounded(3.05f, 2);
+    assertEquals("3.05", fs.toString());
+  }
+
+  @Test
+  void setFloatRoundedThreeDecimalsZeroValue() {
+    FlixelString fs = new FlixelString();
+    fs.setFloatRounded(0f, 3);
+    assertEquals("0.000", fs.toString());
+  }
+
+  @Test
+  void setFloatRoundedZeroDecimalsProducesInteger() {
+    FlixelString fs = new FlixelString();
+    fs.setFloatRounded(3.6f, 0);
+    assertEquals("4", fs.toString());
+  }
+
+  @Test
+  void setFloatRoundedNegativeValue() {
+    FlixelString fs = new FlixelString();
+    fs.setFloatRounded(-2.6f, 2);
+    assertEquals("-2.60", fs.toString());
+  }
+
+  @Test
+  void concatFloatRoundedTwoDecimalsAppends() {
+    FlixelString fs = new FlixelString("v:");
+    fs.concatFloatRounded(9.5f, 2);
+    assertEquals("v:9.50", fs.toString());
+  }
+
+  @Test
+  void concatFloatRoundedDoesNotClearBuffer() {
+    FlixelString fs = new FlixelString("hp:");
+    fs.concatFloatRounded(100.0f, 2);
+    assertEquals("hp:100.00", fs.toString());
+  }
+
+  @Test
   void setFloatRoundedOneDecimalFormatsToOnePlaceRoundingUp() {
     FlixelString fs = new FlixelString();
     fs.setFloatRoundedOneDecimal(3.45f);
@@ -206,7 +263,7 @@ class FlixelStringTest {
 
   @Test
   void setFloatRoundedOneDecimalNegativeValue() {
-    // -1.6 * 10 = -16.0, Math.round(-16.0f) = -16, result "-1.6".
+    // -1.6 * 10 = -16.0, Math.round(-16.0) = -16, result "-1.6".
     FlixelString fs = new FlixelString();
     fs.setFloatRoundedOneDecimal(-1.6f);
     assertEquals("-1.6", fs.toString());

--- a/flixelgdx-test/src/test/java/org/flixelgdx/util/FlixelStringUtilTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/util/FlixelStringUtilTest.java
@@ -89,6 +89,76 @@ class FlixelStringUtilTest {
   }
 
   @Test
+  void appendFloatRoundedTwoDecimalsRoundsUp() {
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, 3.456f, 2);
+    assertEquals("3.46", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedTwoDecimalsRoundsDown() {
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, 3.454f, 2);
+    assertEquals("3.45", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedTwoDecimalsZero() {
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, 0f, 2);
+    assertEquals("0.00", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedTwoDecimalsNegative() {
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, -2.6f, 2);
+    assertEquals("-2.60", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedTwoDecimalsLeadingZeroInFraction() {
+    // 3.05 rounded to 2 places must produce "3.05", not "3.5".
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, 3.05f, 2);
+    assertEquals("3.05", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedThreeDecimalsWholeNumber() {
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, 10f, 3);
+    assertEquals("10.000", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedZeroDecimalsProducesInteger() {
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, 3.6f, 0);
+    assertEquals("4", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedNegativeDecimalsProducesInteger() {
+    CharArray out = new CharArray();
+    FlixelStringUtil.appendFloatRounded(out, 3.6f, -1);
+    assertEquals("4", new String(out.items, 0, out.size));
+  }
+
+  @Test
+  void appendFloatRoundedNullOutDoesNotThrow() {
+    FlixelStringUtil.appendFloatRounded(null, 1.0f, 2);
+  }
+
+  @Test
+  void appendFloatRoundedAppendsToExistingContent() {
+    CharArray out = new CharArray();
+    out.append("v:");
+    FlixelStringUtil.appendFloatRounded(out, 9.5f, 2);
+    assertEquals("v:9.50", new String(out.items, 0, out.size));
+  }
+
+  @Test
   void appendFloatRoundedOneDecimalPositiveRoundsUp() {
     CharArray out = new CharArray();
     FlixelStringUtil.appendFloatRoundedOneDecimal(out, 3.45f);
@@ -111,7 +181,7 @@ class FlixelStringUtilTest {
 
   @Test
   void appendFloatRoundedOneDecimalNegativeValue() {
-    // -2.6 * 10 = -26.0, Math.round(-26.0f) = -26, so the result is "-2.6".
+    // -2.6 * 10 = -26.0, Math.round(-26.0) = -26, so the result is "-2.6".
     CharArray out = new CharArray();
     FlixelStringUtil.appendFloatRoundedOneDecimal(out, -2.6f);
     assertEquals("-2.6", new String(out.items, 0, out.size));


### PR DESCRIPTION
## Description

`FlixelStringUtil.appendFloatRoundedOneDecimal` and the corresponding `FlixelString` helpers (`setFloatRoundedOneDecimal` / `concatFloatRoundedOneDecimal`) were hardcoded to exactly one decimal place. This PR generalizes them so callers can request any number of decimal places without allocating.

**New API:**
- `FlixelStringUtil.appendFloatRounded(CharArray, float, int decimals)` - the general method
- `FlixelString.setFloatRounded(float, int decimals)`
- `FlixelString.concatFloatRounded(float, int decimals)`

The `OneDecimal` variants are kept as zero-overhead convenience delegates that call the new methods with `decimals = 1`, so existing code needs no changes.

The implementation uses `long` arithmetic internally (`10^decimals` scale factor) to avoid any `String` allocation. Fractional digits are zero-padded on the left (e.g. `3.05f` at 2 decimals produces `"3.05"`, not `"3.5"`). Passing `decimals <= 0` writes the rounded integer with no decimal point.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Tests added covering: two and three decimal places, rounding up and down, leading zeros in the fractional part (`3.05`), zero decimals (integer output), negative values, null buffer guard, and append-to-existing-content behavior.