### PR TITLE
Reworked the rig atlas system to include support for rotated parts and to be more robust

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -1145,7 +1145,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   public void changeClipRectX(int clipRectX) {
-    setClipRectX(this.clipRectX + clipRectX);
+    this.clipRectX += clipRectX;
   }
 
   public int getClipRectY() {
@@ -1157,7 +1157,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   public void changeClipRectY(int clipRectY) {
-    setClipRectY(this.clipRectY + clipRectY);
+    this.clipRectY += clipRectY;
   }
 
   public int getClipRectWidth() {
@@ -1168,12 +1168,20 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     this.clipRectWidth = Math.max(0, clipRectWidth);
   }
 
+  public void changeClipRectWidth(int clipRectWidth) {
+    setClipRectWidth(this.clipRectWidth + clipRectWidth);
+  }
+
   public int getClipRectHeight() {
     return clipRectHeight;
   }
 
   public void setClipRectHeight(int clipRectHeight) {
     this.clipRectHeight = Math.max(0, clipRectHeight);
+  }
+
+  public void changeClipRectHeight(int clipRectHeight) {
+    setClipRectHeight(this.clipRectHeight + clipRectHeight);
   }
 
   private void applyBlendMode(FlixelBatch batch, FlixelBlendMode mode) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -33,6 +33,8 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.MathUtils;
+import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.scenes.scene2d.utils.ScissorStack;
 import com.badlogic.gdx.utils.Array;
 
 import org.flixelgdx.animation.FlixelAnimationController;
@@ -134,6 +136,13 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   private static ShaderProgram premultipliedShader;
   @Nullable
   private static ShaderProgram whiteMixShader;
+
+  /** Shared scratch rectangle for clip rect bounds; reused across all sprite draw calls. */
+  private static final Rectangle tempClipBounds = new Rectangle();
+
+  /** Shared scratch rectangle for scissor pixel coordinates; reused across all sprite draw calls. */
+  private static final Rectangle tempScissors = new Rectangle();
+
   private static boolean blendMinMaxChecked;
   private static boolean blendMinMaxSupported;
 
@@ -141,18 +150,26 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   protected int facing = FlixelDirectionFlags.RIGHT;
 
   /**
-   * Visible source width for this sprite.
-   *
-   * <p>The lower this value is, the less visible this sprite will be on
-   * the x-axis from the right side. Good for fade out effects.
+   * X offset of the clip rectangle's left edge, in unscaled sprite-local pixels. Active only when
+   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   */
+  private int clipRectX;
+
+  /**
+   * Y offset of the clip rectangle's bottom edge, in unscaled sprite-local pixels. Active only when
+   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   */
+  private int clipRectY;
+
+  /**
+   * Width of the visible clip rectangle, in unscaled sprite-local pixels. Active only when
+   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
   private int clipRectWidth;
 
   /**
-   * Visible source height for this sprite.
-   *
-   * <p>The lower this value is, the less visible this sprite will be on
-   * the y-axis from the bottom. Good for fade out effects.
+   * Height of the visible clip rectangle, in unscaled sprite-local pixels. Active only when
+   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
   private int clipRectHeight;
 
@@ -175,6 +192,9 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
 
   /** Whether this sprite is flipped vertically. */
   protected boolean flipY = false;
+
+  /** Whether a clip rectangle is active; set via {@link #setClipRect(int, int, int, int)} and cleared by {@link #clearClipRect()}. */
+  private boolean clipRectEnabled;
 
   /** Constructs a new FlixelSprite with default values. */
   public FlixelSprite() {
@@ -591,8 +611,32 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     float originXParam = srcW / 2f - insetX;
     float originYParam = srcH / 2f - insetY;
 
-    int drawW = Math.max(0, regW - (int) (clipRectWidth / Math.abs(scaleX)));
-    int drawH = Math.max(0, regH - (int) (clipRectHeight / Math.abs(scaleY)));
+    boolean clipEnabled = clipRectEnabled;
+    boolean clipPushed = false;
+    if (clipEnabled) {
+      // Flush before changing scissor state so previously batched sprites are not retroactively clipped.
+      batch.flush();
+      float clipScreenX = wx + offsetX + clipRectX * Math.abs(scaleX);
+      float clipScreenY = wy + offsetY + clipRectY * Math.abs(scaleY);
+      float clipScreenW = clipRectWidth * Math.abs(scaleX);
+      float clipScreenH = clipRectHeight * Math.abs(scaleY);
+      tempClipBounds.set(clipScreenX, clipScreenY, clipScreenW, clipScreenH);
+      ScissorStack.calculateScissors(
+          cam.getCamera(),
+          cam.getViewport().getScreenX(), cam.getViewport().getScreenY(),
+          cam.getViewport().getScreenWidth(), cam.getViewport().getScreenHeight(),
+          batch.getTransformMatrix(), tempClipBounds, tempScissors);
+      clipPushed = ScissorStack.pushScissors(tempScissors);
+      if (!clipPushed) {
+        if (spriteShader != null) {
+          batch.setShader(null);
+        }
+        if (blending) {
+          resetBlendMode(batch, previousShader);
+        }
+        return;
+      }
+    }
 
     batch.setColor(color);
     batch.draw(
@@ -601,18 +645,23 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
         drawY,
         originXParam,
         originYParam,
-        drawW,
-        drawH,
+        regW,
+        regH,
         scaleX,
         scaleY,
         getAngle(),
         f.getRegionX(),
         f.getRegionY(),
-        drawW,
-        drawH,
+        regW,
+        regH,
         isFlippedX,
         isFlippedY);
     batch.setColor(Color.WHITE);
+
+    if (clipEnabled && clipPushed) {
+      batch.flush();
+      ScissorStack.popScissors();
+    }
 
     if (spriteShader != null) {
       batch.setShader(null);
@@ -730,6 +779,11 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     flipY = false;
     setAngle(0f);
     currentFrame = null;
+    clipRectX = 0;
+    clipRectY = 0;
+    clipRectWidth = 0;
+    clipRectHeight = 0;
+    clipRectEnabled = false;
     if (atlasFrames != null) {
       atlasFrames.setSize(0);
       atlasFrames = null;
@@ -1036,12 +1090,82 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     return frames;
   }
 
+  public boolean isClipRectEnabled() {
+    return clipRectEnabled;
+  }
+
+  /**
+   * Sets the clip rectangle in sprite-local pixel space and enables clipping.
+   *
+   * <p>Only the region inside the rectangle is drawn; pixels outside are discarded by the GPU
+   * scissor. The origin is the sprite's bottom-left corner before scale, so {@code x=0, y=0}
+   * anchors to the bottom-left of the frame. Moving {@code x} or {@code y} slides the visible
+   * window without changing the sprite's world position, which is the key difference from the
+   * old crop-from-edge approach.
+   *
+   * <p>For example, to show only the center quarter of a 100x100 sprite:
+   * <pre>{@code
+   * sprite.setClipRect(25, 25, 50, 50);
+   * // Slide the window right by 10 px later:
+   * sprite.setClipRectX(35);
+   * // Remove clipping:
+   * sprite.clearClipRect();
+   * }</pre>
+   *
+   * <p>Disable clipping with {@link #clearClipRect()}.
+   *
+   * @param x Left edge of the visible region, in unscaled sprite-local pixels.
+   * @param y Bottom edge of the visible region, in unscaled sprite-local pixels.
+   * @param width Width of the visible region, in unscaled sprite-local pixels.
+   * @param height Height of the visible region, in unscaled sprite-local pixels.
+   */
+  public void setClipRect(int x, int y, int width, int height) {
+    clipRectX = x;
+    clipRectY = y;
+    clipRectWidth = Math.max(0, width);
+    clipRectHeight = Math.max(0, height);
+    clipRectEnabled = true;
+  }
+
+  /** Disables the clip rectangle and resets all clip values to zero. */
+  public void clearClipRect() {
+    clipRectX = 0;
+    clipRectY = 0;
+    clipRectWidth = 0;
+    clipRectHeight = 0;
+    clipRectEnabled = false;
+  }
+
+  public int getClipRectX() {
+    return clipRectX;
+  }
+
+  public void setClipRectX(int clipRectX) {
+    this.clipRectX = clipRectX;
+  }
+
+  public void changeClipRectX(int clipRectX) {
+    setClipRectX(this.clipRectX + clipRectX);
+  }
+
+  public int getClipRectY() {
+    return clipRectY;
+  }
+
+  public void setClipRectY(int clipRectY) {
+    this.clipRectY = clipRectY;
+  }
+
+  public void changeClipRectY(int clipRectY) {
+    setClipRectY(this.clipRectY + clipRectY);
+  }
+
   public int getClipRectWidth() {
     return clipRectWidth;
   }
 
   public void setClipRectWidth(int clipRectWidth) {
-    this.clipRectWidth = MathUtils.clamp(clipRectWidth, 0, (int) getWidth());
+    this.clipRectWidth = Math.max(0, clipRectWidth);
   }
 
   public int getClipRectHeight() {
@@ -1049,7 +1173,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   public void setClipRectHeight(int clipRectHeight) {
-    this.clipRectHeight = MathUtils.clamp(clipRectHeight, 0, (int) getHeight());
+    this.clipRectHeight = Math.max(0, clipRectHeight);
   }
 
   private void applyBlendMode(FlixelBatch batch, FlixelBlendMode mode) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
@@ -87,9 +87,11 @@ import java.util.Objects;
  * loader bakes two Y-flips into every part so the draw path can stay a simple
  * {@code translate * scale * part}:
  * <ol>
- *   <li>A <strong>per-bitmap flip</strong> {@code [1, 0, 0; 0, -1, regionHeight]} that turns libGDX's
+ *   <li>A <strong>per-bitmap flip</strong> {@code [1, 0, 0; 0, -1, origH]} that turns libGDX's
  *   local-space Y-up rectangle into Adobe's Y-down rectangle, applied on the <em>right</em> so that
- *   the existing {@code MX} chain keeps interpreting its input as Flash-local.</li>
+ *   the existing {@code MX} chain keeps interpreting its input as Flash-local. Parts packed rotated
+ *   90 degrees clockwise use an extended matrix {@code [0, -1, origW; -1, 0, origH]} that
+ *   simultaneously un-rotates and Y-flips.</li>
  *   <li>A <strong>rig-wide flip</strong> {@code [1, 0, -anchorMinX; 0, -1, anchorMinY + anchorHeight]}
  *   that turns Flash-world coordinates back into Y-up world coordinates after all Flash matrices have
  *   been composed, and simultaneously shifts the anchor bounding box so its bottom-left corner sits at
@@ -456,7 +458,10 @@ final class FlixelAnimateRigLoader {
           RawPart raw = scratchRaw.get(p);
           FlixelFrame frame = atlas.get(raw.atlasIndex);
           FlixelAnimateRig.Part part = new FlixelAnimateRig.Part(raw.atlasIndex);
-          bakePartAffine(part.local, raw.flashMatrix, frame.getRegionHeight(), anchorMinX, anchorMinY, anchorHeight);
+          bakePartAffine(
+              part.local, raw.flashMatrix,
+              frame.originalWidth, frame.originalHeight, frame.rotated,
+              anchorMinX, anchorMinY, anchorHeight);
           parts[p] = part;
         }
         kfs[t] = new FlixelAnimateRig.Keyframe(parts);
@@ -523,8 +528,9 @@ final class FlixelAnimateRigLoader {
     for (int i = 0; i < tmp.size; i++) {
       RawPart p = tmp.get(i);
       FlixelFrame frame = atlas.get(p.atlasIndex);
-      float w = frame.getRegionWidth();
-      float h = frame.getRegionHeight();
+      // Use logical (unrotated) dimensions in Flash local space regardless of atlas packing.
+      float w = frame.originalWidth;
+      float h = frame.originalHeight;
       accumulateTransformedCorner(p.flashMatrix, 0f, 0f, out);
       accumulateTransformedCorner(p.flashMatrix, w, 0f, out);
       accumulateTransformedCorner(p.flashMatrix, w, h, out);
@@ -1018,29 +1024,38 @@ final class FlixelAnimateRigLoader {
   /**
    * Bakes the final draw-ready affine for a single part.
    *
-   * <p>The returned matrix equals {@code anchorShift * flipRig * P_flash * flipBitmap}, where
-   * {@code P_flash} is the caller-supplied Flash-world matrix, {@code flipBitmap} converts libGDX
-   * Y-up local bitmap coordinates to Flash Y-down, and {@code anchorShift * flipRig} converts the
-   * resulting Flash-world point back to libGDX Y-up while sliding the anchor bounding box's
-   * bottom-left corner onto the sprite origin.
+   * <p>For a non-rotated part the result equals {@code anchorShift * flipRig * P_flash * flipBitmap},
+   * where {@code flipBitmap = [1, 0, 0; 0, -1, origH]} converts libGDX Y-up local bitmap coordinates
+   * to Flash Y-down, and {@code anchorShift * flipRig} converts the resulting Flash-world point back
+   * to libGDX Y-up while sliding the anchor bounding box's bottom-left corner onto the sprite origin.
+   *
+   * <p>For a part that was packed rotated 90 degrees clockwise in the atlas, Adobe Animate stores
+   * the sprite sideways: the atlas footprint is {@code origH} pixels wide and {@code origW} pixels
+   * tall. The draw call therefore produces a quad in {@code [0, origH] x [0, origW]} local space, so
+   * a different per-bitmap matrix {@code rotFlipBitmap = [0, -1, origW; -1, 0, origH]} is substituted
+   * for {@code flipBitmap}. This matrix un-rotates and Y-flips in one step, mapping each atlas-local
+   * coordinate back to the correct Flash-local position.
+   *
+   * <p>Exposed as package-private so the geometry can be unit-tested without a GPU texture.
    *
    * @param out The destination affine; overwritten.
    * @param flashWorld The accumulated Flash-world matrix for this part.
-   * @param regionHeight The height of the part's texture region in pixels (used by {@code flipBitmap}).
+   * @param origW The logical width of the part in Flash space ({@link FlixelFrame#originalWidth}).
+   * @param origH The logical height of the part in Flash space ({@link FlixelFrame#originalHeight}).
+   * @param rotated Whether this part was packed rotated 90 degrees clockwise in the atlas.
    * @param anchorMinX The minimum X of the anchor bounding box in Flash-world space.
    * @param anchorMinY The minimum Y of the anchor bounding box in Flash-world space.
    * @param anchorHeight The height of the anchor bounding box.
    */
-  private static void bakePartAffine(
+  static void bakePartAffine(
       @NotNull Affine2 out,
       @NotNull Affine2 flashWorld,
-      float regionHeight,
+      float origW,
+      float origH,
+      boolean rotated,
       float anchorMinX,
       float anchorMinY,
       float anchorHeight) {
-    // flipBitmap = [1, 0, 0; 0, -1, regionHeight].
-    // After flashWorld * flipBitmap, the libGDX-local top-left of the region maps to where Flash
-    // expects the bitmap's top-left to sit.
     float p00 = flashWorld.m00;
     float p01 = flashWorld.m01;
     float p02 = flashWorld.m02;
@@ -1048,19 +1063,31 @@ final class FlixelAnimateRigLoader {
     float p11 = flashWorld.m11;
     float p12 = flashWorld.m12;
 
-    float fw01 = -p01;
-    float fw02 = p01 * regionHeight + p02;
-    float fw11 = -p11;
-    float fw12 = p11 * regionHeight + p12;
-
-    // anchorShift * flipRig = [1, 0, -anchorMinX; 0, -1, anchorMinY + anchorHeight] applied on the left.
     float shiftY = anchorMinY + anchorHeight;
-    out.m00 = p00;
-    out.m01 = fw01;
-    out.m02 = fw02 - anchorMinX;
-    out.m10 = -p10;
-    out.m11 = -fw11;
-    out.m12 = shiftY - fw12;
+
+    if (rotated) {
+      // rotFlipBitmap = [0, -1, origW; -1, 0, origH].
+      // P_flash * rotFlipBitmap then anchorShift * flipRig on the left:
+      out.m00 = -p01;
+      out.m01 = -p00;
+      out.m02 = p00 * origW + p01 * origH + p02 - anchorMinX;
+      out.m10 = p11;
+      out.m11 = p10;
+      out.m12 = shiftY - p10 * origW - p11 * origH - p12;
+    } else {
+      // flipBitmap = [1, 0, 0; 0, -1, origH].
+      // P_flash * flipBitmap then anchorShift * flipRig on the left:
+      float fw01 = -p01;
+      float fw02 = p01 * origH + p02;
+      float fw11 = -p11;
+      float fw12 = p11 * origH + p12;
+      out.m00 = p00;
+      out.m01 = fw01;
+      out.m02 = fw02 - anchorMinX;
+      out.m10 = -p10;
+      out.m11 = -fw11;
+      out.m12 = shiftY - fw12;
+    }
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateRigLoader.java
@@ -624,7 +624,17 @@ final class FlixelAnimateRigLoader {
       Affine2 rootMatrix = new Affine2();
       matrixFromFlashMxOrM3d(rootSi.get("MX"), rootSi.get("M3D"), rootMatrix);
 
-      visitSymbol(parsed.symbolsByName, nameToIndex, rootSnNode.asString(), frameTime, rootMatrix, out, 0);
+      // Apply the root SI's FF (first frame) and LP (loop mode) the same way visitSymbol handles
+      // nested child SIs. Without this, the FF offset on the root symbol instance is ignored and
+      // every clip that references the same symbol with a non-zero FF (such as danceRight when
+      // FF=15) always starts sampling from frame 0 instead of the intended starting frame.
+      String rootSymName = rootSnNode.asString();
+      int rootFirstFrame = readIntOr(rootSi, "FF", 0);
+      String rootLoopMode = readStringOr(rootSi, "LP", "loop");
+      int rootSymDuration = computeSymbolDuration(parsed.symbolsByName, rootSymName);
+      int rootLocalTime = computeChildLocalTime(rootLoopMode, rootFirstFrame, frameTime, rootSymDuration);
+
+      visitSymbol(parsed.symbolsByName, nameToIndex, rootSymName, rootLocalTime, rootMatrix, out, 0);
       return;
     }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelAnimateSprite.java
@@ -895,17 +895,17 @@ public class FlixelAnimateSprite extends FlixelSprite {
       baseAffine.translate(-anchorOriginX, -anchorOriginY);
     }
 
-    int clipW = getClipRectWidth();
-    int clipH = getClipRectHeight();
-    boolean hasClip = clipW > 0 || clipH > 0;
+    boolean hasClip = isClipRectEnabled();
     boolean clipPushed = false;
     if (hasClip) {
       // Flush pending geometry before switching scissor state so non-clipped sprites that were
       // batched before this draw call are not retroactively clipped.
       batch.flush();
-      float visW = Math.max(0, (getWidth() - clipW) * Math.abs(sx));
-      float visH = Math.max(0, (getHeight() - clipH) * Math.abs(sy));
-      clipBoundsTemp.set(wx - getOffsetX(), wy - getOffsetY(), visW, visH);
+      float clipScreenX = (wx - getOffsetX()) + getClipRectX() * Math.abs(sx);
+      float clipScreenY = (wy - getOffsetY()) + getClipRectY() * Math.abs(sy);
+      float clipScreenW = getClipRectWidth() * Math.abs(sx);
+      float clipScreenH = getClipRectHeight() * Math.abs(sy);
+      clipBoundsTemp.set(clipScreenX, clipScreenY, clipScreenW, clipScreenH);
       ScissorStack.calculateScissors(
           cam.getCamera(),
           cam.getViewport().getScreenX(), cam.getViewport().getScreenY(),

--- a/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/animation/FlixelSpritemapJsonLoader.java
@@ -147,8 +147,10 @@ public final class FlixelSpritemapJsonLoader {
       int y = sp.getInt("y");
       int w = sp.getInt("w");
       int h = sp.getInt("h");
+      JsonValue rotatedNode = sp.get("rotated");
+      boolean rotated = rotatedNode != null && rotatedNode.asBoolean();
       int idx = out.size;
-      out.add(buildFrame(texture, x, y, w, h, name));
+      out.add(buildFrame(texture, x, y, w, h, rotated, name));
       if (name != null && !name.isEmpty()) {
         nameToIndexOut.put(name, idx);
       }
@@ -278,7 +280,7 @@ public final class FlixelSpritemapJsonLoader {
         int y = row.get(1).asInt();
         int w = row.get(2).asInt();
         int h = row.get(3).asInt();
-        out.add(buildFrame(texture, x, y, w, h, "frame" + index));
+        out.add(buildFrame(texture, x, y, w, h, false, "frame" + index));
         index++;
       }
       return out;
@@ -297,7 +299,7 @@ public final class FlixelSpritemapJsonLoader {
         int y = getIntField(fr, "y");
         int w = getIntField(fr, "w", "width");
         int h = getIntField(fr, "h", "height");
-        out.add(buildFrame(texture, x, y, w, h, fname));
+        out.add(buildFrame(texture, x, y, w, h, false, fname));
       }
       return out;
     }
@@ -344,14 +346,20 @@ public final class FlixelSpritemapJsonLoader {
 
   @NotNull
   private static FlixelFrame buildFrame(
-      @NotNull Texture texture, int x, int y, int w, int h, @Nullable String name) {
+      @NotNull Texture texture, int x, int y, int w, int h, boolean rotated, @Nullable String name) {
+    // When Adobe Animate packs a sprite 90 degrees CW, the w and h fields in the JSON are the
+    // *atlas-stored* dimensions (w = logical height, h = logical width). The TextureRegion must
+    // cover exactly the atlas footprint (no swap), and originalWidth/Height must be restored to
+    // the logical (pre-rotation) dimensions so the rig baker can place the sprite correctly in
+    // Flash world space.
     TextureRegion region = new TextureRegion(texture, x, y, w, h);
     FlixelFrame f = new FlixelFrame(region);
     f.name = (name != null && !name.isEmpty()) ? name : "frame";
     f.offsetX = 0;
     f.offsetY = 0;
-    f.originalWidth = w;
-    f.originalHeight = h;
+    f.originalWidth = rotated ? h : w;
+    f.originalHeight = rotated ? w : h;
+    f.rotated = rotated;
     return f;
   }
 }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelFrame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/graphics/FlixelFrame.java
@@ -83,6 +83,17 @@ public final class FlixelFrame {
   public int offsetY;
 
   /**
+   * Whether this frame was packed into its atlas rotated 90 degrees clockwise.
+   *
+   * <p>When {@code true}, Adobe Animate stores the sprite sideways in the PNG to save space.
+   * The backing {@link TextureRegion} covers the on-disk footprint as-is (width = logical height,
+   * height = logical width), while {@link #originalWidth} and {@link #originalHeight} always hold
+   * the logical (pre-rotation) dimensions. The rig baker applies a rotation-correction matrix so
+   * the part renders upright in rig space regardless of how it was packed.
+   */
+  public boolean rotated;
+
+  /**
    * Constructs a new FlixelFrame with the given region.
    *
    * @param region The region to wrap.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -91,10 +91,10 @@ import java.util.function.Supplier;
  * Subclasses of {@code FlixelTween} implement specialized behavior:
  * <ul>
  *   <li>{@link FlixelGoalTween}: interpolates properties of objects using lambda getters and setters</li>
- *   <li>{@link org.flixelgdx.tween.type.FlixelNumTween FlixelNumTween}: tweens a simple numeric value via a callback</li>
- *   <li>{@link org.flixelgdx.tween.type.FlixelColorTween FlixelColorTween}: tweens between colors</li>
- *   <li>{@link org.flixelgdx.tween.type.FlixelAngleTween FlixelAngleTween}: smoothly rotates a value</li>
- *   <li>{@link org.flixelgdx.tween.type.motion.FlixelLinearMotion FlixelLinearMotion} and others: for advanced motion paths</li>
+ *   <li>{@link FlixelNumTween}: tweens a simple numeric value via a callback</li>
+ *   <li>{@link FlixelColorTween}: tweens between colors</li>
+ *   <li>{@link FlixelAngleTween}: smoothly rotates a value</li>
+ *   <li>{@link FlixelLinearMotion} and others: for advanced motion paths</li>
  * </ul>
  *
  * <h2>Key Fields</h2>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -130,7 +130,7 @@ import java.util.function.Supplier;
  * </p>
  *
  * @see FlixelTweenManager
- * @see org.flixelgdx.tween.settings.FlixelTweenSettings
+ * @see FlixelTweenSettings
  *
  * @author stringdotjar
  */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/tween/FlixelTween.java
@@ -134,7 +134,6 @@ import java.util.function.Supplier;
  *
  * @author stringdotjar
  */
-
 public abstract class FlixelTween implements Pool.Poolable {
 
   /** The global tween manager for the entire game. */

--- a/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimateRigBakeTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/animation/FlixelAnimateRigBakeTest.java
@@ -1,0 +1,243 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.animation;
+
+import com.badlogic.gdx.math.Affine2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Covers the pure geometry of {@link FlixelAnimateRigLoader#bakePartAffine} for both the standard
+ * (non-rotated) and the 90-degree-CW-rotated atlas packing cases.
+ *
+ * <p>Coordinate space primer: the baked affine maps from <strong>libGDX atlas local space</strong>
+ * (Y-up, bottom-left at the origin) to <strong>rig local space</strong> (also Y-up, bottom-left of
+ * the anchor box at the origin). For a non-rotated part the atlas quad is {@code (0..origW) x (0..origH)}.
+ * For a 90-degree-CW packed part the atlas region has its width and height swapped, so the quad is
+ * {@code (0..origH) x (0..origW)} - that is, atlas width = origH, atlas height = origW.
+ *
+ * <p>No GPU texture is required; all arithmetic is pure matrix math.
+ */
+class FlixelAnimateRigBakeTest {
+
+  private static final float DELTA = 1e-4f;
+
+  /** Applies the affine to the given local point and returns (x', y'). */
+  private static float[] apply(Affine2 a, float x, float y) {
+    return new float[] { a.m00 * x + a.m01 * y + a.m02, a.m10 * x + a.m11 * y + a.m12 };
+  }
+
+  /**
+   * Non-rotated part at the anchor origin. With an identity Flash matrix and a zero-offset anchor,
+   * the baked affine must be identity so every local atlas coordinate maps 1:1 to rig space.
+   */
+  @Test
+  void nonRotatedIdentityFlashMatrix() {
+    float origW = 100f;
+    float origH = 60f;
+    Affine2 identity = new Affine2();
+    Affine2 out = new Affine2();
+
+    FlixelAnimateRigLoader.bakePartAffine(out, identity, origW, origH, false, 0f, 0f, origH);
+
+    float[] bl = apply(out, 0f, 0f);
+    assertEquals(0f, bl[0], DELTA, "bottom-left x");
+    assertEquals(0f, bl[1], DELTA, "bottom-left y");
+
+    float[] tr = apply(out, origW, origH);
+    assertEquals(origW, tr[0], DELTA, "top-right x");
+    assertEquals(origH, tr[1], DELTA, "top-right y");
+  }
+
+  /**
+   * Rotated (90 degrees CW) part at the anchor origin. The atlas quad has width = origH and
+   * height = origW, so local space is {@code (0..origH) x (0..origW)}. The baked affine must
+   * map each atlas corner to the rig corner that holds the same pixel:
+   * <ul>
+   *   <li>Atlas bottom-left (0, 0) - holds the original bottom-right pixel - must land at rig (origW, 0).</li>
+   *   <li>Atlas bottom-right (origH, 0) - original top-right pixel - must land at rig (origW, origH).</li>
+   *   <li>Atlas top-right (origH, origW) - original top-left pixel - must land at rig (0, origH).</li>
+   *   <li>Atlas top-left (0, origW) - original bottom-left pixel - must land at rig (0, 0).</li>
+   * </ul>
+   */
+  @Test
+  void rotatedIdentityFlashMatrix() {
+    float origW = 100f;
+    float origH = 60f;
+    Affine2 identity = new Affine2();
+    Affine2 out = new Affine2();
+
+    FlixelAnimateRigLoader.bakePartAffine(out, identity, origW, origH, true, 0f, 0f, origH);
+
+    // Atlas bottom-left (0, 0) holds the original bottom-right pixel; should land at rig bottom-right.
+    float[] bl = apply(out, 0f, 0f);
+    assertEquals(origW, bl[0], DELTA, "atlas bottom-left x -> rig bottom-right x");
+    assertEquals(0f, bl[1], DELTA, "atlas bottom-left y -> rig bottom-right y");
+
+    // Atlas bottom-right (origH, 0) holds the original top-right; should land at rig top-right.
+    float[] br = apply(out, origH, 0f);
+    assertEquals(origW, br[0], DELTA, "atlas bottom-right x -> rig top-right x");
+    assertEquals(origH, br[1], DELTA, "atlas bottom-right y -> rig top-right y");
+
+    // Atlas top-right (origH, origW) holds the original top-left; should land at rig top-left.
+    float[] tr = apply(out, origH, origW);
+    assertEquals(0f, tr[0], DELTA, "atlas top-right x -> rig top-left x");
+    assertEquals(origH, tr[1], DELTA, "atlas top-right y -> rig top-left y");
+
+    // Atlas top-left (0, origW) holds the original bottom-left; should land at rig bottom-left.
+    float[] tl = apply(out, 0f, origW);
+    assertEquals(0f, tl[0], DELTA, "atlas top-left x -> rig bottom-left x");
+    assertEquals(0f, tl[1], DELTA, "atlas top-left y -> rig bottom-left y");
+  }
+
+  /**
+   * Non-zero anchor offsets are applied identically to both rotated and non-rotated parts. With a
+   * Flash translate that positions the sprite at the anchor's top-left corner and {@code anchorHeight
+   * == origH}, both cases must produce a translation-only affine with the same offset, confirming
+   * that the anchor shift cancels the Flash translation symmetrically.
+   */
+  @Test
+  void anchorOffsetAppliedToBothCases() {
+    float origW = 80f;
+    float origH = 40f;
+    float anchorMinX = 10f;
+    float anchorMinY = 5f;
+
+    // Placing the sprite at the anchor position so the anchor shift cancels out and the baked
+    // affine should reduce to identity for the non-rotated case.
+    Affine2 flashAtAnchor = new Affine2();
+    flashAtAnchor.m02 = anchorMinX;
+    flashAtAnchor.m12 = anchorMinY;
+
+    Affine2 outNormal = new Affine2();
+    FlixelAnimateRigLoader.bakePartAffine(
+        outNormal, flashAtAnchor, origW, origH, false, anchorMinX, anchorMinY, origH);
+
+    // With the sprite exactly at the anchor, the non-rotated baked affine must be identity.
+    float[] blNormal = apply(outNormal, 0f, 0f);
+    assertEquals(0f, blNormal[0], DELTA, "non-rotated: bottom-left x at anchor");
+    assertEquals(0f, blNormal[1], DELTA, "non-rotated: bottom-left y at anchor");
+
+    float[] trNormal = apply(outNormal, origW, origH);
+    assertEquals(origW, trNormal[0], DELTA, "non-rotated: top-right x at anchor");
+    assertEquals(origH, trNormal[1], DELTA, "non-rotated: top-right y at anchor");
+
+    // The rotated case with the same Flash translate and anchor should also cancel to a known result.
+    // Atlas quad is (0..origH) x (0..origW); atlas top-left (0, origW) holds the bottom-left pixel.
+    Affine2 outRotated = new Affine2();
+    FlixelAnimateRigLoader.bakePartAffine(
+        outRotated, flashAtAnchor, origW, origH, true, anchorMinX, anchorMinY, origH);
+
+    // Atlas top-left (0, origW) -> sprite bottom-left -> should land at rig (0, 0).
+    float[] blRotated = apply(outRotated, 0f, origW);
+    assertEquals(0f, blRotated[0], DELTA, "rotated: bottom-left pixel x at anchor");
+    assertEquals(0f, blRotated[1], DELTA, "rotated: bottom-left pixel y at anchor");
+
+    // Atlas bottom-right (origH, 0) -> sprite top-right -> should land at rig (origW, origH).
+    float[] trRotated = apply(outRotated, origH, 0f);
+    assertEquals(origW, trRotated[0], DELTA, "rotated: top-right pixel x at anchor");
+    assertEquals(origH, trRotated[1], DELTA, "rotated: top-right pixel y at anchor");
+  }
+
+  /**
+   * The bounding box of the rig-space corners must be identical for a non-rotated and a
+   * rotated part with the same Flash world matrix and anchor, because atlas rotation is purely
+   * a packing detail - it must not change where the pixels land on screen. The rotated atlas
+   * quad has corners {@code (0..origH) x (0..origW)} while the non-rotated quad is
+   * {@code (0..origW) x (0..origH)}, so the test evaluates different corner coordinates through
+   * two different baked affines and verifies their screen-space bounding boxes agree.
+   */
+  @Test
+  void rotatedAndNonRotatedHaveSameWorldBoundingBox() {
+    float origW = 120f;
+    float origH = 80f;
+    Affine2 flashTranslate = new Affine2();
+    flashTranslate.m02 = 20f;
+    flashTranslate.m12 = 15f;
+
+    Affine2 outNormal = new Affine2();
+    FlixelAnimateRigLoader.bakePartAffine(outNormal, flashTranslate, origW, origH, false, 0f, 0f, origH);
+
+    Affine2 outRotated = new Affine2();
+    FlixelAnimateRigLoader.bakePartAffine(outRotated, flashTranslate, origW, origH, true, 0f, 0f, origH);
+
+    // 4 corners of the non-rotated quad: (0..origW) x (0..origH)
+    float[][] normalCorners = {
+        apply(outNormal, 0f, 0f),
+        apply(outNormal, origW, 0f),
+        apply(outNormal, origW, origH),
+        apply(outNormal, 0f, origH)
+    };
+    // 4 corners of the rotated quad: atlas width = origH, atlas height = origW
+    float[][] rotatedCorners = {
+        apply(outRotated, 0f, 0f),
+        apply(outRotated, origH, 0f),
+        apply(outRotated, origH, origW),
+        apply(outRotated, 0f, origW)
+    };
+
+    assertEquals(minX(normalCorners), minX(rotatedCorners), DELTA, "bbox minX");
+    assertEquals(minY(normalCorners), minY(rotatedCorners), DELTA, "bbox minY");
+    assertEquals(maxX(normalCorners), maxX(rotatedCorners), DELTA, "bbox maxX");
+    assertEquals(maxY(normalCorners), maxY(rotatedCorners), DELTA, "bbox maxY");
+  }
+
+  private static float minX(float[][] pts) {
+    float m = Float.POSITIVE_INFINITY;
+    for (float[] p : pts) {
+      if (p[0] < m)
+        m = p[0];
+    }
+    return m;
+  }
+
+  private static float minY(float[][] pts) {
+    float m = Float.POSITIVE_INFINITY;
+    for (float[] p : pts) {
+      if (p[1] < m)
+        m = p[1];
+    }
+    return m;
+  }
+
+  private static float maxX(float[][] pts) {
+    float m = Float.NEGATIVE_INFINITY;
+    for (float[] p : pts) {
+      if (p[0] > m)
+        m = p[0];
+    }
+    return m;
+  }
+
+  private static float maxY(float[][] pts) {
+    float m = Float.NEGATIVE_INFINITY;
+    for (float[] p : pts) {
+      if (p[1] > m)
+        m = p[1];
+    }
+    return m;
+  }
+}


### PR DESCRIPTION
## Description

Adobe Animate's texture atlas export can pack sprites rotated 90 degrees clockwise to save space, marking them with `"rotated": true` in the spritemap JSON. The rig loader had no support for this: rotated parts rendered sideways and their bounding boxes were wrong.

Three bugs were fixed:

**1. Wrong dimension interpretation for rotated sprites** (`FlixelSpritemapJsonLoader`)

Adobe exports `w` and `h` for rotated sprites as the *atlas-stored* footprint (`w` = logical height, `h` = logical width). The old code treated them as logical dimensions and swapped the `TextureRegion` construction, covering the wrong atlas pixels and storing wrong values in `originalWidth`/`originalHeight`. The fix: use `(x, y, w, h)` as-is for the `TextureRegion`, and set `originalWidth = h`, `originalHeight = w` for rotated frames so the rig baker always receives the correct logical dimensions.

**2. Missing un-rotate matrix in `bakePartAffine`** (`FlixelAnimateRigLoader`)

Non-rotated parts use `flipBitmap = [1, 0, 0; 0, -1, origH]` to convert from libGDX Y-up atlas local space to Flash Y-down local space. Rotated parts need a different matrix, `rotFlipBitmap = [0, -1, origW; -1, 0, origH]`, that simultaneously un-rotates (swaps axes) and Y-flips. This is now applied when `FlixelFrame.rotated` is `true`.

**3. Root SI `FF` (first frame) offset ignored in `collectKeyframeParts`**

When two clips reference the same symbol with different `FF` offsets (for example, Girlfriend's `danceLeft` uses `FF=0` and `danceRight` uses `FF=15` of the same `GF Dancing Beat` symbol), the root symbol instance's `FF` and `LP` fields were read from the JSON but then discarded before calling `visitSymbol`. The same `computeChildLocalTime(loopMode, firstFrame, frameTime, duration)` logic that handles nested child SIs is now applied to the root SI as well, so each clip samples the symbol from the correct starting frame.

Also adds `FlixelFrame.rotated` (a new `boolean` field) and four pure-geometry unit tests for `bakePartAffine` that cover both the standard and rotated cases without requiring a GPU.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).