### PR TITLE
Added firstPressed, firstJustPressed, and firstJustReleased to the gamepad manager

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -50,8 +50,7 @@ import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.graphics.FlixelBatch;
 import org.flixelgdx.group.FlixelGroupable;
-import org.flixelgdx.input.gamepad.FlixelGamepadInput;
-import org.flixelgdx.input.gamepad.FlixelGamepadManager;
+import org.flixelgdx.input.gamepad.FlixelGamepadInputManager;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import org.flixelgdx.input.mouse.FlixelMouseButton;
 import org.flixelgdx.input.mouse.FlixelMouseManager;
@@ -558,7 +557,7 @@ public final class Flixel {
   /**
    * The gamepad and controller input manager.
    *
-   * <p>The gamepad system is <strong>disabled by default</strong>. Set {@link FlixelGamepadManager#enabled} to
+   * <p>The gamepad system is <strong>disabled by default</strong>. Set {@link FlixelGamepadInputManager#enabled} to
    * {@code true} before the game loop starts if your game needs controller support:
    *
    * <pre>{@code
@@ -567,14 +566,14 @@ public final class Flixel {
    *
    * <p>FlixelGDX's gamepad system is built on the gdx-controllers extension. It abstracts physical
    * controllers (Xbox, PlayStation, generic USB) behind a set of logical button and axis codes
-   * defined in {@link FlixelGamepadInput}, so the same game code works across different controller
+   * defined in {@link FlixelGamepadButton}, so the same game code works across different controller
    * layouts without any platform-specific branching.
    *
    * <p>Each connected controller is identified by a zero-based index. Player 1's controller is
    * index {@code 0}, player 2's is index {@code 1}, and so on. Query button states with
-   * {@link FlixelGamepadManager#pressed(int, int)}, {@link FlixelGamepadManager#justPressed(int, int)},
-   * and {@link FlixelGamepadManager#justReleased(int, int)}, or read analog axes with
-   * {@link FlixelGamepadManager#getAxis(int, int)}.
+   * {@link FlixelGamepadInputManager#pressed(int, int)}, {@link FlixelGamepadInputManager#justPressed(int, int)},
+   * and {@link FlixelGamepadInputManager#justReleased(int, int)}, or read analog axes with
+   * {@link FlixelGamepadInputManager#getAxis(int, int)}.
    *
    * <p>Example:
    * <pre>{@code
@@ -582,19 +581,19 @@ public final class Flixel {
    * Flixel.gamepads.enabled = true;
    *
    * // Check if player 1 pressed the A button this frame.
-   * if (Flixel.gamepads.justPressed(0, FlixelGamepadInput.A)) {
+   * if (Flixel.gamepads.justPressed(0, FlixelGamepadButton.A)) {
    *   player.jump();
    * }
    *
    * // Read the left stick's horizontal axis for movement.
-   * float horizontal = Flixel.gamepads.getAxis(0, FlixelGamepadInput.AXIS_LEFT_X);
+   * float horizontal = Flixel.gamepads.getAxis(0, FlixelGamepadButton.AXIS_LEFT_X);
    * player.setVelocityX(horizontal * MOVE_SPEED * elapsed);
    * }</pre>
    *
-   * @see FlixelGamepadInput
+   * @see FlixelGamepadButton
    */
   @NotNull
-  public static FlixelGamepadManager gamepads;
+  public static FlixelGamepadInputManager gamepads;
 
   /**
    * The default logger used for game diagnostics and debugging output.
@@ -829,7 +828,7 @@ public final class Flixel {
     save = new FlixelSave();
     mouse = new FlixelMouseManager();
     touches = new FlixelTouchManager();
-    gamepads = new FlixelGamepadManager();
+    gamepads = new FlixelGamepadInputManager();
     log = new FlixelLogger(FlixelLogMode.SIMPLE);
     if (assets == null) {
       assets = new FlixelDefaultAssetManager();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionAnalog.java
@@ -51,8 +51,8 @@ import java.util.Objects;
  * move.addBinding("posX", FlixelAnalogBinding.posXKey(FlixelKey.RIGHT));
  * move.addBinding("negY", FlixelAnalogBinding.negYKey(FlixelKey.DOWN));
  * move.addBinding("posY", FlixelAnalogBinding.posYKey(FlixelKey.UP));
- * move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
- * move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
+ * move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadButton.AXIS_LEFT_X));
+ * move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadButton.AXIS_LEFT_Y));
  * }</pre>
  *
  * <h2>Reading</h2>
@@ -138,7 +138,7 @@ public final class FlixelActionAnalog extends FlixelAction {
    * <pre>{@code
    * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(FlixelKey.LEFT));
    * move.addBinding("rightKey", FlixelAnalogBinding.posXKey(FlixelKey.RIGHT));
-   * move.addBinding("stick", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
+   * move.addBinding("stick", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadButton.AXIS_LEFT_X));
    *
    * // Player rebinds the left key at runtime.
    * move.addBinding("leftKey", FlixelAnalogBinding.negXKey(newKey));

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionDigital.java
@@ -97,7 +97,7 @@ public final class FlixelActionDigital extends FlixelAction {
    *
    * <pre>{@code
    * jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKey.SPACE));
-   * jump.addBinding("gamepad", FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
+   * jump.addBinding("gamepad", FlixelDigitalBinding.gamepadButton(0, FlixelGamepadButton.A));
    *
    * // Player rebinds the keyboard slot at runtime.
    * jump.addBinding("keyboard", FlixelDigitalBinding.key(newKey));

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelActionSet.java
@@ -63,14 +63,14 @@ import org.jetbrains.annotations.Nullable;
  *   public PlayerControls() {
  *     jump = new FlixelActionDigital("jump");
  *     jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKey.SPACE));
- *     jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
+ *     jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadButton.A));
  *     add(jump);
  *
  *     move = new FlixelActionAnalog("move");
  *     move.addBinding("negX",   FlixelAnalogBinding.negXKey(FlixelKey.A));
  *     move.addBinding("posX",   FlixelAnalogBinding.posXKey(FlixelKey.D));
- *     move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
- *     move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
+ *     move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadButton.AXIS_LEFT_X));
+ *     move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadButton.AXIS_LEFT_Y));
  *     add(move);
  *   }
  * }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelAnalogBinding.java
@@ -26,7 +26,7 @@ package org.flixelgdx.input.action;
 import com.badlogic.gdx.math.Vector2;
 
 import org.flixelgdx.Flixel;
-import org.flixelgdx.input.gamepad.FlixelGamepadInput;
+import org.flixelgdx.input.gamepad.FlixelGamepadButton;
 
 /**
  * Two-axis input contributor for a {@link FlixelActionAnalog}.
@@ -41,8 +41,8 @@ import org.flixelgdx.input.gamepad.FlixelGamepadInput;
  * <pre>{@code
  * move.addBinding("negX",   FlixelAnalogBinding.negXKey(FlixelKey.A));
  * move.addBinding("posX",   FlixelAnalogBinding.posXKey(FlixelKey.D));
- * move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadInput.AXIS_LEFT_X));
- * move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadInput.AXIS_LEFT_Y));
+ * move.addBinding("stickX", FlixelAnalogBinding.gamepadAxisX(0, FlixelGamepadButton.AXIS_LEFT_X));
+ * move.addBinding("stickY", FlixelAnalogBinding.gamepadAxisY(0, FlixelGamepadButton.AXIS_LEFT_Y));
  * move.addBinding("custom", out -> out.x += myJoystick.getX());
  * }</pre>
  *
@@ -127,7 +127,7 @@ public interface FlixelAnalogBinding {
    * negative, right is positive), so no correction is applied.
    *
    * @param slot Gamepad slot (0 and up).
-   * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_X} or similar.
+   * @param logicalAxis {@link FlixelGamepadButton#AXIS_LEFT_X} or similar.
    * @return Binding that contributes the stick X value.
    */
   static FlixelAnalogBinding gamepadAxisX(int slot, int logicalAxis) {
@@ -143,7 +143,7 @@ public interface FlixelAnalogBinding {
    * up = positive Y, matching key bindings. This is the right choice for almost every game.
    *
    * @param slot Gamepad slot (0 and up).
-   * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_Y} or similar.
+   * @param logicalAxis {@link FlixelGamepadButton#AXIS_LEFT_Y} or similar.
    * @return Binding that contributes the stick Y value (up = positive).
    */
   static FlixelAnalogBinding gamepadAxisY(int slot, int logicalAxis) {
@@ -154,7 +154,7 @@ public interface FlixelAnalogBinding {
    * Adds the Y component of a gamepad stick.
    *
    * @param slot Gamepad slot (0 and up).
-   * @param logicalAxis {@link FlixelGamepadInput#AXIS_LEFT_Y} or similar.
+   * @param logicalAxis {@link FlixelGamepadButton#AXIS_LEFT_Y} or similar.
    * @param raw When {@code false} (the default), the raw hardware Y is negated so that up = positive
    *   Y, matching key bindings. Pass {@code true} to use the raw screen-space value unchanged.
    * @return Binding that contributes the stick Y value.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/action/FlixelDigitalBinding.java
@@ -26,6 +26,7 @@ package org.flixelgdx.input.action;
 import com.badlogic.gdx.Gdx;
 
 import org.flixelgdx.Flixel;
+import org.flixelgdx.input.gamepad.FlixelGamepadButton;
 import org.flixelgdx.input.mouse.FlixelMouseButton;
 import org.flixelgdx.input.touch.FlixelTouch;
 
@@ -41,7 +42,7 @@ import org.flixelgdx.input.touch.FlixelTouch;
  *
  * <pre>{@code
  * jump.addBinding("keyboard", FlixelDigitalBinding.key(FlixelKey.SPACE));
- * jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadInput.A));
+ * jump.addBinding("gamepad",  FlixelDigitalBinding.gamepadButton(0, FlixelGamepadButton.A));
  * jump.addBinding("touch",    FlixelDigitalBinding.touch(0));
  * jump.addBinding("sensor",   () -> myCustomSensor.isActive());
  * }</pre>
@@ -86,7 +87,7 @@ public interface FlixelDigitalBinding {
    *
    * @param slot Gamepad slot (0 and up), or {@link #GAMEPAD_SLOT_ANY} to match any connected slot.
    * @param logicalButton Logical button value from
-   *   {@link org.flixelgdx.input.gamepad.FlixelGamepadInput FlixelGamepadInput}.
+   *   {@link FlixelGamepadButton FlixelGamepadButton}.
    * @return Binding that fires while the button is held on the given slot.
    */
   static FlixelDigitalBinding gamepadButton(int slot, int logicalButton) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelAnalogButtonReader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelAnalogButtonReader.java
@@ -37,17 +37,17 @@ import org.jetbrains.annotations.NotNull;
  * through the standard interface. Implementations of this interface read that value through
  * platform-specific means.
  *
- * <p>The primary use case is populating {@link FlixelGamepadInput#AXIS_TRIGGER_L} and
- * {@link FlixelGamepadInput#AXIS_TRIGGER_R} on backends where L2 and R2 are mapped to button
+ * <p>The primary use case is populating {@link FlixelGamepadButton#AXIS_TRIGGER_L} and
+ * {@link FlixelGamepadButton#AXIS_TRIGGER_R} on backends where L2 and R2 are mapped to button
  * indices (for example {@link ControllerMapping#buttonL2} on web) rather than dedicated axes.
  * Install a platform implementation via
- * {@link FlixelGamepadManager#setAnalogButtonReader(FlixelAnalogButtonReader)}.
+ * {@link FlixelGamepadInputManager#setAnalogButtonReader(FlixelAnalogButtonReader)}.
  *
  * <p>On the Jamepad/SDL desktop backend, triggers are already reported as raw axes and no reader
  * is needed. {@code FlixelTeaVMAnalogButtonReader} (in the {@code flixelgdx-teavm} module) covers
  * the web case and is installed automatically by {@code FlixelTeaVMLauncher}.
  *
- * @see FlixelGamepadManager#setAnalogButtonReader(FlixelAnalogButtonReader)
+ * @see FlixelGamepadInputManager#setAnalogButtonReader(FlixelAnalogButtonReader)
  */
 @FunctionalInterface
 public interface FlixelAnalogButtonReader {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelDefaultHapticsProvider.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelDefaultHapticsProvider.java
@@ -42,9 +42,9 @@ import com.badlogic.gdx.controllers.Controller;
  */
 final class FlixelDefaultHapticsProvider implements FlixelHapticsProvider {
 
-  private final FlixelGamepadManager manager;
+  private final FlixelGamepadInputManager manager;
 
-  FlixelDefaultHapticsProvider(FlixelGamepadManager manager) {
+  FlixelDefaultHapticsProvider(FlixelGamepadInputManager manager) {
     this.manager = manager;
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadButton.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadButton.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Locale;
 
 /**
- * Logical gamepad button and axis identifiers for {@link FlixelGamepadManager}, resolved to native
+ * Logical gamepad button and axis identifiers for {@link FlixelGamepadInputManager}, resolved to native
  * indices through each {@link Controller#getMapping()} (gdx-controllers SDL-style layout).
  *
  * <h2>Important Note for Desktop (LWJGL3) vs Web (TeaVM)</h2>
@@ -49,9 +49,9 @@ import java.util.Locale;
  * without per-device tables. Games that need perfect parity can offer a remap screen or branch on
  * {@link com.badlogic.gdx.Application#getType()} and {@link Controller#getName()}.
  */
-public final class FlixelGamepadInput {
+public final class FlixelGamepadButton {
 
-  private FlixelGamepadInput() {}
+  private FlixelGamepadButton() {}
 
   public static final int NONE = -2;
   public static final int ANY = -1;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadDevice.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadDevice.java
@@ -27,15 +27,15 @@ import org.jetbrains.annotations.NotNull;
 
 /**
  * Optional per-slot facade for gamepad queries. Instances are created only when the game calls
- * {@link FlixelGamepadManager#ensureDevice(int)}; {@link FlixelGamepadManager#getById(int)} stays
+ * {@link FlixelGamepadInputManager#ensureDevice(int)}; {@link FlixelGamepadInputManager#getById(int)} stays
  * {@code null} until then.
  */
 public final class FlixelGamepadDevice {
 
-  private final FlixelGamepadManager manager;
+  private final FlixelGamepadInputManager manager;
   private final int id;
 
-  FlixelGamepadDevice(@NotNull FlixelGamepadManager manager, int id) {
+  FlixelGamepadDevice(@NotNull FlixelGamepadInputManager manager, int id) {
     this.manager = manager;
     this.id = id;
   }
@@ -44,7 +44,7 @@ public final class FlixelGamepadDevice {
    * Slot index for this device (stable while the controller stays at the same list index in the
    * backend).
    *
-   * @return Gamepad id between {@code 0} and {@link FlixelGamepadManager#MAX_GAMEPADS} exclusive.
+   * @return Gamepad id between {@code 0} and {@link FlixelGamepadInputManager#MAX_GAMEPADS} exclusive.
    */
   public int getId() {
     return id;
@@ -77,7 +77,7 @@ public final class FlixelGamepadDevice {
   /**
    * Returns {@code true} when this controller is currently pressing the given button.
    *
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} when the button is held this frame.
    */
   public boolean pressed(int logicalButton) {
@@ -87,7 +87,7 @@ public final class FlixelGamepadDevice {
   /**
    * Returns {@code true} when this controller first pressed the button this frame.
    *
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} on the first frame the button is pressed.
    */
   public boolean justPressed(int logicalButton) {
@@ -97,7 +97,7 @@ public final class FlixelGamepadDevice {
   /**
    * Returns {@code true} when this controller released the button this frame.
    *
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} on the first frame the button is no longer pressed.
    */
   public boolean justReleased(int logicalButton) {
@@ -153,7 +153,7 @@ public final class FlixelGamepadDevice {
   /**
    * Returns the current value of a logical axis on this controller, after dead-zone processing.
    *
-   * @param logicalAxis A logical axis constant from {@link FlixelGamepadInput}.
+   * @param logicalAxis A logical axis constant from {@link FlixelGamepadButton}.
    * @return Axis value in the range {@code [-1, 1]}, or {@code 0f} when inactive or within the
    *     dead zone.
    */
@@ -162,21 +162,21 @@ public final class FlixelGamepadDevice {
   }
 
   /**
-   * Shorthand for the left stick horizontal axis ({@link FlixelGamepadInput#AXIS_LEFT_X}).
+   * Shorthand for the left stick horizontal axis ({@link FlixelGamepadButton#AXIS_LEFT_X}).
    *
    * @return Horizontal axis value in the range {@code [-1, 1]}.
    */
   public float getXAxis() {
-    return manager.getAxis(id, FlixelGamepadInput.AXIS_LEFT_X);
+    return manager.getAxis(id, FlixelGamepadButton.AXIS_LEFT_X);
   }
 
   /**
-   * Shorthand for the left stick vertical axis ({@link FlixelGamepadInput#AXIS_LEFT_Y}).
+   * Shorthand for the left stick vertical axis ({@link FlixelGamepadButton#AXIS_LEFT_Y}).
    *
    * @return Vertical axis value in the range {@code [-1, 1]}.
    */
   public float getYAxis() {
-    return manager.getAxis(id, FlixelGamepadInput.AXIS_LEFT_Y);
+    return manager.getAxis(id, FlixelGamepadButton.AXIS_LEFT_Y);
   }
 
   /**
@@ -185,7 +185,7 @@ public final class FlixelGamepadDevice {
    *
    * <p>On Jamepad/SDL desktop, triggers are axes; this reads the trigger axis directly.
    * On web (TeaVM/W3C Gamepad API), triggers are digital buttons and this always returns {@code 0};
-   * because of this, use {@link #pressed(int)} with {@link FlixelGamepadInput#L2} there instead.
+   * because of this, use {@link #pressed(int)} with {@link FlixelGamepadButton#L2} there instead.
    *
    * @return Trigger pressure in {@code [0, 1]}, or {@code 0f} within the dead zone.
    */
@@ -199,7 +199,7 @@ public final class FlixelGamepadDevice {
    *
    * <p>On Jamepad/SDL desktop, triggers are axes; this reads the trigger axis directly.
    * On web (TeaVM/W3C Gamepad API), triggers are digital buttons and this always returns {@code 0};
-   * because of this, use {@link #pressed(int)} with {@link FlixelGamepadInput#R2} there instead.
+   * because of this, use {@link #pressed(int)} with {@link FlixelGamepadButton#R2} there instead.
    *
    * @return Trigger pressure in {@code [0, 1]}, or {@code 0f} within the dead zone.
    */

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManager.java
@@ -28,6 +28,7 @@ import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.ControllerMapping;
 import com.badlogic.gdx.controllers.Controllers;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.IntArray;
 
 import org.flixelgdx.FlixelGame;
 import org.flixelgdx.input.FlixelInputManager;
@@ -94,6 +95,7 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
   private final boolean[][] previousButtons = new boolean[MAX_GAMEPADS][MAX_BUTTONS];
 
   private final float[][] axisValues = new float[MAX_GAMEPADS][MAX_AXES];
+  private final IntArray[] pressedOrder = new IntArray[MAX_GAMEPADS];
 
   @Nullable
   private final FlixelGamepadDevice[] ensuredDevices = new FlixelGamepadDevice[MAX_GAMEPADS];
@@ -112,7 +114,11 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
 
   private boolean listenerAttached;
 
-  public FlixelGamepadInputManager() {}
+  public FlixelGamepadInputManager() {
+    for (int i = 0; i < MAX_GAMEPADS; i++) {
+      pressedOrder[i] = new IntArray();
+    }
+  }
 
   /**
    * Registers a {@link ControllerListener} with gdx-controllers. Safe to call more than once.
@@ -154,6 +160,7 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
       Arrays.fill(currentButtons[i], false);
       Arrays.fill(previousButtons[i], false);
       Arrays.fill(axisValues[i], 0f);
+      pressedOrder[i].clear();
     }
   }
 
@@ -497,6 +504,140 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
   }
 
   /**
+   * Returns the logical button code of the button that has been held the longest on the given slot,
+   * or {@link FlixelGamepadButton#NONE} when no button is currently held.
+   *
+   * <p>Press order is tracked across frames: the first physical button detected as pressed since
+   * the slot was connected (or last cleared) is always returned first, regardless of how many
+   * buttons are held simultaneously.
+   *
+   * <pre>{@code
+   * int btn = Flixel.gamepads.firstPressed(0);
+   * if (btn != FlixelGamepadButton.NONE) {
+   *   System.out.println("Oldest held button: " + FlixelGamepadButton.toString(btn));
+   * }
+   * }</pre>
+   *
+   * @param gamepadId Slot index.
+   * @return Logical button code from {@link FlixelGamepadButton}, or {@link FlixelGamepadButton#NONE}
+   *     when no button is held or the slot is inactive.
+   */
+  public int firstPressed(int gamepadId) {
+    if (!enabled || gamepadId < 0 || gamepadId >= numActiveGamepads) {
+      return FlixelGamepadButton.NONE;
+    }
+    Controller c = slotController[gamepadId];
+    if (c == null) {
+      return FlixelGamepadButton.NONE;
+    }
+    IntArray order = pressedOrder[gamepadId];
+    if (order.size == 0) {
+      return FlixelGamepadButton.NONE;
+    }
+    return nativeButtonToLogical(c, order.first());
+  }
+
+  /**
+   * Returns the logical button code of the first button that transitioned to pressed this frame on
+   * the given slot, or {@link FlixelGamepadButton#NONE} when no button was just pressed.
+   *
+   * <p>When multiple buttons are pressed in the same frame, the one with the lowest native index
+   * is returned. Unmapped native buttons (those not in {@link FlixelGamepadButton}) are skipped.
+   *
+   * <pre>{@code
+   * int btn = Flixel.gamepads.firstJustPressed(0);
+   * if (btn == FlixelGamepadButton.A) {
+   *   jump();
+   * }
+   * }</pre>
+   *
+   * @param gamepadId Slot index.
+   * @return Logical button code from {@link FlixelGamepadButton}, or {@link FlixelGamepadButton#NONE}
+   *     when no button was just pressed or the slot is inactive.
+   */
+  public int firstJustPressed(int gamepadId) {
+    if (!enabled || gamepadId < 0 || gamepadId >= numActiveGamepads) {
+      return FlixelGamepadButton.NONE;
+    }
+    Controller c = slotController[gamepadId];
+    if (c == null) {
+      return FlixelGamepadButton.NONE;
+    }
+    int min = c.getMinButtonIndex();
+    int max = c.getMaxButtonIndex();
+    for (int b = min; b <= max; b++) {
+      if (b >= 0 && b < MAX_BUTTONS && currentButtons[gamepadId][b] && !previousButtons[gamepadId][b]) {
+        int logical = nativeButtonToLogical(c, b);
+        if (logical != FlixelGamepadButton.NONE) {
+          return logical;
+        }
+      }
+    }
+    ControllerMapping m = c.getMapping();
+    if (m.buttonL2 == ControllerMapping.UNDEFINED
+        && currentButtons[gamepadId][SYNTHETIC_TRIGGER_L]
+        && !previousButtons[gamepadId][SYNTHETIC_TRIGGER_L]) {
+      return FlixelGamepadButton.L2;
+    }
+    if (m.buttonR2 == ControllerMapping.UNDEFINED
+        && currentButtons[gamepadId][SYNTHETIC_TRIGGER_R]
+        && !previousButtons[gamepadId][SYNTHETIC_TRIGGER_R]) {
+      return FlixelGamepadButton.R2;
+    }
+    return FlixelGamepadButton.NONE;
+  }
+
+  /**
+   * Returns the logical button code of the first button that was released this frame on the given
+   * slot, or {@link FlixelGamepadButton#NONE} when no button was just released.
+   *
+   * <p>When multiple buttons are released in the same frame, the one with the lowest native index
+   * is returned. Unmapped native buttons (those not in {@link FlixelGamepadButton}) are skipped.
+   *
+   * <pre>{@code
+   * int btn = Flixel.gamepads.firstJustReleased(0);
+   * if (btn == FlixelGamepadButton.A) {
+   *   stopCharge();
+   * }
+   * }</pre>
+   *
+   * @param gamepadId Slot index.
+   * @return Logical button code from {@link FlixelGamepadButton}, or {@link FlixelGamepadButton#NONE}
+   *     when no button was just released or the slot is inactive.
+   */
+  public int firstJustReleased(int gamepadId) {
+    if (!enabled || gamepadId < 0 || gamepadId >= numActiveGamepads) {
+      return FlixelGamepadButton.NONE;
+    }
+    Controller c = slotController[gamepadId];
+    if (c == null) {
+      return FlixelGamepadButton.NONE;
+    }
+    int min = c.getMinButtonIndex();
+    int max = c.getMaxButtonIndex();
+    for (int b = min; b <= max; b++) {
+      if (b >= 0 && b < MAX_BUTTONS && !currentButtons[gamepadId][b] && previousButtons[gamepadId][b]) {
+        int logical = nativeButtonToLogical(c, b);
+        if (logical != FlixelGamepadButton.NONE) {
+          return logical;
+        }
+      }
+    }
+    ControllerMapping m = c.getMapping();
+    if (m.buttonL2 == ControllerMapping.UNDEFINED
+        && !currentButtons[gamepadId][SYNTHETIC_TRIGGER_L]
+        && previousButtons[gamepadId][SYNTHETIC_TRIGGER_L]) {
+      return FlixelGamepadButton.L2;
+    }
+    if (m.buttonR2 == ControllerMapping.UNDEFINED
+        && !currentButtons[gamepadId][SYNTHETIC_TRIGGER_R]
+        && previousButtons[gamepadId][SYNTHETIC_TRIGGER_R]) {
+      return FlixelGamepadButton.R2;
+    }
+    return FlixelGamepadButton.NONE;
+  }
+
+  /**
    * Returns the current value of a logical axis on the given slot, after applying the global dead
    * zone. Returns {@code 0f} when the value is within the dead zone or the slot is out of range.
    *
@@ -723,6 +864,74 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
   }
 
   /**
+   * Reverse of {@link FlixelGamepadButton#logicalButtonToNative}: maps a native button index back
+   * to a logical {@link FlixelGamepadButton} constant. Also handles the two synthetic trigger slots
+   * ({@link #SYNTHETIC_TRIGGER_L} and {@link #SYNTHETIC_TRIGGER_R}), returning {@link FlixelGamepadButton#L2}
+   * and {@link FlixelGamepadButton#R2} respectively.
+   *
+   * Returns {@link FlixelGamepadButton#NONE} for native indices that do not correspond to any
+   * known logical button on this controller.
+   */
+  private int nativeButtonToLogical(@NotNull Controller c, int nativeButton) {
+    if (nativeButton == SYNTHETIC_TRIGGER_L) {
+      return FlixelGamepadButton.L2;
+    }
+    if (nativeButton == SYNTHETIC_TRIGGER_R) {
+      return FlixelGamepadButton.R2;
+    }
+    ControllerMapping m = c.getMapping();
+    if (nativeButton == m.buttonA) {
+      return FlixelGamepadButton.A;
+    }
+    if (nativeButton == m.buttonB) {
+      return FlixelGamepadButton.B;
+    }
+    if (nativeButton == m.buttonX) {
+      return FlixelGamepadButton.X;
+    }
+    if (nativeButton == m.buttonY) {
+      return FlixelGamepadButton.Y;
+    }
+    if (nativeButton == m.buttonL1) {
+      return FlixelGamepadButton.L1;
+    }
+    if (nativeButton == m.buttonR1) {
+      return FlixelGamepadButton.R1;
+    }
+    if (nativeButton == m.buttonL2) {
+      return FlixelGamepadButton.L2;
+    }
+    if (nativeButton == m.buttonR2) {
+      return FlixelGamepadButton.R2;
+    }
+    if (nativeButton == m.buttonLeftStick) {
+      return FlixelGamepadButton.THUMBL;
+    }
+    if (nativeButton == m.buttonRightStick) {
+      return FlixelGamepadButton.THUMBR;
+    }
+    if (nativeButton == m.buttonStart) {
+      return FlixelGamepadButton.START;
+    }
+    if (nativeButton == m.buttonBack) {
+      return FlixelGamepadButton.SELECT;
+    }
+    if (nativeButton == m.buttonDpadUp) {
+      return FlixelGamepadButton.DPAD_UP;
+    }
+    if (nativeButton == m.buttonDpadDown) {
+      return FlixelGamepadButton.DPAD_DOWN;
+    }
+    if (nativeButton == m.buttonDpadLeft) {
+      return FlixelGamepadButton.DPAD_LEFT;
+    }
+    if (nativeButton == m.buttonDpadRight) {
+      return FlixelGamepadButton.DPAD_RIGHT;
+    }
+    return FlixelGamepadButton.NONE;
+  }
+
+  /**
    * Resolves a logical button to its native index, falling back to a synthetic trigger index for
    * L2 and R2 when the backend leaves their {@link ControllerMapping} entries as
    * {@link ControllerMapping#UNDEFINED}.
@@ -784,6 +993,7 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
     Arrays.fill(currentButtons[slot], false);
     Arrays.fill(previousButtons[slot], false);
     Arrays.fill(axisValues[slot], 0f);
+    pressedOrder[slot].clear();
   }
 
   private void pollHardware() {
@@ -796,7 +1006,15 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
       int maxB = c.getMaxButtonIndex();
       for (int b = minB; b <= maxB; b++) {
         if (b >= 0 && b < MAX_BUTTONS) {
-          currentButtons[s][b] = c.getButton(b);
+          boolean newState = c.getButton(b);
+          if (newState && !previousButtons[s][b]) {
+            if (pressedOrder[s].indexOf(b) < 0) {
+              pressedOrder[s].add(b);
+            }
+          } else if (!newState && previousButtons[s][b]) {
+            pressedOrder[s].removeValue(b);
+          }
+          currentButtons[s][b] = newState;
         }
       }
       int ac = Math.min(c.getAxisCount(), MAX_AXES);
@@ -820,11 +1038,27 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
       // work correctly on those backends.
       if (m.buttonL2 == ControllerMapping.UNDEFINED) {
         float v = FlixelGamepadButton.AXIS_TRIGGER_L < ac ? axisValues[s][FlixelGamepadButton.AXIS_TRIGGER_L] : 0f;
-        currentButtons[s][SYNTHETIC_TRIGGER_L] = v > TRIGGER_BUTTON_THRESHOLD;
+        boolean newTriggerL = v > TRIGGER_BUTTON_THRESHOLD;
+        if (newTriggerL && !previousButtons[s][SYNTHETIC_TRIGGER_L]) {
+          if (pressedOrder[s].indexOf(SYNTHETIC_TRIGGER_L) < 0) {
+            pressedOrder[s].add(SYNTHETIC_TRIGGER_L);
+          }
+        } else if (!newTriggerL && previousButtons[s][SYNTHETIC_TRIGGER_L]) {
+          pressedOrder[s].removeValue(SYNTHETIC_TRIGGER_L);
+        }
+        currentButtons[s][SYNTHETIC_TRIGGER_L] = newTriggerL;
       }
       if (m.buttonR2 == ControllerMapping.UNDEFINED) {
         float v = FlixelGamepadButton.AXIS_TRIGGER_R < ac ? axisValues[s][FlixelGamepadButton.AXIS_TRIGGER_R] : 0f;
-        currentButtons[s][SYNTHETIC_TRIGGER_R] = v > TRIGGER_BUTTON_THRESHOLD;
+        boolean newTriggerR = v > TRIGGER_BUTTON_THRESHOLD;
+        if (newTriggerR && !previousButtons[s][SYNTHETIC_TRIGGER_R]) {
+          if (pressedOrder[s].indexOf(SYNTHETIC_TRIGGER_R) < 0) {
+            pressedOrder[s].add(SYNTHETIC_TRIGGER_R);
+          }
+        } else if (!newTriggerR && previousButtons[s][SYNTHETIC_TRIGGER_R]) {
+          pressedOrder[s].removeValue(SYNTHETIC_TRIGGER_R);
+        }
+        currentButtons[s][SYNTHETIC_TRIGGER_R] = newTriggerR;
       }
     }
   }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManager.java
@@ -49,11 +49,11 @@ import java.util.Objects;
  * Flixel.gamepads.enabled = true;
  * }</pre>
  *
- * <p>Use logical button and axis constants from {@link FlixelGamepadInput} (for example {@link FlixelGamepadInput#A})
+ * <p>Use logical button and axis constants from {@link FlixelGamepadButton} (for example {@link FlixelGamepadButton#A})
  * with {@link #pressed(int, int)}; each {@link Controller#getMapping()} supplies native indices.
  * {@link FlixelGamepadDevice} is optional; call {@link #ensureDevice(int)} once per slot you want a facade for.
  */
-public class FlixelGamepadManager implements FlixelInputManager, ControllerListener {
+public class FlixelGamepadInputManager implements FlixelInputManager, ControllerListener {
 
   /** Maximum supported simultaneous controllers. */
   public static final int MAX_GAMEPADS = 8;
@@ -112,7 +112,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
 
   private boolean listenerAttached;
 
-  public FlixelGamepadManager() {}
+  public FlixelGamepadInputManager() {}
 
   /**
    * Registers a {@link ControllerListener} with gdx-controllers. Safe to call more than once.
@@ -279,8 +279,8 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
   /**
    * Returns {@code true} when any active gamepad currently holds the given button.
    *
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}, such as
-   *     {@link FlixelGamepadInput#A}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}, such as
+   *     {@link FlixelGamepadButton#A}.
    * @return {@code true} when at least one gamepad is pressing the button this frame.
    */
   public boolean anyPressed(int logicalButton) {
@@ -298,7 +298,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
   /**
    * Returns {@code true} when any active gamepad first pressed the given button this frame.
    *
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} when at least one gamepad transitioned to pressed this frame.
    */
   public boolean anyJustPressed(int logicalButton) {
@@ -316,7 +316,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
   /**
    * Returns {@code true} when any active gamepad released the given button this frame.
    *
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} when at least one gamepad transitioned to released this frame.
    */
   public boolean anyJustReleased(int logicalButton) {
@@ -361,10 +361,10 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
     }
     float dz = deadZoneValue();
     for (int s = 0; s < numActiveGamepads; s++) {
-      if (Math.abs(getAxisRaw(s, FlixelGamepadInput.AXIS_LEFT_X)) > dz) {
+      if (Math.abs(getAxisRaw(s, FlixelGamepadButton.AXIS_LEFT_X)) > dz) {
         return true;
       }
-      if (Math.abs(getAxisRaw(s, FlixelGamepadInput.AXIS_RIGHT_X)) > dz) {
+      if (Math.abs(getAxisRaw(s, FlixelGamepadButton.AXIS_RIGHT_X)) > dz) {
         return true;
       }
     }
@@ -383,10 +383,10 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
     }
     float dz = deadZoneValue();
     for (int s = 0; s < numActiveGamepads; s++) {
-      if (Math.abs(getAxisRaw(s, FlixelGamepadInput.AXIS_LEFT_Y)) > dz) {
+      if (Math.abs(getAxisRaw(s, FlixelGamepadButton.AXIS_LEFT_Y)) > dz) {
         return true;
       }
-      if (Math.abs(getAxisRaw(s, FlixelGamepadInput.AXIS_RIGHT_Y)) > dz) {
+      if (Math.abs(getAxisRaw(s, FlixelGamepadButton.AXIS_RIGHT_Y)) > dz) {
         return true;
       }
     }
@@ -396,11 +396,11 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
   /**
    * Returns {@code true} when the given slot is currently pressing the given button.
    *
-   * <p>Pass {@link FlixelGamepadInput#ANY} as the button to check whether the slot has any
+   * <p>Pass {@link FlixelGamepadButton#ANY} as the button to check whether the slot has any
    * button pressed or meaningful analog movement this frame.
    *
    * @param gamepadId Slot index.
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} when that button is pressed on the given slot this frame.
    */
   public boolean pressed(int gamepadId, int logicalButton) {
@@ -412,7 +412,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
     if (c == null) {
       return false;
     }
-    if (logicalButton == FlixelGamepadInput.ANY) {
+    if (logicalButton == FlixelGamepadButton.ANY) {
       return slotAnyPhysicalButton(gamepadId, c) || slotHasAxisBeyondDeadzone(gamepadId, c)
           || slotHasTriggerActivity(gamepadId, c);
     }
@@ -429,7 +429,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * last frame).
    *
    * @param gamepadId Slot index.
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} on the first frame the button is pressed.
    */
   public boolean justPressed(int gamepadId, int logicalButton) {
@@ -442,7 +442,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
       return false;
     }
 
-    if (logicalButton == FlixelGamepadInput.ANY) {
+    if (logicalButton == FlixelGamepadButton.ANY) {
       int min = c.getMinButtonIndex();
       int max = c.getMaxButtonIndex();
       for (int b = min; b <= max; b++) {
@@ -465,7 +465,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * frame, not pressed now).
    *
    * @param gamepadId Slot index.
-   * @param logicalButton A logical button constant from {@link FlixelGamepadInput}.
+   * @param logicalButton A logical button constant from {@link FlixelGamepadButton}.
    * @return {@code true} on the first frame the button is no longer pressed.
    */
   public boolean justReleased(int gamepadId, int logicalButton) {
@@ -478,7 +478,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
       return false;
     }
 
-    if (logicalButton == FlixelGamepadInput.ANY) {
+    if (logicalButton == FlixelGamepadButton.ANY) {
       int min = c.getMinButtonIndex();
       int max = c.getMaxButtonIndex();
       for (int b = min; b <= max; b++) {
@@ -501,8 +501,8 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * zone. Returns {@code 0f} when the value is within the dead zone or the slot is out of range.
    *
    * @param gamepadId Slot index.
-   * @param logicalAxis A logical axis constant from {@link FlixelGamepadInput}, such as
-   *     {@link FlixelGamepadInput#AXIS_LEFT_X}.
+   * @param logicalAxis A logical axis constant from {@link FlixelGamepadButton}, such as
+   *     {@link FlixelGamepadButton#AXIS_LEFT_X}.
    * @return Axis value in the range {@code [-1, 1]}, or {@code 0f} when inactive.
    */
   public float getAxis(int gamepadId, int logicalAxis) {
@@ -547,7 +547,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
 
   /**
    * Installs a platform-specific reader for analog button values, used to populate
-   * {@link FlixelGamepadInput#AXIS_TRIGGER_L} and {@link FlixelGamepadInput#AXIS_TRIGGER_R} on
+   * {@link FlixelGamepadButton#AXIS_TRIGGER_L} and {@link FlixelGamepadButton#AXIS_TRIGGER_R} on
    * backends where triggers are exposed as buttons rather than axes (for example, the web W3C
    * Gamepad API).
    *
@@ -629,7 +629,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * <p>On the Jamepad/SDL desktop backend, triggers are reported as axes, so this reads the
    * raw trigger axis directly. On web (TeaVM/W3C Gamepad API), triggers are digital buttons;
    * this method returns {@code 0} there; for web, use {@link #pressed(int, int)} with
-   * {@link FlixelGamepadInput#L2} instead.
+   * {@link FlixelGamepadButton#L2} instead.
    *
    * <pre>{@code
    * float howHardL2 = Flixel.gamepads.getTriggerL(0);
@@ -639,7 +639,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * @return Trigger pressure in {@code [0, 1]}, or {@code 0f} when inactive or within the dead zone.
    */
   public float getTriggerL(int gamepadId) {
-    return getAxis(gamepadId, FlixelGamepadInput.AXIS_TRIGGER_L);
+    return getAxis(gamepadId, FlixelGamepadButton.AXIS_TRIGGER_L);
   }
 
   /**
@@ -649,7 +649,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * <p>On the Jamepad/SDL desktop backend, triggers are reported as axes, so this reads the
    * raw trigger axis directly. On web (TeaVM/W3C Gamepad API), triggers are digital buttons;
    * this method returns {@code 0} there; for web, use {@link #pressed(int, int)} with
-   * {@link FlixelGamepadInput#R2} instead.
+   * {@link FlixelGamepadButton#R2} instead.
    *
    * <pre>{@code
    * float howHardR2 = Flixel.gamepads.getTriggerR(0);
@@ -659,7 +659,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * @return Trigger pressure in {@code [0, 1]}, or {@code 0f} when inactive or within the dead zone.
    */
   public float getTriggerR(int gamepadId) {
-    return getAxis(gamepadId, FlixelGamepadInput.AXIS_TRIGGER_R);
+    return getAxis(gamepadId, FlixelGamepadButton.AXIS_TRIGGER_R);
   }
 
   /**
@@ -728,14 +728,14 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
    * {@link ControllerMapping#UNDEFINED}.
    */
   private int resolvedNativeButton(@NotNull Controller c, int logicalButton) {
-    int code = FlixelGamepadInput.logicalButtonToNative(c, logicalButton);
+    int code = FlixelGamepadButton.logicalButtonToNative(c, logicalButton);
     if (code != ControllerMapping.UNDEFINED) {
       return code;
     }
-    if (logicalButton == FlixelGamepadInput.L2) {
+    if (logicalButton == FlixelGamepadButton.L2) {
       return SYNTHETIC_TRIGGER_L;
     }
-    if (logicalButton == FlixelGamepadInput.R2) {
+    if (logicalButton == FlixelGamepadButton.R2) {
       return SYNTHETIC_TRIGGER_R;
     }
     return ControllerMapping.UNDEFINED;
@@ -808,10 +808,10 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
       // trigger axis slots from the reader so that getTriggerL/R() returns pressure values.
       if (analogButtonReader != null) {
         if (m.buttonL2 != ControllerMapping.UNDEFINED) {
-          axisValues[s][FlixelGamepadInput.AXIS_TRIGGER_L] = analogButtonReader.read(c, m.buttonL2);
+          axisValues[s][FlixelGamepadButton.AXIS_TRIGGER_L] = analogButtonReader.read(c, m.buttonL2);
         }
         if (m.buttonR2 != ControllerMapping.UNDEFINED) {
-          axisValues[s][FlixelGamepadInput.AXIS_TRIGGER_R] = analogButtonReader.read(c, m.buttonR2);
+          axisValues[s][FlixelGamepadButton.AXIS_TRIGGER_R] = analogButtonReader.read(c, m.buttonR2);
         }
       }
       // On backends such as Jamepad/SDL, triggers are analog axes rather than digital buttons,
@@ -819,11 +819,11 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
       // state from the trigger axis value so that pressed(), justPressed(), and justReleased()
       // work correctly on those backends.
       if (m.buttonL2 == ControllerMapping.UNDEFINED) {
-        float v = FlixelGamepadInput.AXIS_TRIGGER_L < ac ? axisValues[s][FlixelGamepadInput.AXIS_TRIGGER_L] : 0f;
+        float v = FlixelGamepadButton.AXIS_TRIGGER_L < ac ? axisValues[s][FlixelGamepadButton.AXIS_TRIGGER_L] : 0f;
         currentButtons[s][SYNTHETIC_TRIGGER_L] = v > TRIGGER_BUTTON_THRESHOLD;
       }
       if (m.buttonR2 == ControllerMapping.UNDEFINED) {
-        float v = FlixelGamepadInput.AXIS_TRIGGER_R < ac ? axisValues[s][FlixelGamepadInput.AXIS_TRIGGER_R] : 0f;
+        float v = FlixelGamepadButton.AXIS_TRIGGER_R < ac ? axisValues[s][FlixelGamepadButton.AXIS_TRIGGER_R] : 0f;
         currentButtons[s][SYNTHETIC_TRIGGER_R] = v > TRIGGER_BUTTON_THRESHOLD;
       }
     }
@@ -842,19 +842,19 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
 
   private boolean slotHasAxisBeyondDeadzone(int slot, @NotNull Controller c) {
     float dz = deadZoneValue();
-    int ax = FlixelGamepadInput.logicalAxisToNative(c, FlixelGamepadInput.AXIS_LEFT_X);
+    int ax = FlixelGamepadButton.logicalAxisToNative(c, FlixelGamepadButton.AXIS_LEFT_X);
     if (isAxisActive(slot, ax, dz)) {
       return true;
     }
-    ax = FlixelGamepadInput.logicalAxisToNative(c, FlixelGamepadInput.AXIS_LEFT_Y);
+    ax = FlixelGamepadButton.logicalAxisToNative(c, FlixelGamepadButton.AXIS_LEFT_Y);
     if (isAxisActive(slot, ax, dz)) {
       return true;
     }
-    ax = FlixelGamepadInput.logicalAxisToNative(c, FlixelGamepadInput.AXIS_RIGHT_X);
+    ax = FlixelGamepadButton.logicalAxisToNative(c, FlixelGamepadButton.AXIS_RIGHT_X);
     if (isAxisActive(slot, ax, dz)) {
       return true;
     }
-    ax = FlixelGamepadInput.logicalAxisToNative(c, FlixelGamepadInput.AXIS_RIGHT_Y);
+    ax = FlixelGamepadButton.logicalAxisToNative(c, FlixelGamepadButton.AXIS_RIGHT_Y);
     return isAxisActive(slot, ax, dz);
   }
 
@@ -882,7 +882,7 @@ public class FlixelGamepadManager implements FlixelInputManager, ControllerListe
     if (c == null) {
       return 0f;
     }
-    int nat = FlixelGamepadInput.logicalAxisToNative(c, logicalAxis);
+    int nat = FlixelGamepadButton.logicalAxisToNative(c, logicalAxis);
     if (nat < 0 || nat >= MAX_AXES) {
       return 0f;
     }

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManager.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManager.java
@@ -869,7 +869,7 @@ public class FlixelGamepadInputManager implements FlixelInputManager, Controller
    * ({@link #SYNTHETIC_TRIGGER_L} and {@link #SYNTHETIC_TRIGGER_R}), returning {@link FlixelGamepadButton#L2}
    * and {@link FlixelGamepadButton#R2} respectively.
    *
-   * Returns {@link FlixelGamepadButton#NONE} for native indices that do not correspond to any
+   * <p>Returns {@link FlixelGamepadButton#NONE} for native indices that do not correspond to any
    * known logical button on this controller.
    */
   private int nativeButtonToLogical(@NotNull Controller c, int nativeButton) {

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelHapticsProvider.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/FlixelHapticsProvider.java
@@ -24,14 +24,14 @@
 package org.flixelgdx.input.gamepad;
 
 /**
- * Pluggable vibration backend for {@link FlixelGamepadManager}.
+ * Pluggable vibration backend for {@link FlixelGamepadInputManager}.
  *
  * <p>The built-in implementation, {@link FlixelDefaultHapticsProvider}, delegates to
  * gdx-controllers' {@link com.badlogic.gdx.controllers.Controller#startVibration} and works on
  * desktop (SDL via {@code gdx-controllers-desktop}) and web (W3C Gamepad API via
  * {@code gdx-controllers-teavm}) without any extra setup. For platform-specific features such as
  * dual-motor channels, haptic patterns, or DualSense adaptive triggers, supply a custom
- * implementation via {@link FlixelGamepadManager#setHapticsProvider}.
+ * implementation via {@link FlixelGamepadInputManager#setHapticsProvider}.
  *
  * <h2>Intensity values</h2>
  *
@@ -41,7 +41,7 @@ package org.flixelgdx.input.gamepad;
  *
  * <h2>Slot indices</h2>
  *
- * <p>Each method receives the same slot id used throughout {@link FlixelGamepadManager}. The
+ * <p>Each method receives the same slot id used throughout {@link FlixelGamepadInputManager}. The
  * manager already validates that the slot is in range and that the gamepad system is enabled
  * before calling the provider, so implementations do not need to repeat those checks.
  */
@@ -54,7 +54,7 @@ public interface FlixelHapticsProvider {
    * Implementations targeting single-motor hardware may collapse the two intensities to a single
    * value, typically the larger of the two.
    *
-   * @param slot Slot index between {@code 0} and {@link FlixelGamepadManager#MAX_GAMEPADS} exclusive.
+   * @param slot Slot index between {@code 0} and {@link FlixelGamepadInputManager#MAX_GAMEPADS} exclusive.
    * @param leftIntensity Strength for the left (low-frequency) motor, in the range {@code [0, 1]}.
    * @param rightIntensity Strength for the right (high-frequency) motor, in the range {@code [0, 1]}.
    * @param durationSecs How long to vibrate, in seconds.

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/gamepad/package-info.java
@@ -1,13 +1,13 @@
 /**
  * Gamepad input and haptics support for FlixelGDX.
  *
- * <p>{@link org.flixelgdx.input.gamepad.FlixelGamepadManager FlixelGamepadManager} is the global
+ * <p>{@link org.flixelgdx.input.gamepad.FlixelGamepadInputManager FlixelGamepadInputManager} is the global
  * entry point, accessible via {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads}. It polls
  * controllers each frame and exposes familiar pressed/justPressed/justReleased semantics
  * alongside analog axis reads.
  *
  * <p>Logical button and axis constants live on
- * {@link org.flixelgdx.input.gamepad.FlixelGamepadInput FlixelGamepadInput} and are resolved to
+ * {@link org.flixelgdx.input.gamepad.FlixelGamepadButton FlixelGamepadButton} and are resolved to
  * native hardware indices through each
  * {@link com.badlogic.gdx.controllers.Controller#getMapping() Controller.getMapping()} at query
  * time. {@link org.flixelgdx.input.gamepad.FlixelGamepadModel FlixelGamepadModel} identifies the
@@ -15,7 +15,7 @@
  *
  * <p>The optional per-slot {@link org.flixelgdx.input.gamepad.FlixelGamepadDevice FlixelGamepadDevice}
  * facade exposes the same queries without passing a slot id on every call. Create one via
- * {@link org.flixelgdx.input.gamepad.FlixelGamepadManager#ensureDevice(int)}.
+ * {@link org.flixelgdx.input.gamepad.FlixelGamepadInputManager#ensureDevice(int)}.
  *
  * <h2>Haptics and vibration</h2>
  *
@@ -47,6 +47,6 @@
  *
  * <p>For platform-specific haptics (for example DualSense adaptive triggers), supply a custom
  * {@link org.flixelgdx.input.gamepad.FlixelHapticsProvider} via
- * {@link org.flixelgdx.input.gamepad.FlixelGamepadManager#setHapticsProvider}.
+ * {@link org.flixelgdx.input.gamepad.FlixelGamepadInputManager#setHapticsProvider}.
  */
 package org.flixelgdx.input.gamepad;

--- a/flixelgdx-core/src/main/java/org/flixelgdx/input/package-info.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/input/package-info.java
@@ -14,7 +14,7 @@
  * <ul>
  *   <li><b>Keyboard:</b> {@link org.flixelgdx.input.keyboard.FlixelKeyInputManager FlixelKeyInputManager} on {@link org.flixelgdx.Flixel#keys Flixel.keys}.</li>
  *   <li><b>Mouse / pointers:</b> {@link org.flixelgdx.input.mouse.FlixelMouseManager FlixelMouseManager} on {@link org.flixelgdx.Flixel#mouse Flixel.mouse}.</li>
- *   <li><b>Gamepads:</b> {@link org.flixelgdx.input.gamepad.FlixelGamepadManager FlixelGamepadManager} on {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads}.</li>
+ *   <li><b>Gamepads:</b> {@link org.flixelgdx.input.gamepad.FlixelGamepadInputManager FlixelGamepadInputManager} on {@link org.flixelgdx.Flixel#gamepads Flixel.gamepads}.</li>
  *   <li><b>Logical actions (rebindable layers):</b> {@link org.flixelgdx.input.action action} ({@link org.flixelgdx.input.action.FlixelActionSet FlixelActionSet}, {@link org.flixelgdx.input.action.FlixelActionDigital FlixelActionDigital}, {@link org.flixelgdx.input.action.FlixelActionAnalog FlixelActionAnalog}).</li>
  * </ul>
  *

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMAnalogButtonReader.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMAnalogButtonReader.java
@@ -40,8 +40,8 @@ import org.teavm.jso.JSBody;
  * {@code navigator.getGamepads()[index].buttons[buttonIndex].value} instead.
  *
  * <p>This reader is installed automatically by {@link FlixelTeaVMLauncher} and covers
- * {@link org.flixelgdx.input.gamepad.FlixelGamepadInput#AXIS_TRIGGER_L AXIS_TRIGGER_L} and
- * {@link org.flixelgdx.input.gamepad.FlixelGamepadInput#AXIS_TRIGGER_R AXIS_TRIGGER_R} on web.
+ * {@link FlixelGamepadButton#AXIS_TRIGGER_L AXIS_TRIGGER_L} and
+ * {@link FlixelGamepadButton#AXIS_TRIGGER_R AXIS_TRIGGER_R} on web.
  * You do not need to install it manually.
  */
 final class FlixelTeaVMAnalogButtonReader implements FlixelAnalogButtonReader {

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManagerTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManagerTest.java
@@ -1,0 +1,376 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 stringdotjar
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.flixelgdx.input.gamepad;
+
+import com.badlogic.gdx.controllers.Controller;
+import com.badlogic.gdx.controllers.ControllerListener;
+import com.badlogic.gdx.controllers.ControllerMapping;
+import com.badlogic.gdx.controllers.ControllerPowerLevel;
+import com.badlogic.gdx.utils.IntArray;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit tests for {@link FlixelGamepadInputManager#firstPressed(int)},
+ * {@link FlixelGamepadInputManager#firstJustPressed(int)}, and
+ * {@link FlixelGamepadInputManager#firstJustReleased(int)}.
+ *
+ * <p>Internal state (slotController, currentButtons, previousButtons, pressedOrder) is injected via
+ * reflection so tests remain isolated from the gdx-controllers hardware layer.
+ */
+class FlixelGamepadInputManagerTest {
+
+  /**
+   * A {@link ControllerMapping} subclass with predictable, fixed button and axis indices for use
+   * in tests. Indices are assigned sequentially starting at 0, with L2/R2 left as
+   * {@link ControllerMapping#UNDEFINED} to exercise the synthetic trigger path.
+   */
+  private static final class TestMapping extends ControllerMapping {
+
+    static final int NATIVE_A = 0;
+    static final int NATIVE_B = 1;
+    static final int NATIVE_X = 2;
+    static final int NATIVE_Y = 3;
+    static final int NATIVE_L1 = 4;
+    static final int NATIVE_R1 = 5;
+    static final int NATIVE_BACK = 6;
+    static final int NATIVE_START = 7;
+    static final int NATIVE_LEFT_STICK = 8;
+    static final int NATIVE_RIGHT_STICK = 9;
+    static final int NATIVE_DPAD_UP = 10;
+    static final int NATIVE_DPAD_DOWN = 11;
+    static final int NATIVE_DPAD_LEFT = 12;
+    static final int NATIVE_DPAD_RIGHT = 13;
+    static final int MAX_BUTTON = 13;
+
+    TestMapping() {
+      super(
+          0, 1, 2, 3,
+          NATIVE_A, NATIVE_B, NATIVE_X, NATIVE_Y,
+          NATIVE_BACK, NATIVE_START,
+          NATIVE_L1, UNDEFINED,
+          NATIVE_R1, UNDEFINED,
+          NATIVE_LEFT_STICK, NATIVE_RIGHT_STICK,
+          NATIVE_DPAD_UP, NATIVE_DPAD_DOWN, NATIVE_DPAD_LEFT, NATIVE_DPAD_RIGHT);
+    }
+  }
+
+  /** Minimal {@link Controller} stub backed by a configurable boolean button array. */
+  private static final class StubController implements Controller {
+
+    private final boolean[] buttons = new boolean[TestMapping.MAX_BUTTON + 1];
+    private final TestMapping mapping = new TestMapping();
+
+    void press(int nativeButton) {
+      buttons[nativeButton] = true;
+    }
+
+    void release(int nativeButton) {
+      buttons[nativeButton] = false;
+    }
+
+    @Override
+    public boolean getButton(int buttonCode) {
+      return buttonCode >= 0 && buttonCode < buttons.length && buttons[buttonCode];
+    }
+
+    @Override
+    public ControllerMapping getMapping() {
+      return mapping;
+    }
+
+    @Override
+    public int getMinButtonIndex() {
+      return 0;
+    }
+
+    @Override
+    public int getMaxButtonIndex() {
+      return TestMapping.MAX_BUTTON;
+    }
+
+    @Override
+    public int getAxisCount() {
+      return 6;
+    }
+
+    @Override
+    public float getAxis(int axisCode) {
+      return 0f;
+    }
+
+    @Override
+    public String getName() {
+      return "StubController";
+    }
+
+    @Override
+    public String getUniqueId() {
+      return "stub-0";
+    }
+
+    @Override
+    public boolean isConnected() {
+      return true;
+    }
+
+    @Override
+    public boolean canVibrate() {
+      return false;
+    }
+
+    @Override
+    public boolean isVibrating() {
+      return false;
+    }
+
+    @Override
+    public void startVibration(int duration, float strength) {}
+
+    @Override
+    public void cancelVibration() {}
+
+    @Override
+    public boolean supportsPlayerIndex() {
+      return false;
+    }
+
+    @Override
+    public int getPlayerIndex() {
+      return Controller.PLAYER_IDX_UNSET;
+    }
+
+    @Override
+    public void setPlayerIndex(int index) {}
+
+    @Override
+    public ControllerPowerLevel getPowerLevel() {
+      return ControllerPowerLevel.POWER_UNKNOWN;
+    }
+
+    @Override
+    public void addListener(ControllerListener listener) {}
+
+    @Override
+    public void removeListener(ControllerListener listener) {}
+  }
+
+  private FlixelGamepadInputManager manager;
+  private StubController stub;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    manager = new FlixelGamepadInputManager();
+    manager.enabled = true;
+    manager.numActiveGamepads = 1;
+    stub = new StubController();
+    injectController(0, stub);
+  }
+
+  // --- firstPressed ---
+
+  @Test
+  void firstPressedReturnsNoneWhenDisabled() {
+    manager.enabled = false;
+    assertEquals(FlixelGamepadButton.NONE, manager.firstPressed(0));
+  }
+
+  @Test
+  void firstPressedReturnsNoneForNegativeId() {
+    assertEquals(FlixelGamepadButton.NONE, manager.firstPressed(-1));
+  }
+
+  @Test
+  void firstPressedReturnsNoneWhenIdExceedsActiveCount() {
+    assertEquals(FlixelGamepadButton.NONE, manager.firstPressed(1));
+  }
+
+  @Test
+  void firstPressedReturnsNoneWhenNothingHeld() {
+    assertEquals(FlixelGamepadButton.NONE, manager.firstPressed(0));
+  }
+
+  @Test
+  void firstPressedReturnsChronologicallyFirstButton() throws Exception {
+    // B was pressed first, then A.
+    addToPressedOrder(0, TestMapping.NATIVE_B);
+    addToPressedOrder(0, TestMapping.NATIVE_A);
+    setCurrent(0, TestMapping.NATIVE_A, true);
+    setCurrent(0, TestMapping.NATIVE_B, true);
+
+    assertEquals(FlixelGamepadButton.B, manager.firstPressed(0));
+  }
+
+  @Test
+  void firstPressedReturnsSingleHeldButton() throws Exception {
+    addToPressedOrder(0, TestMapping.NATIVE_Y);
+    setCurrent(0, TestMapping.NATIVE_Y, true);
+
+    assertEquals(FlixelGamepadButton.Y, manager.firstPressed(0));
+  }
+
+  // --- firstJustPressed ---
+
+  @Test
+  void firstJustPressedReturnsNoneWhenDisabled() {
+    manager.enabled = false;
+    assertEquals(FlixelGamepadButton.NONE, manager.firstJustPressed(0));
+  }
+
+  @Test
+  void firstJustPressedReturnsNoneWhenNothingChanged() throws Exception {
+    setCurrent(0, TestMapping.NATIVE_A, true);
+    setPrevious(0, TestMapping.NATIVE_A, true);
+
+    assertEquals(FlixelGamepadButton.NONE, manager.firstJustPressed(0));
+  }
+
+  @Test
+  void firstJustPressedReturnsButtonThatTransitionedToPressed() throws Exception {
+    setCurrent(0, TestMapping.NATIVE_A, true);
+    // previous is false by default
+
+    assertEquals(FlixelGamepadButton.A, manager.firstJustPressed(0));
+  }
+
+  @Test
+  void firstJustPressedSkipsButtonAlreadyHeldLastFrame() throws Exception {
+    // B was held last frame; X is newly pressed.
+    setCurrent(0, TestMapping.NATIVE_B, true);
+    setPrevious(0, TestMapping.NATIVE_B, true);
+    setCurrent(0, TestMapping.NATIVE_X, true);
+
+    assertEquals(FlixelGamepadButton.X, manager.firstJustPressed(0));
+  }
+
+  @Test
+  void firstJustPressedReturnsSyntheticL2WhenTriggerCrossesThreshold() throws Exception {
+    // L2 mapping is UNDEFINED in TestMapping, so the synthetic trigger slot is used.
+    int syntheticL = syntheticTriggerL();
+    setCurrent(0, syntheticL, true);
+
+    assertEquals(FlixelGamepadButton.L2, manager.firstJustPressed(0));
+  }
+
+  @Test
+  void firstJustPressedReturnsSyntheticR2WhenTriggerCrossesThreshold() throws Exception {
+    int syntheticR = syntheticTriggerR();
+    setCurrent(0, syntheticR, true);
+
+    assertEquals(FlixelGamepadButton.R2, manager.firstJustPressed(0));
+  }
+
+  // --- firstJustReleased ---
+
+  @Test
+  void firstJustReleasedReturnsNoneWhenDisabled() {
+    manager.enabled = false;
+    assertEquals(FlixelGamepadButton.NONE, manager.firstJustReleased(0));
+  }
+
+  @Test
+  void firstJustReleasedReturnsNoneWhenNothingChanged() throws Exception {
+    setCurrent(0, TestMapping.NATIVE_A, true);
+    setPrevious(0, TestMapping.NATIVE_A, true);
+
+    assertEquals(FlixelGamepadButton.NONE, manager.firstJustReleased(0));
+  }
+
+  @Test
+  void firstJustReleasedReturnsButtonThatTransitionedToReleased() throws Exception {
+    // previous = pressed, current = released
+    setPrevious(0, TestMapping.NATIVE_B, true);
+
+    assertEquals(FlixelGamepadButton.B, manager.firstJustReleased(0));
+  }
+
+  @Test
+  void firstJustReleasedSkipsButtonStillHeld() throws Exception {
+    // A is held both frames; B was released.
+    setCurrent(0, TestMapping.NATIVE_A, true);
+    setPrevious(0, TestMapping.NATIVE_A, true);
+    setPrevious(0, TestMapping.NATIVE_B, true);
+
+    assertEquals(FlixelGamepadButton.B, manager.firstJustReleased(0));
+  }
+
+  @Test
+  void firstJustReleasedReturnsSyntheticL2WhenTriggerDropsBelowThreshold() throws Exception {
+    int syntheticL = syntheticTriggerL();
+    setPrevious(0, syntheticL, true);
+
+    assertEquals(FlixelGamepadButton.L2, manager.firstJustReleased(0));
+  }
+
+  @Test
+  void firstJustReleasedReturnsSyntheticR2WhenTriggerDropsBelowThreshold() throws Exception {
+    int syntheticR = syntheticTriggerR();
+    setPrevious(0, syntheticR, true);
+
+    assertEquals(FlixelGamepadButton.R2, manager.firstJustReleased(0));
+  }
+
+  // --- helpers ---
+
+  private void injectController(int slot, Controller c) throws Exception {
+    Field f = FlixelGamepadInputManager.class.getDeclaredField("slotController");
+    f.setAccessible(true);
+    ((Controller[]) f.get(manager))[slot] = c;
+  }
+
+  private void setCurrent(int slot, int button, boolean state) throws Exception {
+    Field f = FlixelGamepadInputManager.class.getDeclaredField("currentButtons");
+    f.setAccessible(true);
+    ((boolean[][]) f.get(manager))[slot][button] = state;
+  }
+
+  private void setPrevious(int slot, int button, boolean state) throws Exception {
+    Field f = FlixelGamepadInputManager.class.getDeclaredField("previousButtons");
+    f.setAccessible(true);
+    ((boolean[][]) f.get(manager))[slot][button] = state;
+  }
+
+  private void addToPressedOrder(int slot, int nativeButton) throws Exception {
+    Field f = FlixelGamepadInputManager.class.getDeclaredField("pressedOrder");
+    f.setAccessible(true);
+    ((IntArray[]) f.get(manager))[slot].add(nativeButton);
+  }
+
+  private static int syntheticTriggerL() throws Exception {
+    Field f = FlixelGamepadInputManager.class.getDeclaredField("SYNTHETIC_TRIGGER_L");
+    f.setAccessible(true);
+    return f.getInt(null);
+  }
+
+  private static int syntheticTriggerR() throws Exception {
+    Field f = FlixelGamepadInputManager.class.getDeclaredField("SYNTHETIC_TRIGGER_R");
+    f.setAccessible(true);
+    return f.getInt(null);
+  }
+}

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManagerTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/gamepad/FlixelGamepadInputManagerTest.java
@@ -182,18 +182,15 @@ class FlixelGamepadInputManagerTest {
   }
 
   private FlixelGamepadInputManager manager;
-  private StubController stub;
 
   @BeforeEach
   void setUp() throws Exception {
     manager = new FlixelGamepadInputManager();
     manager.enabled = true;
     manager.numActiveGamepads = 1;
-    stub = new StubController();
-    injectController(0, stub);
+    StubController stub = new StubController();
+    injectController(stub);
   }
-
-  // --- firstPressed ---
 
   @Test
   void firstPressedReturnsNoneWhenDisabled() {
@@ -219,23 +216,21 @@ class FlixelGamepadInputManagerTest {
   @Test
   void firstPressedReturnsChronologicallyFirstButton() throws Exception {
     // B was pressed first, then A.
-    addToPressedOrder(0, TestMapping.NATIVE_B);
-    addToPressedOrder(0, TestMapping.NATIVE_A);
-    setCurrent(0, TestMapping.NATIVE_A, true);
-    setCurrent(0, TestMapping.NATIVE_B, true);
+    addToPressedOrder(TestMapping.NATIVE_B);
+    addToPressedOrder(TestMapping.NATIVE_A);
+    setCurrent(TestMapping.NATIVE_A);
+    setCurrent(TestMapping.NATIVE_B);
 
     assertEquals(FlixelGamepadButton.B, manager.firstPressed(0));
   }
 
   @Test
   void firstPressedReturnsSingleHeldButton() throws Exception {
-    addToPressedOrder(0, TestMapping.NATIVE_Y);
-    setCurrent(0, TestMapping.NATIVE_Y, true);
+    addToPressedOrder(TestMapping.NATIVE_Y);
+    setCurrent(TestMapping.NATIVE_Y);
 
     assertEquals(FlixelGamepadButton.Y, manager.firstPressed(0));
   }
-
-  // --- firstJustPressed ---
 
   @Test
   void firstJustPressedReturnsNoneWhenDisabled() {
@@ -245,16 +240,16 @@ class FlixelGamepadInputManagerTest {
 
   @Test
   void firstJustPressedReturnsNoneWhenNothingChanged() throws Exception {
-    setCurrent(0, TestMapping.NATIVE_A, true);
-    setPrevious(0, TestMapping.NATIVE_A, true);
+    setCurrent(TestMapping.NATIVE_A);
+    setPrevious(TestMapping.NATIVE_A);
 
     assertEquals(FlixelGamepadButton.NONE, manager.firstJustPressed(0));
   }
 
   @Test
   void firstJustPressedReturnsButtonThatTransitionedToPressed() throws Exception {
-    setCurrent(0, TestMapping.NATIVE_A, true);
-    // previous is false by default
+    setCurrent(TestMapping.NATIVE_A);
+    // Previous is false by default.
 
     assertEquals(FlixelGamepadButton.A, manager.firstJustPressed(0));
   }
@@ -262,9 +257,9 @@ class FlixelGamepadInputManagerTest {
   @Test
   void firstJustPressedSkipsButtonAlreadyHeldLastFrame() throws Exception {
     // B was held last frame; X is newly pressed.
-    setCurrent(0, TestMapping.NATIVE_B, true);
-    setPrevious(0, TestMapping.NATIVE_B, true);
-    setCurrent(0, TestMapping.NATIVE_X, true);
+    setCurrent(TestMapping.NATIVE_B);
+    setPrevious(TestMapping.NATIVE_B);
+    setCurrent(TestMapping.NATIVE_X);
 
     assertEquals(FlixelGamepadButton.X, manager.firstJustPressed(0));
   }
@@ -273,7 +268,7 @@ class FlixelGamepadInputManagerTest {
   void firstJustPressedReturnsSyntheticL2WhenTriggerCrossesThreshold() throws Exception {
     // L2 mapping is UNDEFINED in TestMapping, so the synthetic trigger slot is used.
     int syntheticL = syntheticTriggerL();
-    setCurrent(0, syntheticL, true);
+    setCurrent(syntheticL);
 
     assertEquals(FlixelGamepadButton.L2, manager.firstJustPressed(0));
   }
@@ -281,12 +276,10 @@ class FlixelGamepadInputManagerTest {
   @Test
   void firstJustPressedReturnsSyntheticR2WhenTriggerCrossesThreshold() throws Exception {
     int syntheticR = syntheticTriggerR();
-    setCurrent(0, syntheticR, true);
+    setCurrent(syntheticR);
 
     assertEquals(FlixelGamepadButton.R2, manager.firstJustPressed(0));
   }
-
-  // --- firstJustReleased ---
 
   @Test
   void firstJustReleasedReturnsNoneWhenDisabled() {
@@ -296,16 +289,16 @@ class FlixelGamepadInputManagerTest {
 
   @Test
   void firstJustReleasedReturnsNoneWhenNothingChanged() throws Exception {
-    setCurrent(0, TestMapping.NATIVE_A, true);
-    setPrevious(0, TestMapping.NATIVE_A, true);
+    setCurrent(TestMapping.NATIVE_A);
+    setPrevious(TestMapping.NATIVE_A);
 
     assertEquals(FlixelGamepadButton.NONE, manager.firstJustReleased(0));
   }
 
   @Test
   void firstJustReleasedReturnsButtonThatTransitionedToReleased() throws Exception {
-    // previous = pressed, current = released
-    setPrevious(0, TestMapping.NATIVE_B, true);
+    // previous = pressed, current = released.
+    setPrevious(TestMapping.NATIVE_B);
 
     assertEquals(FlixelGamepadButton.B, manager.firstJustReleased(0));
   }
@@ -313,9 +306,9 @@ class FlixelGamepadInputManagerTest {
   @Test
   void firstJustReleasedSkipsButtonStillHeld() throws Exception {
     // A is held both frames; B was released.
-    setCurrent(0, TestMapping.NATIVE_A, true);
-    setPrevious(0, TestMapping.NATIVE_A, true);
-    setPrevious(0, TestMapping.NATIVE_B, true);
+    setCurrent(TestMapping.NATIVE_A);
+    setPrevious(TestMapping.NATIVE_A);
+    setPrevious(TestMapping.NATIVE_B);
 
     assertEquals(FlixelGamepadButton.B, manager.firstJustReleased(0));
   }
@@ -323,7 +316,7 @@ class FlixelGamepadInputManagerTest {
   @Test
   void firstJustReleasedReturnsSyntheticL2WhenTriggerDropsBelowThreshold() throws Exception {
     int syntheticL = syntheticTriggerL();
-    setPrevious(0, syntheticL, true);
+    setPrevious(syntheticL);
 
     assertEquals(FlixelGamepadButton.L2, manager.firstJustReleased(0));
   }
@@ -331,35 +324,33 @@ class FlixelGamepadInputManagerTest {
   @Test
   void firstJustReleasedReturnsSyntheticR2WhenTriggerDropsBelowThreshold() throws Exception {
     int syntheticR = syntheticTriggerR();
-    setPrevious(0, syntheticR, true);
+    setPrevious(syntheticR);
 
     assertEquals(FlixelGamepadButton.R2, manager.firstJustReleased(0));
   }
 
-  // --- helpers ---
-
-  private void injectController(int slot, Controller c) throws Exception {
+  private void injectController(Controller c) throws Exception {
     Field f = FlixelGamepadInputManager.class.getDeclaredField("slotController");
     f.setAccessible(true);
-    ((Controller[]) f.get(manager))[slot] = c;
+    ((Controller[]) f.get(manager))[0] = c;
   }
 
-  private void setCurrent(int slot, int button, boolean state) throws Exception {
+  private void setCurrent(int button) throws Exception {
     Field f = FlixelGamepadInputManager.class.getDeclaredField("currentButtons");
     f.setAccessible(true);
-    ((boolean[][]) f.get(manager))[slot][button] = state;
+    ((boolean[][]) f.get(manager))[0][button] = true;
   }
 
-  private void setPrevious(int slot, int button, boolean state) throws Exception {
+  private void setPrevious(int button) throws Exception {
     Field f = FlixelGamepadInputManager.class.getDeclaredField("previousButtons");
     f.setAccessible(true);
-    ((boolean[][]) f.get(manager))[slot][button] = state;
+    ((boolean[][]) f.get(manager))[0][button] = true;
   }
 
-  private void addToPressedOrder(int slot, int nativeButton) throws Exception {
+  private void addToPressedOrder(int nativeButton) throws Exception {
     Field f = FlixelGamepadInputManager.class.getDeclaredField("pressedOrder");
     f.setAccessible(true);
-    ((IntArray[]) f.get(manager))[slot].add(nativeButton);
+    ((IntArray[]) f.get(manager))[0].add(nativeButton);
   }
 
   private static int syntheticTriggerL() throws Exception {

--- a/flixelgdx-test/src/test/java/org/flixelgdx/input/gamepad/FlixelHapticsTest.java
+++ b/flixelgdx-test/src/test/java/org/flixelgdx/input/gamepad/FlixelHapticsTest.java
@@ -29,11 +29,11 @@ import org.junit.jupiter.api.Test;
 
 class FlixelHapticsTest {
 
-  private FlixelGamepadManager manager;
+  private FlixelGamepadInputManager manager;
 
   @BeforeEach
   void setUp() {
-    manager = new FlixelGamepadManager();
+    manager = new FlixelGamepadInputManager();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Added `firstPressed(int gamepadId)`, `firstJustPressed(int gamepadId)`, and `firstJustReleased(int gamepadId)` to `FlixelGamepadInputManager`, mirroring the same API pattern from `FlixelKeyInputManager`
- All three methods return a logical `FlixelGamepadButton` constant (or `FlixelGamepadButton.NONE`), so callers can compare against named constants directly (e.g. `if (btn == FlixelGamepadButton.A)`)
- Added a private `nativeButtonToLogical` helper (reverse of the existing `FlixelGamepadButton.logicalButtonToNative`)
- `firstPressed` tracks chronological button press order using a new per-slot `IntArray[] pressedOrder`, maintained in `pollHardware()` and cleared in `clearSlot()` / `reset()`
- `firstJustPressed` and `firstJustReleased` scan the current/previous button arrays, and additionally cover the synthetic L2/R2 trigger slots used on SDL/Jamepad backends where triggers are axes rather than buttons
- Added 18 unit tests in `FlixelGamepadInputManagerTest`, covering all three methods across disabled, out-of-range, no-button, and synthetic trigger scenarios; state is injected via reflection to remain isolated from the hardware layer

## Test plan

- [x] All 18 new tests pass (`FlixelGamepadInputManagerTest`)
- [x] Full test suite passes (25 suites, 0 failures)
- [x] Spotless applied
- [x] Javadoc lint clean (pre-existing warnings in `Flixel.java` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)