### PR TITLE
Fixed and issue with atlas-based sprites not receiving antialiasing

### DIFF
--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -24,6 +24,7 @@
 package org.flixelgdx;
 
 import com.badlogic.gdx.Preferences;
+import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
@@ -50,6 +51,7 @@ import org.flixelgdx.functional.FlixelAntialiasable;
 import org.flixelgdx.functional.FlixelDrawable;
 import org.flixelgdx.graphics.FlixelBatch;
 import org.flixelgdx.group.FlixelGroupable;
+import org.flixelgdx.input.gamepad.FlixelGamepadButton;
 import org.flixelgdx.input.gamepad.FlixelGamepadInputManager;
 import org.flixelgdx.input.keyboard.FlixelKeyInputManager;
 import org.flixelgdx.input.mouse.FlixelMouseButton;
@@ -1333,6 +1335,10 @@ public final class Flixel {
    * value to actually apply to any {@link FlixelSprite} / {@link FlixelAntialiasable} object being
    * added to a {@link FlixelState}, set {@link #applyAntialiasingOnStateAdd} to {@code true}.
    *
+   * <p>After propagating the new value to every state member, this method calls
+   * {@link #refreshAntialiasing()} to guarantee that members sharing the same underlying texture
+   * end up with a consistent filter. See that method's documentation for details.
+   *
    * @param enabled If antialiasing should be applied to all current
    *     {@link FlixelSprite} / {@link FlixelAntialiasable} objects.
    */
@@ -1358,6 +1364,68 @@ public final class Flixel {
       }
       if (member instanceof FlixelAntialiasable m) {
         m.setAntialiasing(enabled);
+      }
+    }
+    members.end();
+    refreshAntialiasing();
+  }
+
+  /**
+   * Re-applies texture filter settings for every {@link FlixelAntialiasable} member of the current
+   * state in a two-pass order that resolves conflicts on shared textures.
+   *
+   * <p>OpenGL texture filtering is a property of the texture object itself, not of each individual
+   * sprite. When multiple sprites share the same underlying texture (for example, every arrow in a
+   * rhythm game's strumline atlas), the last call sets the filter for the texture directly, regardless
+   * of which sprite made the call. This can leave sprites with {@code antialiasing = true} rendering with
+   * a {@link Texture.TextureFilter#Nearest} filter if a sprite with {@code antialiasing = false} that
+   * uses the same texture was set up last.
+   *
+   * <p>This method fixes that by always processing members in two passes:
+   * <ol>
+   *   <li>First, all members whose {@code antialiasing} flag is {@code false} re-apply Nearest.</li>
+   *   <li>Then, all members whose {@code antialiasing} flag is {@code true} re-apply Linear.</li>
+   * </ol>
+   * Because the Linear pass runs last, any texture shared between a "smooth" and a "pixelated"
+   * member will end up with a {@link Texture.TextureFilter#Linear}, matching what a developer who requested
+   * antialiasing would expect.
+   *
+   * <p>Call this after finishing the setup of a state (for example, at the end of
+   * {@link FlixelState#create()}), especially when some state members share textures but have
+   * different antialiasing settings.
+   *
+   * <p>Example usage:
+   * <pre>{@code
+   * @Override
+   * public void create() {
+   *   // ... add all sprites, groups, etc. ...
+   *   Flixel.refreshAntialiasing();
+   * }
+   * }</pre>
+   */
+  public static void refreshAntialiasing() {
+    if (state == null) {
+      return;
+    }
+    var members = state.getMembers();
+    if (members == null) {
+      return;
+    }
+
+    var mbrs = members.begin();
+    for (int i = 0; i < members.size; i++) {
+      var member = mbrs[i];
+      if (member instanceof FlixelAntialiasable m && !m.isAntialiasing()) {
+        m.setAntialiasing(false);
+      }
+    }
+    members.end();
+
+    mbrs = members.begin();
+    for (int i = 0; i < members.size; i++) {
+      var member = mbrs[i];
+      if (member instanceof FlixelAntialiasable m && m.isAntialiasing()) {
+        m.setAntialiasing(true);
       }
     }
     members.end();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -484,6 +484,10 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
       // this is just a sensible default for the very first frame.
       setSize(first.originalWidth, first.originalHeight);
       setOriginCenter();
+      if (antialiasing) {
+        newGraphic.getTexture().setFilter(
+            Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+      }
     }
   }
 
@@ -532,8 +536,10 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     }
     secondaryGraphics.add(graphic);
 
-    if (antialiasing && graphic.isLoaded()) {
-      graphic.getTexture().setFilter(Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
+    if (graphic.isLoaded()) {
+      graphic.getTexture().setFilter(
+          antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest,
+          antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest);
     }
   }
 
@@ -946,6 +952,14 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
       texture.setFilter(
           antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest,
           antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest);
+    }
+    if (secondaryGraphics != null) {
+      for (FlixelGraphic g : secondaryGraphics) {
+        var t = g.getTexture();
+        t.setFilter(
+            antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest,
+            antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest);
+      }
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelSprite.java
@@ -36,6 +36,7 @@ import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.scenes.scene2d.utils.ScissorStack;
 import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.XmlReader;
 
 import org.flixelgdx.animation.FlixelAnimationController;
 import org.flixelgdx.animation.FlixelSpritemapJsonLoader;
@@ -230,7 +231,8 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
   }
 
   /**
-   * Returns the existing controller or creates and assigns a new {@link FlixelAnimationController} for {@code this} sprite.
+   * Returns the existing controller or creates and assigns a new {@link FlixelAnimationController}
+   * for {@code this} sprite.
    */
   @NotNull
   public FlixelAnimationController ensureAnimation() {
@@ -325,6 +327,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
     frames = wrapFrames(regions);
     currentFrame = frames[0][0];
     updateHitbox(frameWidth, frameHeight);
+    setAntialiasing(antialiasing);
     return this;
   }
 
@@ -412,6 +415,7 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
       animation.clear();
     }
     updateHitbox(frameWidth, frameHeight);
+    setAntialiasing(antialiasing);
     return this;
   }
 
@@ -459,10 +463,10 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
 
   /**
    * Installs a retained {@link FlixelGraphic} and parsed Sparrow atlas frames. Called by
-   * {@link FlixelAnimationController#addSparrowFrames(String, com.badlogic.gdx.utils.XmlReader.Element)} and
+   * {@link FlixelAnimationController#addSparrowFrames(String, XmlReader.Element)} and
    * {@link FlixelSpritemapJsonLoader#load}, not a general API for game code.
    *
-   * @param newGraphic Graphic from {@link Flixel#ensureAssets() Flixel.ensureAssets()}{@code .get}(...) with
+   * @param newGraphic Graphic from {@link Flixel#ensureAssets() Flixel.ensureAssets()}{@code .get(...)} with
    *     {@code retain()} already called.
    * @param parsedFrames Frames built from the XML (which may be empty).
    */
@@ -484,10 +488,9 @@ public class FlixelSprite extends FlixelObject implements FlixelAntialiasable, F
       // this is just a sensible default for the very first frame.
       setSize(first.originalWidth, first.originalHeight);
       setOriginCenter();
-      if (antialiasing) {
-        newGraphic.getTexture().setFilter(
-            Texture.TextureFilter.Linear, Texture.TextureFilter.Linear);
-      }
+      newGraphic.getTexture().setFilter(
+          antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest,
+          antialiasing ? Texture.TextureFilter.Linear : Texture.TextureFilter.Nearest);
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
@@ -348,6 +348,7 @@ public class FlixelSpriteGroup extends FlixelSprite implements FlixelBasicGroupa
   @Override
   public void setAntialiasing(boolean antialiasing) {
     this.antialiasing = antialiasing;
+    super.setAntialiasing(antialiasing);
     FlixelSprite[] items = members.begin();
     for (int i = 0, n = members.size; i < n; i++) {
       FlixelSprite s = items[i];

--- a/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/group/FlixelSpriteGroup.java
@@ -779,14 +779,14 @@ public class FlixelSpriteGroup extends FlixelSprite implements FlixelBasicGroupa
   }
 
   @Override
-  public void update(float delta) {
-    super.update(delta);
+  public void update(float elapsed) {
+    super.update(elapsed);
 
     FlixelSprite[] items = members.begin();
     for (int i = 0, n = members.size; i < n; i++) {
       FlixelSprite member = items[i];
       if (member != null) {
-        member.update(delta);
+        member.update(elapsed);
       }
     }
     members.end();

--- a/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelShader.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/util/FlixelShader.java
@@ -290,7 +290,7 @@ public class FlixelShader extends FlixelBasic {
 
   /** Returns whether this shader compiled without errors and is ready to use. */
   public boolean getCompiled() {
-    return program != null && program.isCompiled();
+    return isCompiled();
   }
 
   /**


### PR DESCRIPTION
## Description

Previously, antialiasing on some sprites (particularly ones using Sparrow sheets) never got antialiasing applied correctly. `FlixelSprite` now receives these fixes.

Alongside of it, a new method has been added to `Flixel`, which re-applies antialiasing on all sprites in the current state to ensure they all visually get the same effect.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Tested inside of a test game.
