### PR TITLE
Added named slot, reference-based, and clear binding removal to action types

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -151,25 +151,25 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
 
   /**
    * X offset of the clip rectangle's left edge, in screen pixels from the sprite's drawn left edge.
-   * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(float, float, float, float)}.
    */
   private float clipRectX;
 
   /**
    * Y offset of the clip rectangle's bottom edge, in screen pixels from the sprite's drawn bottom edge.
-   * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(float, float, float, float)}.
    */
   private float clipRectY;
 
   /**
    * Width of the visible clip rectangle, in screen pixels. Active only when
-   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(float, float, float, float)}.
    */
   private float clipRectWidth;
 
   /**
    * Height of the visible clip rectangle, in screen pixels. Active only when
-   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(float, float, float, float)}.
    */
   private float clipRectHeight;
 
@@ -193,7 +193,12 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   /** Whether this sprite is flipped vertically. */
   protected boolean flipY = false;
 
-  /** Whether a clip rectangle is active; set via {@link #setClipRect(int, int, int, int)} and cleared by {@link #clearClipRect()}. */
+  /**
+   * Whether a clip rectangle is active.
+   *
+   * <p>Set from either {@link #setClipRect(float, float, float, float)}, and cleared by
+   * {@link #clearClipRect()}.
+   */
   private boolean clipRectEnabled;
 
   /** Constructs a new FlixelSprite with default values. */
@@ -1099,30 +1104,28 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    *
    * <p>Only the region inside the rectangle is drawn; pixels outside are discarded by the GPU
    * scissor. Coordinates are in the same units as {@link #getWidth()}/{@link #getHeight()} - that
-   * is, they already account for scale - so {@code x=0, y=0} anchors to the drawn bottom-left
-   * corner and {@code width=(int)getWidth()} covers the full drawn width regardless of scale.
+   * is, they already account for scale, so {@code x=0, y=0} anchors to the drawn bottom-left
+   * corner and {@code width=getWidth()} covers the full drawn width regardless of scale.
    *
    * <p>For example, to show only the left half of a sprite regardless of its current scale:
    * <pre>{@code
-   * sprite.setClipRect(0, 0, (int)(sprite.getWidth() * 0.5f), (int)sprite.getHeight());
+   * sprite.setClipRect(0, 0, sprite.getWidth() * 0.5f, sprite.getHeight());
    * // Slide the window right by 10 px later:
-   * sprite.setClipRectX(10);
+   * sprite.changeClipRectX(10);
    * // Remove clipping:
    * sprite.clearClipRect();
    * }</pre>
-   *
-   * <p>Disable clipping with {@link #clearClipRect()}.
    *
    * @param x Left edge of the visible region, in screen pixels from the sprite's drawn left edge.
    * @param y Bottom edge of the visible region, in screen pixels from the sprite's drawn bottom edge.
    * @param width Width of the visible region, in screen pixels.
    * @param height Height of the visible region, in screen pixels.
    */
-  public void setClipRect(int x, int y, int width, int height) {
+  public void setClipRect(float x, float y, float width, float height) {
     clipRectX = x;
     clipRectY = y;
-    clipRectWidth = Math.max(0, width);
-    clipRectHeight = Math.max(0, height);
+    clipRectWidth = MathUtils.clamp(width, 0, getWidth());
+    clipRectHeight = MathUtils.clamp(height, 0, getHeight());
     clipRectEnabled = true;
   }
 
@@ -1164,7 +1167,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   public void setClipRectWidth(float clipRectWidth) {
-    this.clipRectWidth = MathUtils.clamp(clipRectWidth, 0, (int) getWidth());
+    this.clipRectWidth = MathUtils.clamp(clipRectWidth, 0, getWidth());
   }
 
   public void changeClipRectWidth(float clipRectWidth) {
@@ -1176,7 +1179,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   public void setClipRectHeight(float clipRectHeight) {
-    this.clipRectHeight = MathUtils.clamp(clipRectHeight, 0, (int) getHeight());
+    this.clipRectHeight = MathUtils.clamp(clipRectHeight, 0, getHeight());
   }
 
   public void changeClipRectHeight(float clipRectHeight) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -1164,7 +1164,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   public void setClipRectWidth(int clipRectWidth) {
-    this.clipRectWidth = Math.max(0, clipRectWidth);
+    this.clipRectWidth = MathUtils.clamp(clipRectWidth, 0, (int) getWidth());
   }
 
   public void changeClipRectWidth(int clipRectWidth) {
@@ -1176,7 +1176,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   public void setClipRectHeight(int clipRectHeight) {
-    this.clipRectHeight = Math.max(0, clipRectHeight);
+    this.clipRectHeight = MathUtils.clamp(clipRectHeight, 0, (int) getHeight());
   }
 
   public void changeClipRectHeight(int clipRectHeight) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -68,6 +68,20 @@ import org.jetbrains.annotations.Nullable;
  */
 public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, FlixelColorable, FlixelShaderable {
 
+  @Nullable
+  private static ShaderProgram premultipliedShader;
+  @Nullable
+  private static ShaderProgram whiteMixShader;
+
+  /** Shared scratch rectangle for clip rect bounds; reused across all sprite draw calls. */
+  private static final Rectangle tempClipBounds = new Rectangle();
+
+  /** Shared scratch rectangle for scissor pixel coordinates; reused across all sprite draw calls. */
+  private static final Rectangle tempScissors = new Rectangle();
+
+  private static boolean blendMinMaxChecked;
+  private static boolean blendMinMaxSupported;
+
   /** Graphic backing this sprite (shared/cached wrapper around a Texture). */
   @Nullable
   protected FlixelGraphic graphic;
@@ -132,20 +146,6 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   @NotNull
   private FlixelBlendMode blendMode = FlixelBlendMode.NORMAL;
 
-  @Nullable
-  private static ShaderProgram premultipliedShader;
-  @Nullable
-  private static ShaderProgram whiteMixShader;
-
-  /** Shared scratch rectangle for clip rect bounds; reused across all sprite draw calls. */
-  private static final Rectangle tempClipBounds = new Rectangle();
-
-  /** Shared scratch rectangle for scissor pixel coordinates; reused across all sprite draw calls. */
-  private static final Rectangle tempScissors = new Rectangle();
-
-  private static boolean blendMinMaxChecked;
-  private static boolean blendMinMaxSupported;
-
   /** The direction this sprite is facing. Useful for automatic flipping. */
   protected int facing = FlixelDirectionFlags.RIGHT;
 
@@ -153,25 +153,25 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
    * X offset of the clip rectangle's left edge, in screen pixels from the sprite's drawn left edge.
    * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
-  private int clipRectX;
+  private float clipRectX;
 
   /**
    * Y offset of the clip rectangle's bottom edge, in screen pixels from the sprite's drawn bottom edge.
    * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
-  private int clipRectY;
+  private float clipRectY;
 
   /**
    * Width of the visible clip rectangle, in screen pixels. Active only when
    * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
-  private int clipRectWidth;
+  private float clipRectWidth;
 
   /**
    * Height of the visible clip rectangle, in screen pixels. Active only when
    * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
-  private int clipRectHeight;
+  private float clipRectHeight;
 
   /**
    * The shader applied to this sprite individually, or {@code null} for no per-sprite effect.
@@ -1135,51 +1135,51 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     clipRectEnabled = false;
   }
 
-  public int getClipRectX() {
+  public float getClipRectX() {
     return clipRectX;
   }
 
-  public void setClipRectX(int clipRectX) {
+  public void setClipRectX(float clipRectX) {
     this.clipRectX = clipRectX;
   }
 
-  public void changeClipRectX(int clipRectX) {
+  public void changeClipRectX(float clipRectX) {
     this.clipRectX += clipRectX;
   }
 
-  public int getClipRectY() {
+  public float getClipRectY() {
     return clipRectY;
   }
 
-  public void setClipRectY(int clipRectY) {
+  public void setClipRectY(float clipRectY) {
     this.clipRectY = clipRectY;
   }
 
-  public void changeClipRectY(int clipRectY) {
+  public void changeClipRectY(float clipRectY) {
     this.clipRectY += clipRectY;
   }
 
-  public int getClipRectWidth() {
+  public float getClipRectWidth() {
     return clipRectWidth;
   }
 
-  public void setClipRectWidth(int clipRectWidth) {
+  public void setClipRectWidth(float clipRectWidth) {
     this.clipRectWidth = MathUtils.clamp(clipRectWidth, 0, (int) getWidth());
   }
 
-  public void changeClipRectWidth(int clipRectWidth) {
+  public void changeClipRectWidth(float clipRectWidth) {
     setClipRectWidth(this.clipRectWidth + clipRectWidth);
   }
 
-  public int getClipRectHeight() {
+  public float getClipRectHeight() {
     return clipRectHeight;
   }
 
-  public void setClipRectHeight(int clipRectHeight) {
+  public void setClipRectHeight(float clipRectHeight) {
     this.clipRectHeight = MathUtils.clamp(clipRectHeight, 0, (int) getHeight());
   }
 
-  public void changeClipRectHeight(int clipRectHeight) {
+  public void changeClipRectHeight(float clipRectHeight) {
     setClipRectHeight(this.clipRectHeight + clipRectHeight);
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -150,25 +150,25 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   protected int facing = FlixelDirectionFlags.RIGHT;
 
   /**
-   * X offset of the clip rectangle's left edge, in unscaled sprite-local pixels. Active only when
-   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   * X offset of the clip rectangle's left edge, in screen pixels from the sprite's drawn left edge.
+   * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
   private int clipRectX;
 
   /**
-   * Y offset of the clip rectangle's bottom edge, in unscaled sprite-local pixels. Active only when
-   * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
+   * Y offset of the clip rectangle's bottom edge, in screen pixels from the sprite's drawn bottom edge.
+   * Active only when {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
   private int clipRectY;
 
   /**
-   * Width of the visible clip rectangle, in unscaled sprite-local pixels. Active only when
+   * Width of the visible clip rectangle, in screen pixels. Active only when
    * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
   private int clipRectWidth;
 
   /**
-   * Height of the visible clip rectangle, in unscaled sprite-local pixels. Active only when
+   * Height of the visible clip rectangle, in screen pixels. Active only when
    * {@link #clipRectEnabled} is {@code true}; see {@link #setClipRect(int, int, int, int)}.
    */
   private int clipRectHeight;
@@ -616,10 +616,10 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     if (clipEnabled) {
       // Flush before changing scissor state so previously batched sprites are not retroactively clipped.
       batch.flush();
-      float clipScreenX = wx + offsetX + clipRectX * Math.abs(scaleX);
-      float clipScreenY = wy + offsetY + clipRectY * Math.abs(scaleY);
-      float clipScreenW = clipRectWidth * Math.abs(scaleX);
-      float clipScreenH = clipRectHeight * Math.abs(scaleY);
+      float clipScreenX = wx + offsetX + clipRectX;
+      float clipScreenY = wy + offsetY + clipRectY;
+      float clipScreenW = clipRectWidth;
+      float clipScreenH = clipRectHeight;
       tempClipBounds.set(clipScreenX, clipScreenY, clipScreenW, clipScreenH);
       ScissorStack.calculateScissors(
           cam.getCamera(),
@@ -1095,29 +1095,28 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   /**
-   * Sets the clip rectangle in sprite-local pixel space and enables clipping.
+   * Sets the clip rectangle in screen-pixel space relative to the sprite's drawn position, and enables clipping.
    *
    * <p>Only the region inside the rectangle is drawn; pixels outside are discarded by the GPU
-   * scissor. The origin is the sprite's bottom-left corner before scale, so {@code x=0, y=0}
-   * anchors to the bottom-left of the frame. Moving {@code x} or {@code y} slides the visible
-   * window without changing the sprite's world position, which is the key difference from the
-   * old crop-from-edge approach.
+   * scissor. Coordinates are in the same units as {@link #getWidth()}/{@link #getHeight()} - that
+   * is, they already account for scale - so {@code x=0, y=0} anchors to the drawn bottom-left
+   * corner and {@code width=(int)getWidth()} covers the full drawn width regardless of scale.
    *
-   * <p>For example, to show only the center quarter of a 100x100 sprite:
+   * <p>For example, to show only the left half of a sprite regardless of its current scale:
    * <pre>{@code
-   * sprite.setClipRect(25, 25, 50, 50);
+   * sprite.setClipRect(0, 0, (int)(sprite.getWidth() * 0.5f), (int)sprite.getHeight());
    * // Slide the window right by 10 px later:
-   * sprite.setClipRectX(35);
+   * sprite.setClipRectX(10);
    * // Remove clipping:
    * sprite.clearClipRect();
    * }</pre>
    *
    * <p>Disable clipping with {@link #clearClipRect()}.
    *
-   * @param x Left edge of the visible region, in unscaled sprite-local pixels.
-   * @param y Bottom edge of the visible region, in unscaled sprite-local pixels.
-   * @param width Width of the visible region, in unscaled sprite-local pixels.
-   * @param height Height of the visible region, in unscaled sprite-local pixels.
+   * @param x Left edge of the visible region, in screen pixels from the sprite's drawn left edge.
+   * @param y Bottom edge of the visible region, in screen pixels from the sprite's drawn bottom edge.
+   * @param width Width of the visible region, in screen pixels.
+   * @param height Height of the visible region, in screen pixels.
    */
   public void setClipRect(int x, int y, int width, int height) {
     clipRectX = x;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -25,6 +25,7 @@ package org.flixelgdx.input.action;
 
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -98,6 +99,8 @@ public final class FlixelActionAnalog extends FlixelAction {
   private float flickThreshold = 0.3f;
 
   private final Array<FlixelAnalogBinding> bindings = new Array<>(12);
+  @Nullable
+  private ObjectMap<String, FlixelAnalogBinding> namedBindings;
 
   private final Vector2 scratch = new Vector2();
 
@@ -117,12 +120,101 @@ public final class FlixelActionAnalog extends FlixelAction {
   }
 
   /**
-   * Adds a binding evaluated each frame (allocation-free after this call).
+   * Removes all bindings from this action, including any registered under named slots.
+   *
+   * <p>Use this before re-populating bindings from scratch, or to leave an action with no active
+   * sources (it will produce a zero vector until at least one binding is added again).
+   */
+  public void clearBindings() {
+    bindings.clear();
+    if (namedBindings != null) {
+      namedBindings.clear();
+    }
+  }
+
+  /**
+   * Adds an unnamed binding evaluated each frame (allocation-free after this call).
+   *
+   * <p>Each binding contributes to a shared accumulator; the sum is clamped to a maximum length
+   * of {@code 1}. Prefer {@link #addBinding(String, FlixelAnalogBinding)} when you need to replace
+   * or remove this binding later (for example, a rebinding screen).
    *
    * @param binding Non-null binding.
    */
   public void addBinding(@NotNull FlixelAnalogBinding binding) {
     bindings.add(binding);
+  }
+
+  /**
+   * Adds a binding under a named slot (allocation-free after this call).
+   *
+   * <p>If a binding is already registered under {@code slot}, it is removed and replaced. Named
+   * slots are the natural model for a rebinding screen: one slot per axis or device, replaced
+   * in-place when the player picks a new key or stick.
+   *
+   * <pre>{@code
+   * move.addBinding("leftKey",  FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
+   * move.addBinding("rightKey", FlixelAnalogBinding.posXKey(Input.Keys.RIGHT));
+   * move.addBinding("stick",    FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
+   *
+   * // Player rebinds the left key at runtime.
+   * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(newKey));
+   * }</pre>
+   *
+   * @param slot    Non-null, non-empty identifier for this binding (for example {@code "leftKey"}).
+   * @param binding Non-null binding.
+   */
+  public void addBinding(@NotNull String slot, @NotNull FlixelAnalogBinding binding) {
+    if (namedBindings == null) {
+      namedBindings = new ObjectMap<>(4);
+    }
+    FlixelAnalogBinding old = namedBindings.put(slot, binding);
+    if (old != null) {
+      bindings.removeValue(old, true);
+    }
+    bindings.add(binding);
+  }
+
+  /**
+   * Removes the binding registered under the given slot name.
+   *
+   * @param slot Slot name passed to {@link #addBinding(String, FlixelAnalogBinding)}.
+   * @return {@code true} if a binding was found and removed, {@code false} if the slot was unknown.
+   */
+  public boolean removeBinding(@NotNull String slot) {
+    if (namedBindings == null) {
+      return false;
+    }
+    FlixelAnalogBinding old = namedBindings.remove(slot);
+    if (old == null) {
+      return false;
+    }
+    bindings.removeValue(old, true);
+    return true;
+  }
+
+  /**
+   * Removes a specific binding by reference identity.
+   *
+   * <p>If the binding was added via {@link #addBinding(String, FlixelAnalogBinding)}, its slot
+   * entry is also cleared.
+   *
+   * @param binding The exact binding instance to remove.
+   * @return {@code true} if the binding was found and removed.
+   */
+  public boolean removeBinding(@NotNull FlixelAnalogBinding binding) {
+    boolean removed = bindings.removeValue(binding, true);
+    if (removed && namedBindings != null) {
+      ObjectMap.Keys<String> keys = namedBindings.keys();
+      while (keys.hasNext()) {
+        String key = keys.next();
+        if (namedBindings.get(key) == binding) {
+          namedBindings.remove(key);
+          break;
+        }
+      }
+    }
+    return removed;
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -189,11 +189,6 @@ public final class FlixelActionAnalog extends FlixelAction {
    * Returns the binding registered under the given slot name, or {@code null} if the slot is
    * unknown.
    *
-   * <p>The primary use is a rebinding screen that needs to read the currently active binding in
-   * order to display it. Note that a {@link FlixelAnalogBinding} is a functional interface, so the
-   * returned instance is only meaningful when compared by reference or when your code holds a
-   * separate record of what the binding represents (for example, a keycode stored alongside it).
-   *
    * @param slot Slot name passed to {@link #addBinding(String, FlixelAnalogBinding)}.
    * @return The registered binding, or {@code null} if no binding is registered under that slot.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -136,8 +136,8 @@ public final class FlixelActionAnalog extends FlixelAction {
    * in-place when the player picks a new key or stick.
    *
    * <pre>{@code
-   * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(FlixelKeys.LEFT));
-   * move.addBinding("rightKey", FlixelAnalogBinding.posXKey(FlixelKeys.RIGHT));
+   * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(FlixelKey.LEFT));
+   * move.addBinding("rightKey", FlixelAnalogBinding.posXKey(FlixelKey.RIGHT));
    * move.addBinding("stick", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
    *
    * // Player rebinds the left key at runtime.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -46,12 +46,12 @@ import org.jetbrains.annotations.Nullable;
  *
  * <pre>{@code
  * move = new FlixelActionAnalog("move");
- * move.addBinding(FlixelAnalogBinding.negXKey(FlixelKey.LEFT));
- * move.addBinding(FlixelAnalogBinding.posXKey(FlixelKey.RIGHT));
- * move.addBinding(FlixelAnalogBinding.negYKey(FlixelKey.DOWN));
- * move.addBinding(FlixelAnalogBinding.posYKey(FlixelKey.UP));
- * move.addBinding(FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
- * move.addBinding(FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
+ * move.addBinding("negX",  FlixelAnalogBinding.negXKey(FlixelKey.LEFT));
+ * move.addBinding("posX",  FlixelAnalogBinding.posXKey(FlixelKey.RIGHT));
+ * move.addBinding("negY",  FlixelAnalogBinding.negYKey(FlixelKey.DOWN));
+ * move.addBinding("posY",  FlixelAnalogBinding.posYKey(FlixelKey.UP));
+ * move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
+ * move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
  * }</pre>
  *
  * <h2>Reading</h2>
@@ -130,19 +130,6 @@ public final class FlixelActionAnalog extends FlixelAction {
     if (namedBindings != null) {
       namedBindings.clear();
     }
-  }
-
-  /**
-   * Adds an unnamed binding evaluated each frame (allocation-free after this call).
-   *
-   * <p>Each binding contributes to a shared accumulator; the sum is clamped to a maximum length
-   * of {@code 1}. Prefer {@link #addBinding(String, FlixelAnalogBinding)} when you need to replace
-   * or remove this binding later (for example, a rebinding screen).
-   *
-   * @param binding Non-null binding.
-   */
-  public void addBinding(@NotNull FlixelAnalogBinding binding) {
-    bindings.add(binding);
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -140,15 +140,15 @@ public final class FlixelActionAnalog extends FlixelAction {
    * in-place when the player picks a new key or stick.
    *
    * <pre>{@code
-   * move.addBinding("leftKey",  FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
+   * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
    * move.addBinding("rightKey", FlixelAnalogBinding.posXKey(Input.Keys.RIGHT));
-   * move.addBinding("stick",    FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
+   * move.addBinding("stick", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
    *
    * // Player rebinds the left key at runtime.
    * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(newKey));
    * }</pre>
    *
-   * @param slot    Non-null, non-empty identifier for this binding (for example {@code "leftKey"}).
+   * @param slot Non-null, non-empty identifier for this binding (for example {@code "leftKey"}).
    * @param binding Non-null binding.
    */
   public void addBinding(@NotNull String slot, @NotNull FlixelAnalogBinding binding) {
@@ -178,6 +178,23 @@ public final class FlixelActionAnalog extends FlixelAction {
     }
     bindings.removeValue(old, true);
     return true;
+  }
+
+  /**
+   * Returns the binding registered under the given slot name, or {@code null} if the slot is
+   * unknown.
+   *
+   * <p>The primary use is a rebinding screen that needs to read the currently active binding in
+   * order to display it. Note that a {@link FlixelAnalogBinding} is a functional interface, so the
+   * returned instance is only meaningful when compared by reference or when your code holds a
+   * separate record of what the binding represents (for example, a keycode stored alongside it).
+   *
+   * @param slot Slot name passed to {@link #addBinding(String, FlixelAnalogBinding)}.
+   * @return The registered binding, or {@code null} if no binding is registered under that slot.
+   */
+  @Nullable
+  public FlixelAnalogBinding getBinding(@NotNull String slot) {
+    return namedBindings != null ? namedBindings.get(slot) : null;
   }
 
   /**

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -47,10 +47,10 @@ import java.util.Objects;
  *
  * <pre>{@code
  * move = new FlixelActionAnalog("move");
- * move.addBinding("negX",  FlixelAnalogBinding.negXKey(FlixelKey.LEFT));
- * move.addBinding("posX",  FlixelAnalogBinding.posXKey(FlixelKey.RIGHT));
- * move.addBinding("negY",  FlixelAnalogBinding.negYKey(FlixelKey.DOWN));
- * move.addBinding("posY",  FlixelAnalogBinding.posYKey(FlixelKey.UP));
+ * move.addBinding("negX", FlixelAnalogBinding.negXKey(FlixelKey.LEFT));
+ * move.addBinding("posX", FlixelAnalogBinding.posXKey(FlixelKey.RIGHT));
+ * move.addBinding("negY", FlixelAnalogBinding.negYKey(FlixelKey.DOWN));
+ * move.addBinding("posY", FlixelAnalogBinding.posYKey(FlixelKey.UP));
  * move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
  * move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
  * }</pre>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -24,11 +24,12 @@
 package org.flixelgdx.input.action;
 
 import com.badlogic.gdx.math.Vector2;
-import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ObjectMap;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * Two-axis vector built from {@link FlixelAnalogBinding} contributors plus optional Steam analog
@@ -98,9 +99,7 @@ public final class FlixelActionAnalog extends FlixelAction {
    */
   private float flickThreshold = 0.3f;
 
-  private final Array<FlixelAnalogBinding> bindings = new Array<>(12);
-  @Nullable
-  private ObjectMap<String, FlixelAnalogBinding> namedBindings;
+  private final ObjectMap<String, FlixelAnalogBinding> namedBindings = new ObjectMap<>(12);
 
   private final Vector2 scratch = new Vector2();
 
@@ -120,16 +119,13 @@ public final class FlixelActionAnalog extends FlixelAction {
   }
 
   /**
-   * Removes all bindings from this action, including any registered under named slots.
+   * Removes all bindings from this action.
    *
    * <p>Use this before re-populating bindings from scratch, or to leave an action with no active
    * sources (it will produce a zero vector until at least one binding is added again).
    */
   public void clearBindings() {
-    bindings.clear();
-    if (namedBindings != null) {
-      namedBindings.clear();
-    }
+    namedBindings.clear();
   }
 
   /**
@@ -140,8 +136,8 @@ public final class FlixelActionAnalog extends FlixelAction {
    * in-place when the player picks a new key or stick.
    *
    * <pre>{@code
-   * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
-   * move.addBinding("rightKey", FlixelAnalogBinding.posXKey(Input.Keys.RIGHT));
+   * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(FlixelKeys.LEFT));
+   * move.addBinding("rightKey", FlixelAnalogBinding.posXKey(FlixelKeys.RIGHT));
    * move.addBinding("stick", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
    *
    * // Player rebinds the left key at runtime.
@@ -152,14 +148,9 @@ public final class FlixelActionAnalog extends FlixelAction {
    * @param binding Non-null binding.
    */
   public void addBinding(@NotNull String slot, @NotNull FlixelAnalogBinding binding) {
-    if (namedBindings == null) {
-      namedBindings = new ObjectMap<>(4);
-    }
-    FlixelAnalogBinding old = namedBindings.put(slot, binding);
-    if (old != null) {
-      bindings.removeValue(old, true);
-    }
-    bindings.add(binding);
+    var s = Objects.requireNonNull(slot, "slot cannot be null.");
+    var b = Objects.requireNonNull(binding, "binding cannot be null.");
+    namedBindings.put(s, b);
   }
 
   /**
@@ -169,15 +160,29 @@ public final class FlixelActionAnalog extends FlixelAction {
    * @return {@code true} if a binding was found and removed, {@code false} if the slot was unknown.
    */
   public boolean removeBinding(@NotNull String slot) {
-    if (namedBindings == null) {
-      return false;
+    FlixelAnalogBinding old = namedBindings.remove(Objects.requireNonNull(slot, "slot cannot be null."));
+    return old != null;
+  }
+
+  /**
+   * Removes a specific binding by reference identity.
+   *
+   * <p>If the binding was added via {@link #addBinding(String, FlixelAnalogBinding)}, its slot
+   * entry is also cleared.
+   *
+   * @param binding The exact binding instance to remove.
+   * @return {@code true} if the binding was found and removed.
+   */
+  public boolean removeBinding(@NotNull FlixelAnalogBinding binding) {
+    ObjectMap.Keys<String> keys = namedBindings.keys();
+    while (keys.hasNext()) {
+      String key = keys.next();
+      if (namedBindings.get(key) == binding) {
+        keys.remove();
+        return true;
+      }
     }
-    FlixelAnalogBinding old = namedBindings.remove(slot);
-    if (old == null) {
-      return false;
-    }
-    bindings.removeValue(old, true);
-    return true;
+    return false;
   }
 
   /**
@@ -194,31 +199,7 @@ public final class FlixelActionAnalog extends FlixelAction {
    */
   @Nullable
   public FlixelAnalogBinding getBinding(@NotNull String slot) {
-    return namedBindings != null ? namedBindings.get(slot) : null;
-  }
-
-  /**
-   * Removes a specific binding by reference identity.
-   *
-   * <p>If the binding was added via {@link #addBinding(String, FlixelAnalogBinding)}, its slot
-   * entry is also cleared.
-   *
-   * @param binding The exact binding instance to remove.
-   * @return {@code true} if the binding was found and removed.
-   */
-  public boolean removeBinding(@NotNull FlixelAnalogBinding binding) {
-    boolean removed = bindings.removeValue(binding, true);
-    if (removed && namedBindings != null) {
-      ObjectMap.Keys<String> keys = namedBindings.keys();
-      while (keys.hasNext()) {
-        String key = keys.next();
-        if (namedBindings.get(key) == binding) {
-          namedBindings.remove(key);
-          break;
-        }
-      }
-    }
-    return removed;
+    return namedBindings.get(Objects.requireNonNull(slot, "slot cannot be null."));
   }
 
   @Override
@@ -233,8 +214,9 @@ public final class FlixelActionAnalog extends FlixelAction {
       return;
     }
     scratch.set(0f, 0f);
-    for (int i = 0, n = bindings.size; i < n; i++) {
-      bindings.get(i).accumulate(scratch);
+    ObjectMap.Values<FlixelAnalogBinding> vals = namedBindings.values();
+    while (vals.hasNext()) {
+      vals.next().accumulate(scratch);
     }
     FlixelSteamActionReader steam = owner != null ? owner.steamReader : null;
     if (steam != null) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -97,13 +97,13 @@ public final class FlixelActionDigital extends FlixelAction {
    *
    * <pre>{@code
    * jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.SPACE));
-   * jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
+   * jump.addBinding("gamepad", FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
    *
    * // Player rebinds the keyboard slot at runtime.
    * jump.addBinding("keyboard", FlixelDigitalBinding.key(newKey));
    * }</pre>
    *
-   * @param slot    Non-null, non-empty identifier for this binding (for example {@code "keyboard"}).
+   * @param slot Non-null, non-empty identifier for this binding (for example {@code "keyboard"}).
    * @param binding Non-null binding.
    */
   public void addBinding(@NotNull String slot, @NotNull FlixelDigitalBinding binding) {
@@ -125,11 +125,6 @@ public final class FlixelActionDigital extends FlixelAction {
   /**
    * Returns the binding registered under the given slot name, or {@code null} if the slot is
    * unknown.
-   *
-   * <p>The primary use is a rebinding screen that needs to read the currently active binding in
-   * order to display it. Note that a {@link FlixelDigitalBinding} is a functional interface, so the
-   * returned instance is only meaningful when compared by reference or when your code holds a
-   * separate record of what the binding represents (for example, a keycode stored alongside it).
    *
    * @param slot Slot name passed to {@link #addBinding(String, FlixelDigitalBinding)}.
    * @return The registered binding, or {@code null} if no binding is registered under that slot.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -23,11 +23,12 @@
  */
 package org.flixelgdx.input.action;
 
-import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.ObjectMap;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
 
 /**
  * Boolean action: any {@link FlixelDigitalBinding} that evaluates true, OR optional Steam digital
@@ -35,9 +36,9 @@ import org.jetbrains.annotations.Nullable;
  *
  * <h2>Setup</h2>
  *
- * <p>Call {@link #addBinding(FlixelDigitalBinding)} only during construction or loading (not each
- * frame). Multiple bindings are OR'd: a {@code jump} action might accept Space, gamepad A, and a
- * touch region.
+ * <p>Add bindings via {@link #addBinding(String, FlixelDigitalBinding)} during construction or
+ * loading (not each frame). Multiple bindings are OR'd: a {@code jump} action might accept Space,
+ * gamepad A, and a touch region, each under its own named slot.
  *
  * <h2>Reading in gameplay</h2>
  *
@@ -64,9 +65,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public final class FlixelActionDigital extends FlixelAction {
 
-  private final Array<FlixelDigitalBinding> bindings = new Array<>(8);
-  @Nullable
-  private ObjectMap<String, FlixelDigitalBinding> namedBindings;
+  private final ObjectMap<String, FlixelDigitalBinding> namedBindings = new ObjectMap<>(8);
 
   private float holdAccum;
 
@@ -86,10 +85,7 @@ public final class FlixelActionDigital extends FlixelAction {
    * sources (it will never fire until at least one binding is added again).
    */
   public void clearBindings() {
-    bindings.clear();
-    if (namedBindings != null) {
-      namedBindings.clear();
-    }
+    namedBindings.clear();
   }
 
   /**
@@ -111,14 +107,9 @@ public final class FlixelActionDigital extends FlixelAction {
    * @param binding Non-null binding.
    */
   public void addBinding(@NotNull String slot, @NotNull FlixelDigitalBinding binding) {
-    if (namedBindings == null) {
-      namedBindings = new ObjectMap<>(4);
-    }
-    FlixelDigitalBinding old = namedBindings.put(slot, binding);
-    if (old != null) {
-      bindings.removeValue(old, true);
-    }
-    bindings.add(binding);
+    namedBindings.put(
+        Objects.requireNonNull(slot, "slot cannot be null."),
+        Objects.requireNonNull(binding, "binding cannot be null."));
   }
 
   /**
@@ -128,15 +119,7 @@ public final class FlixelActionDigital extends FlixelAction {
    * @return {@code true} if a binding was found and removed, {@code false} if the slot was unknown.
    */
   public boolean removeBinding(@NotNull String slot) {
-    if (namedBindings == null) {
-      return false;
-    }
-    FlixelDigitalBinding old = namedBindings.remove(slot);
-    if (old == null) {
-      return false;
-    }
-    bindings.removeValue(old, true);
-    return true;
+    return namedBindings.remove(Objects.requireNonNull(slot, "slot cannot be null.")) != null;
   }
 
   /**
@@ -153,7 +136,7 @@ public final class FlixelActionDigital extends FlixelAction {
    */
   @Nullable
   public FlixelDigitalBinding getBinding(@NotNull String slot) {
-    return namedBindings != null ? namedBindings.get(slot) : null;
+    return namedBindings.get(Objects.requireNonNull(slot, "slot cannot be null."));
   }
 
   /**
@@ -166,18 +149,15 @@ public final class FlixelActionDigital extends FlixelAction {
    * @return {@code true} if the binding was found and removed.
    */
   public boolean removeBinding(@NotNull FlixelDigitalBinding binding) {
-    boolean removed = bindings.removeValue(binding, true);
-    if (removed && namedBindings != null) {
-      ObjectMap.Keys<String> keys = namedBindings.keys();
-      while (keys.hasNext()) {
-        String key = keys.next();
-        if (namedBindings.get(key) == binding) {
-          namedBindings.remove(key);
-          break;
-        }
+    ObjectMap.Keys<String> keys = namedBindings.keys();
+    while (keys.hasNext()) {
+      String key = keys.next();
+      if (namedBindings.get(key) == binding) {
+        keys.remove();
+        return true;
       }
     }
-    return removed;
+    return false;
   }
 
   @Override
@@ -194,8 +174,9 @@ public final class FlixelActionDigital extends FlixelAction {
     if (steam != null && steam.getDigital(getName())) {
       v = true;
     }
-    for (int i = 0, n = bindings.size; i < n; i++) {
-      v |= bindings.get(i).evaluate();
+    ObjectMap.Values<FlixelDigitalBinding> vals = namedBindings.values();
+    while (vals.hasNext()) {
+      v |= vals.next().evaluate();
     }
     boolean edge = v && !previous;
     Runnable cb = callback;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -96,7 +96,7 @@ public final class FlixelActionDigital extends FlixelAction {
    * in-place when the player picks a new key.
    *
    * <pre>{@code
-   * jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.SPACE));
+   * jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKeys.SPACE));
    * jump.addBinding("gamepad", FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
    *
    * // Player rebinds the keyboard slot at runtime.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -93,19 +93,6 @@ public final class FlixelActionDigital extends FlixelAction {
   }
 
   /**
-   * Adds an unnamed binding evaluated each frame (allocation-free after this call).
-   *
-   * <p>Multiple bindings are OR'd: the action fires if any one returns {@code true}. Prefer
-   * {@link #addBinding(String, FlixelDigitalBinding)} when you need to replace or remove this
-   * binding later (for example, a rebinding screen).
-   *
-   * @param binding Non-null binding.
-   */
-  public void addBinding(@NotNull FlixelDigitalBinding binding) {
-    bindings.add(binding);
-  }
-
-  /**
    * Adds a binding under a named slot (allocation-free after this call).
    *
    * <p>If a binding is already registered under {@code slot}, it is removed and replaced. This

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -24,6 +24,7 @@
 package org.flixelgdx.input.action;
 
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.ObjectMap;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -64,6 +65,8 @@ import org.jetbrains.annotations.Nullable;
 public final class FlixelActionDigital extends FlixelAction {
 
   private final Array<FlixelDigitalBinding> bindings = new Array<>(8);
+  @Nullable
+  private ObjectMap<String, FlixelDigitalBinding> namedBindings;
 
   private float holdAccum;
 
@@ -77,12 +80,100 @@ public final class FlixelActionDigital extends FlixelAction {
   }
 
   /**
-   * Adds a binding evaluated each frame (allocation-free after this call).
+   * Removes all bindings from this action, including any registered under named slots.
+   *
+   * <p>Use this before re-populating bindings from scratch, or to leave an action with no active
+   * sources (it will never fire until at least one binding is added again).
+   */
+  public void clearBindings() {
+    bindings.clear();
+    if (namedBindings != null) {
+      namedBindings.clear();
+    }
+  }
+
+  /**
+   * Adds an unnamed binding evaluated each frame (allocation-free after this call).
+   *
+   * <p>Multiple bindings are OR'd: the action fires if any one returns {@code true}. Prefer
+   * {@link #addBinding(String, FlixelDigitalBinding)} when you need to replace or remove this
+   * binding later (for example, a rebinding screen).
    *
    * @param binding Non-null binding.
    */
   public void addBinding(@NotNull FlixelDigitalBinding binding) {
     bindings.add(binding);
+  }
+
+  /**
+   * Adds a binding under a named slot (allocation-free after this call).
+   *
+   * <p>If a binding is already registered under {@code slot}, it is removed and replaced. This
+   * makes named slots the natural model for a rebinding screen: one slot per device type, replaced
+   * in-place when the player picks a new key.
+   *
+   * <pre>{@code
+   * jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.SPACE));
+   * jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
+   *
+   * // Player rebinds the keyboard slot at runtime.
+   * jump.addBinding("keyboard", FlixelDigitalBinding.key(newKey));
+   * }</pre>
+   *
+   * @param slot    Non-null, non-empty identifier for this binding (for example {@code "keyboard"}).
+   * @param binding Non-null binding.
+   */
+  public void addBinding(@NotNull String slot, @NotNull FlixelDigitalBinding binding) {
+    if (namedBindings == null) {
+      namedBindings = new ObjectMap<>(4);
+    }
+    FlixelDigitalBinding old = namedBindings.put(slot, binding);
+    if (old != null) {
+      bindings.removeValue(old, true);
+    }
+    bindings.add(binding);
+  }
+
+  /**
+   * Removes the binding registered under the given slot name.
+   *
+   * @param slot Slot name passed to {@link #addBinding(String, FlixelDigitalBinding)}.
+   * @return {@code true} if a binding was found and removed, {@code false} if the slot was unknown.
+   */
+  public boolean removeBinding(@NotNull String slot) {
+    if (namedBindings == null) {
+      return false;
+    }
+    FlixelDigitalBinding old = namedBindings.remove(slot);
+    if (old == null) {
+      return false;
+    }
+    bindings.removeValue(old, true);
+    return true;
+  }
+
+  /**
+   * Removes a specific binding by reference identity.
+   *
+   * <p>If the binding was added via {@link #addBinding(String, FlixelDigitalBinding)}, its slot
+   * entry is also cleared.
+   *
+   * @param binding The exact binding instance to remove.
+   * @return {@code true} if the binding was found and removed.
+   */
+  public boolean removeBinding(@NotNull FlixelDigitalBinding binding) {
+    boolean removed = bindings.removeValue(binding, true);
+    if (removed && namedBindings != null) {
+      ObjectMap.Keys<String> keys = namedBindings.keys();
+      while (keys.hasNext()) {
+        String key = keys.next();
+        if (namedBindings.get(key) == binding) {
+          namedBindings.remove(key);
+          break;
+        }
+      }
+    }
+    return removed;
   }
 
   @Override

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -140,6 +140,23 @@ public final class FlixelActionDigital extends FlixelAction {
   }
 
   /**
+   * Returns the binding registered under the given slot name, or {@code null} if the slot is
+   * unknown.
+   *
+   * <p>The primary use is a rebinding screen that needs to read the currently active binding in
+   * order to display it. Note that a {@link FlixelDigitalBinding} is a functional interface, so the
+   * returned instance is only meaningful when compared by reference or when your code holds a
+   * separate record of what the binding represents (for example, a keycode stored alongside it).
+   *
+   * @param slot Slot name passed to {@link #addBinding(String, FlixelDigitalBinding)}.
+   * @return The registered binding, or {@code null} if no binding is registered under that slot.
+   */
+  @Nullable
+  public FlixelDigitalBinding getBinding(@NotNull String slot) {
+    return namedBindings != null ? namedBindings.get(slot) : null;
+  }
+
+  /**
    * Removes a specific binding by reference identity.
    *
    * <p>If the binding was added via {@link #addBinding(String, FlixelDigitalBinding)}, its slot

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -96,7 +96,7 @@ public final class FlixelActionDigital extends FlixelAction {
    * in-place when the player picks a new key.
    *
    * <pre>{@code
-   * jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKeys.SPACE));
+   * jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKey.SPACE));
    * jump.addBinding("gamepad", FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
    *
    * // Player rebinds the keyboard slot at runtime.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
@@ -62,15 +62,15 @@ import org.jetbrains.annotations.Nullable;
  *
  *   public PlayerControls() {
  *     jump = new FlixelActionDigital("jump");
- *     jump.addBinding(FlixelDigitalBinding.key(FlixelKey.SPACE));
- *     jump.addBinding(FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
+ *     jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKey.SPACE));
+ *     jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
  *     add(jump);
  *
  *     move = new FlixelActionAnalog("move");
- *     move.addBinding(FlixelAnalogBinding.negXKey(FlixelKey.A));
- *     move.addBinding(FlixelAnalogBinding.posXKey(FlixelKey.D));
- *     move.addBinding(FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
- *     move.addBinding(FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
+ *     move.addBinding("negX",   FlixelAnalogBinding.negXKey(FlixelKey.A));
+ *     move.addBinding("posX",   FlixelAnalogBinding.posXKey(FlixelKey.D));
+ *     move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
+ *     move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
  *     add(move);
  *   }
  * }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogBinding.java
@@ -39,11 +39,11 @@ import org.flixelgdx.input.gamepad.FlixelGamepadInput;
  * common cases (keyboard halves, gamepad axes). For anything else, pass a plain lambda:
  *
  * <pre>{@code
- * move.addBinding(FlixelAnalogBinding.negXKey(FlixelKey.A));
- * move.addBinding(FlixelAnalogBinding.posXKey(FlixelKey.D));
- * move.addBinding(FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
- * move.addBinding(FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
- * move.addBinding(out -> out.x += myJoystick.getX()); // Custom contributor.
+ * move.addBinding("negX",   FlixelAnalogBinding.negXKey(FlixelKey.A));
+ * move.addBinding("posX",   FlixelAnalogBinding.posXKey(FlixelKey.D));
+ * move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
+ * move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
+ * move.addBinding("custom", out -> out.x += myJoystick.getX());
  * }</pre>
  *
  * <h2>Axis conventions</h2>

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
@@ -40,10 +40,10 @@ import org.flixelgdx.input.touch.FlixelTouch;
  * common cases (keyboard, mouse, gamepad, touch region). For anything else, pass a plain lambda:
  *
  * <pre>{@code
- * jump.addBinding(FlixelDigitalBinding.key(FlixelKey.SPACE));
- * jump.addBinding(FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
- * jump.addBinding(FlixelDigitalBinding.touch(0));          // first finger
- * jump.addBinding(() -> myCustomSensor.isActive());        // custom source
+ * jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKey.SPACE));
+ * jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
+ * jump.addBinding("touch",    FlixelDigitalBinding.touch(0));
+ * jump.addBinding("sensor",   () -> myCustomSensor.isActive());
  * }</pre>
  *
  * @see FlixelActionDigital
@@ -106,7 +106,7 @@ public interface FlixelDigitalBinding {
    *
    * <pre>{@code
    * // Fire while the first finger is down.
-   * shoot.addBinding(FlixelDigitalBinding.touch(0));
+   * shoot.addBinding("touch", FlixelDigitalBinding.touch(0));
    * }</pre>
    *
    * @param pointer Zero-based pointer index (0 = first finger).
@@ -123,7 +123,7 @@ public interface FlixelDigitalBinding {
    *
    * <pre>{@code
    * // Bottom-left quarter of the screen as a virtual jump button.
-   * jump.addBinding(FlixelDigitalBinding.touchRegion(0f, 0.5f, 0.5f, 0.5f));
+   * jump.addBinding("touch", FlixelDigitalBinding.touchRegion(0f, 0.5f, 0.5f, 0.5f));
    * }</pre>
    *
    * @param normX Left edge as a fraction of the back buffer width (0..1).
@@ -171,7 +171,7 @@ public interface FlixelDigitalBinding {
    *
    * <pre>{@code
    * // Virtual jump button occupying the left half of a 480x270 world.
-   * jump.addBinding(FlixelDigitalBinding.touchRegionWorld(0f, 0f, 240f, 270f));
+   * jump.addBinding("touch", FlixelDigitalBinding.touchRegionWorld(0f, 0f, 240f, 270f));
    * }</pre>
    *
    * @param x Left edge in world units.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadManager.java
@@ -29,6 +29,7 @@ import com.badlogic.gdx.controllers.ControllerMapping;
 import com.badlogic.gdx.controllers.Controllers;
 import com.badlogic.gdx.utils.Array;
 
+import org.flixelgdx.FlixelGame;
 import org.flixelgdx.input.FlixelInputManager;
 import org.flixelgdx.util.signal.FlixelSignal;
 import org.jetbrains.annotations.NotNull;
@@ -39,7 +40,7 @@ import java.util.Objects;
 
 /**
  * Global gamepad manager backed by gdx-controllers. Polls controllers each frame and mirrors the
- * keyboard and mouse frame contract from {@link org.flixelgdx.FlixelGame FlixelGame}.
+ * keyboard and mouse frame contract from {@link FlixelGame}.
  *
  * <p>The gamepad system is <strong>disabled by default</strong>. Set {@link #enabled} to {@code true} before the game
  * loop starts to opt in:
@@ -52,7 +53,7 @@ import java.util.Objects;
  * with {@link #pressed(int, int)}; each {@link Controller#getMapping()} supplies native indices.
  * {@link FlixelGamepadDevice} is optional; call {@link #ensureDevice(int)} once per slot you want a facade for.
  */
-public final class FlixelGamepadManager implements FlixelInputManager, ControllerListener {
+public class FlixelGamepadManager implements FlixelInputManager, ControllerListener {
 
   /** Maximum supported simultaneous controllers. */
   public static final int MAX_GAMEPADS = 8;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/timer/FlixelTimerManager.java
@@ -97,10 +97,13 @@ public class FlixelTimerManager extends FlixelBasic {
     if (!active || !exists || !alive) {
       return;
     }
-    if (activeTimers.size == 0) {
+    if (activeTimers.size == 0 || activeTimers.isEmpty()) {
       return;
     }
     for (int i = activeTimers.size - 1; i >= 0; i--) {
+      if (i >= activeTimers.size) {
+        continue;
+      }
       activeTimers.get(i).update(elapsed);
     }
   }

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -60,7 +60,7 @@ class FlixelActionSystemTest {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
     FlixelActionDigital fire = new FlixelActionDigital("fire");
-    fire.addBinding(FlixelDigitalBinding.key(Input.Keys.F));
+    fire.addBinding("key", FlixelDigitalBinding.key(Input.Keys.F));
     set.add(fire);
 
     Flixel.keys.getInputProcessor().keyDown(Input.Keys.F);
@@ -88,8 +88,8 @@ class FlixelActionSystemTest {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
     FlixelActionDigital any = new FlixelActionDigital("any");
-    any.addBinding(FlixelDigitalBinding.key(Input.Keys.A));
-    any.addBinding(FlixelDigitalBinding.key(Input.Keys.B));
+    any.addBinding("a", FlixelDigitalBinding.key(Input.Keys.A));
+    any.addBinding("b", FlixelDigitalBinding.key(Input.Keys.B));
     set.add(any);
 
     Flixel.keys.getInputProcessor().keyDown(Input.Keys.B);
@@ -106,7 +106,7 @@ class FlixelActionSystemTest {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
     FlixelActionDigital zone = new FlixelActionDigital("zone");
-    zone.addBinding(FlixelDigitalBinding.touchRegion(0f, 0f, 0.5f, 0.5f));
+    zone.addBinding("touch", FlixelDigitalBinding.touchRegion(0f, 0f, 0.5f, 0.5f));
     set.add(zone);
     set.update(0f);
     assertFalse(zone.pressed());
@@ -118,7 +118,7 @@ class FlixelActionSystemTest {
     };
     FlixelActionDigital custom = new FlixelActionDigital("custom");
     boolean[] active = { true };
-    custom.addBinding(() -> active[0]);
+    custom.addBinding("lambda", () -> active[0]);
     set.add(custom);
 
     set.update(0f);
@@ -134,10 +134,10 @@ class FlixelActionSystemTest {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
     FlixelActionAnalog move = new FlixelActionAnalog("move");
-    move.addBinding(FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
-    move.addBinding(FlixelAnalogBinding.posXKey(Input.Keys.RIGHT));
-    move.addBinding(FlixelAnalogBinding.negYKey(Input.Keys.DOWN));
-    move.addBinding(FlixelAnalogBinding.posYKey(Input.Keys.UP));
+    move.addBinding("negX", FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
+    move.addBinding("posX", FlixelAnalogBinding.posXKey(Input.Keys.RIGHT));
+    move.addBinding("negY", FlixelAnalogBinding.negYKey(Input.Keys.DOWN));
+    move.addBinding("posY", FlixelAnalogBinding.posYKey(Input.Keys.UP));
     set.add(move);
 
     Flixel.keys.getInputProcessor().keyDown(Input.Keys.RIGHT);
@@ -161,8 +161,8 @@ class FlixelActionSystemTest {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
     FlixelActionAnalog navigate = new FlixelActionAnalog("navigate");
-    navigate.addBinding(FlixelAnalogBinding.negYKey(Input.Keys.DOWN));
-    navigate.addBinding(FlixelAnalogBinding.posYKey(Input.Keys.UP));
+    navigate.addBinding("down", FlixelAnalogBinding.negYKey(Input.Keys.DOWN));
+    navigate.addBinding("up", FlixelAnalogBinding.posYKey(Input.Keys.UP));
     set.add(navigate);
 
     // First press: flicked() fires on the first frame.
@@ -193,7 +193,7 @@ class FlixelActionSystemTest {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
     FlixelActionDigital scroll = new FlixelActionDigital("scroll");
-    scroll.addBinding(FlixelDigitalBinding.key(Input.Keys.DOWN));
+    scroll.addBinding("key", FlixelDigitalBinding.key(Input.Keys.DOWN));
     scroll.setHoldDelay(0.5f);
     scroll.setHoldInterval(0.1f);
     set.add(scroll);
@@ -235,7 +235,7 @@ class FlixelActionSystemTest {
     FlixelActionSet set = new FlixelActionSet(false) {
     };
     FlixelActionAnalog navigate = new FlixelActionAnalog("navigate");
-    navigate.addBinding(FlixelAnalogBinding.negYKey(Input.Keys.DOWN));
+    navigate.addBinding("down", FlixelAnalogBinding.negYKey(Input.Keys.DOWN));
     navigate.setHoldDelay(0.5f);
     navigate.setHoldInterval(0.1f);
     set.add(navigate);
@@ -311,7 +311,7 @@ class FlixelActionSystemTest {
     };
     FlixelActionDigital jump = new FlixelActionDigital("jump");
     FlixelDigitalBinding binding = FlixelDigitalBinding.key(Input.Keys.SPACE);
-    jump.addBinding(binding);
+    jump.addBinding("key", binding);
     set.add(jump);
 
     assertTrue(jump.removeBinding(binding));
@@ -326,7 +326,7 @@ class FlixelActionSystemTest {
     };
     FlixelActionDigital jump = new FlixelActionDigital("jump");
     jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.SPACE));
-    jump.addBinding(FlixelDigitalBinding.key(Input.Keys.ENTER));
+    jump.addBinding("enter", FlixelDigitalBinding.key(Input.Keys.ENTER));
     set.add(jump);
 
     jump.clearBindings();
@@ -376,7 +376,7 @@ class FlixelActionSystemTest {
     };
     FlixelActionAnalog move = new FlixelActionAnalog("move");
     FlixelAnalogBinding binding = FlixelAnalogBinding.posXKey(Input.Keys.RIGHT);
-    move.addBinding(binding);
+    move.addBinding("right", binding);
     set.add(move);
 
     assertTrue(move.removeBinding(binding));

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/action/FlixelActionSystemTest.java
@@ -263,6 +263,144 @@ class FlixelActionSystemTest {
   }
 
   @Test
+  void digitalNamedSlotOverwritesPreviousBinding() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionDigital jump = new FlixelActionDigital("jump");
+    jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.F));
+    jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.G));
+    set.add(jump);
+
+    // Old key (F) must no longer fire.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.F);
+    set.update(0f);
+    assertFalse(jump.pressed());
+
+    // New key (G) must fire.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.G);
+    set.update(0f);
+    assertTrue(jump.pressed());
+  }
+
+  @Test
+  void digitalRemoveBindingBySlotStopsFiring() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionDigital jump = new FlixelActionDigital("jump");
+    jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.SPACE));
+    set.add(jump);
+
+    assertTrue(jump.removeBinding("keyboard"));
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.SPACE);
+    set.update(0f);
+    assertFalse(jump.pressed());
+  }
+
+  @Test
+  void digitalRemoveNonExistentSlotReturnsFalse() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionDigital jump = new FlixelActionDigital("jump");
+    set.add(jump);
+    assertFalse(jump.removeBinding("keyboard"));
+  }
+
+  @Test
+  void digitalRemoveBindingByReferenceStopsFiring() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionDigital jump = new FlixelActionDigital("jump");
+    FlixelDigitalBinding binding = FlixelDigitalBinding.key(Input.Keys.SPACE);
+    jump.addBinding(binding);
+    set.add(jump);
+
+    assertTrue(jump.removeBinding(binding));
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.SPACE);
+    set.update(0f);
+    assertFalse(jump.pressed());
+  }
+
+  @Test
+  void digitalClearBindingsStopsAllFiring() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionDigital jump = new FlixelActionDigital("jump");
+    jump.addBinding("keyboard", FlixelDigitalBinding.key(Input.Keys.SPACE));
+    jump.addBinding(FlixelDigitalBinding.key(Input.Keys.ENTER));
+    set.add(jump);
+
+    jump.clearBindings();
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.SPACE);
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.ENTER);
+    set.update(0f);
+    assertFalse(jump.pressed());
+  }
+
+  @Test
+  void analogNamedSlotOverwritesPreviousBinding() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionAnalog move = new FlixelActionAnalog("move");
+    move.addBinding("left", FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
+    move.addBinding("left", FlixelAnalogBinding.negXKey(Input.Keys.A));
+    set.add(move);
+
+    // Old key (LEFT) must no longer contribute.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.LEFT);
+    set.update(0f);
+    assertEquals(0f, move.getX(), 1e-5f);
+
+    // New key (A) must contribute.
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.A);
+    set.update(0f);
+    assertEquals(-1f, move.getX(), 1e-5f);
+  }
+
+  @Test
+  void analogRemoveBindingBySlotStopsContributing() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionAnalog move = new FlixelActionAnalog("move");
+    move.addBinding("right", FlixelAnalogBinding.posXKey(Input.Keys.RIGHT));
+    set.add(move);
+
+    assertTrue(move.removeBinding("right"));
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.RIGHT);
+    set.update(0f);
+    assertEquals(0f, move.getX(), 1e-5f);
+  }
+
+  @Test
+  void analogRemoveBindingByReferenceStopsContributing() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionAnalog move = new FlixelActionAnalog("move");
+    FlixelAnalogBinding binding = FlixelAnalogBinding.posXKey(Input.Keys.RIGHT);
+    move.addBinding(binding);
+    set.add(move);
+
+    assertTrue(move.removeBinding(binding));
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.RIGHT);
+    set.update(0f);
+    assertEquals(0f, move.getX(), 1e-5f);
+  }
+
+  @Test
+  void analogClearBindingsStopsAllContributions() {
+    FlixelActionSet set = new FlixelActionSet(false) {
+    };
+    FlixelActionAnalog move = new FlixelActionAnalog("move");
+    move.addBinding("left", FlixelAnalogBinding.negXKey(Input.Keys.LEFT));
+    move.addBinding("right", FlixelAnalogBinding.posXKey(Input.Keys.RIGHT));
+    set.add(move);
+
+    move.clearBindings();
+    Flixel.keys.getInputProcessor().keyDown(Input.Keys.RIGHT);
+    set.update(0f);
+    assertEquals(0f, move.getX(), 1e-5f);
+  }
+
+  @Test
   void steamReaderMergesDigital() {
     FlixelActionSet set = new FlixelActionSet(false) {
     };


### PR DESCRIPTION
## Description

Adds three binding removal methods to both `FlixelActionDigital` and `FlixelActionAnalog`, primarily motivated by rebinding screen use cases.

This also removes the old pure-binding system and now enforces the new named system. Developers should keep their code organized with named binds anyways.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

9 new tests added to `FlixelActionSystemTest` covering: named slot overwrite, remove by slot, remove by reference, clear all, and the `false` return for an unknown slot - for both digital and analog action types. All 17 tests pass.