### PR TITLE
Reworked how video extension natives are handled by pre-packaging them inside JARs to make the video extension more robust

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,10 +50,16 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Install p7zip (required to extract the macOS VLC DMG on Linux)
+        run: sudo apt-get install -y p7zip-full
+
       - name: Publish to Maven Central
         # Secrets are injected as Gradle project properties via the ORG_GRADLE_PROJECT_ prefix.
         # signingInMemoryKey is the ASCII-armored GPG private key (supports newlines safely as an env var).
         # The artifact version is derived from the git tag: v1.2.3 -> 1.2.3.
+        # packageVlcNatives=true triggers DownloadVlcNativesTask in flixelgdx-video-vlc-natives,
+        # which downloads and strips all three platform bundles before they are JAR-packaged and
+        # published alongside the rest of the framework artifacts.
         env:
           ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
@@ -64,6 +70,6 @@ jobs:
           VERSION=${GITHUB_REF_NAME#v}
           ./gradlew publishAllPublicationsToMavenCentralRepository \
             -PprojectVersion=$VERSION \
-            -PskipVlcNatives=true \
+            -PpackageVlcNatives=true \
             --no-daemon \
             --warning-mode all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We welcome contributions! Whether you're fixing bugs, adding new features, or im
 
 > [!IMPORTANT]
 > ## Our Stance on AI
-> We welcome AI assistance with open arms. We believe that AI (if used correctly) is a powerful tool, which can be a massive
+> We welcome AI assistance with open arms. We believe that AI -- if used correctly -- is an incredibly powerful tool, which can be an enhansive
 > aid for development; however, we put emphasis on "assistance". While AI can be incredibly useful, it's not a replacement.
 > You can't outsource to AI with a brain if you don't have one in the first place.
 >
@@ -22,6 +22,14 @@ We welcome contributions! Whether you're fixing bugs, adding new features, or im
 > point asks you about whether or not you used AI to help you, we request you to be honest and transparent about it.
 >
 > 3. If your code is broken or rejected, ***it is not the AI's fault, it is yours***. AI is useful, but it can't do the thinking for you.
+> 
+> 4. We do not mind if you create pull request *descriptions* with AI. As long as the information provided is accurate and there's clear evidence 
+> that the pull request fulfills the task it's for, it's okay by us; *however*, you're **not allowed to use AI to comment in the PR conversation or 
+> any area where it requires human communication.** That must be done by you. It's extremely rude and unethical to use a chatbot to talk to other 
+> human collaborators for you.
+> 
+> 5. AI-generated bug reports are **not allowed**. If there's an issue with your game or the framework itself, *you* are the one who should address it.
+> AI is allowed to find the bug itself, but you need to be the one presenting it. This also includes feature requests for the same obvious reasons.
 
 ## Java runtime (JDK 17, Eclipse Temurin)
 

--- a/build-logic/src/main/kotlin/DownloadVlcNativesTask.kt
+++ b/build-logic/src/main/kotlin/DownloadVlcNativesTask.kt
@@ -1,6 +1,4 @@
-import org.apache.commons.compress.archivers.ar.ArArchiveInputStream
 import org.apache.commons.compress.archivers.sevenz.SevenZFile
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.ArchiveOperations
@@ -12,12 +10,10 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
-import org.tukaani.xz.XZInputStream
 import java.io.File
 import java.net.URI
 import java.security.MessageDigest
 import java.util.Locale
-import java.util.zip.GZIPInputStream
 import javax.inject.Inject
 
 /**
@@ -108,29 +104,29 @@ abstract class DownloadVlcNativesTask @Inject constructor(
   }
 
   private fun extractDeb(deb: File, destDir: File) {
-    deb.inputStream().use { fis ->
-      val ar = ArArchiveInputStream(fis)
-      var entry = ar.nextEntry
-      while (entry != null) {
-        if (entry.name.startsWith("data.tar")) {
-          val dataStream = when {
-            entry.name.endsWith(".xz") -> XZInputStream(ar)
-            entry.name.endsWith(".gz") -> GZIPInputStream(ar)
-            else -> ar
-          }
-          val tar = TarArchiveInputStream(dataStream)
-          var tarEntry = tar.nextEntry
-          while (tarEntry != null) {
-            if (tarEntry.isFile) {
-              val out = File(destDir, tarEntry.name)
-              out.parentFile.mkdirs()
-              out.outputStream().use { tar.copyTo(it) }
-            }
-            tarEntry = tar.nextEntry
-          }
-        }
-        entry = ar.nextEntry
+    // Use system ar/tar instead of commons-compress to avoid classloader version conflicts
+    // with the Android Gradle Plugin, which pulls commons-compress 1.21 into a shared
+    // parent classloader that overrides build-logic's 1.27.x at runtime.
+    destDir.mkdirs()
+    val arStage = createTempDir("deb-ar-")
+    try {
+      val arResult = ProcessBuilder("ar", "x", deb.absolutePath)
+        .directory(arStage)
+        .redirectErrorStream(true)
+        .start()
+      val arOut = arResult.inputStream.bufferedReader().readText()
+      val arExit = arResult.waitFor()
+      if (arExit != 0) throw GradleException("ar x failed for ${deb.name} (exit $arExit): $arOut")
+      arStage.listFiles()?.filter { it.name.startsWith("data.tar") }?.forEach { dataTar ->
+        val tarResult = ProcessBuilder("tar", "xf", dataTar.absolutePath, "-C", destDir.absolutePath)
+          .redirectErrorStream(true)
+          .start()
+        val tarOut = tarResult.inputStream.bufferedReader().readText()
+        val tarExit = tarResult.waitFor()
+        if (tarExit != 0) throw GradleException("tar xf failed for ${dataTar.name} (exit $tarExit): $tarOut")
       }
+    } finally {
+      arStage.deleteRecursively()
     }
   }
 
@@ -152,18 +148,18 @@ abstract class DownloadVlcNativesTask @Inject constructor(
     }
   }
 
-  private fun findFile(files: Map<String, File>, suffix: String): File =
+  private fun findFile(files: Map<String, File>, suffix: String): File? =
     files.entries.firstOrNull { (name, _) -> name.endsWith(suffix) }?.value
-      ?: throw GradleException("No download spec found with name suffix '$suffix'")
 
   private fun extractWindows(version: String, files: Map<String, File>, outRoot: File) {
+    val zip = findFile(files, "-win64.zip") ?: return
     val blocklist = pluginBlocklist.get()
     val winDir = File(outRoot, "windows-amd64")
     val zipRoot = "vlc-$version/"
     if (!File(winDir, "libvlc.dll").exists()) {
       logger.lifecycle("Extracting Windows natives...")
       fs.copy {
-        from(archives.zipTree(findFile(files, "-win64.zip"))) {
+        from(archives.zipTree(zip)) {
           include("${zipRoot}libvlc.dll", "${zipRoot}libvlccore.dll", "${zipRoot}plugins/**")
           blocklist.forEach { exclude("${zipRoot}plugins/$it/**") }
           eachFile { path = path.substring(zipRoot.length) }
@@ -172,20 +168,23 @@ abstract class DownloadVlcNativesTask @Inject constructor(
         into(winDir)
       }
     }
-    if (!File(winDir, "sdk/libvlc.lib").exists()) {
+    val sevenZip = findFile(files, "-win64.7z")
+    if (sevenZip != null && !File(winDir, "sdk/libvlc.lib").exists()) {
       logger.lifecycle("Extracting Windows SDK import libraries...")
-      extractLibsFrom7z(findFile(files, "-win64.7z"), "vlc-$version/sdk/lib/", File(winDir, "sdk"))
+      extractLibsFrom7z(sevenZip, "vlc-$version/sdk/lib/", File(winDir, "sdk"))
     }
   }
 
   private fun extractLinux(files: Map<String, File>, outRoot: File, dlDir: File) {
+    val debs = downloadSpecs.get().filter { it["name"]!!.endsWith(".deb") }
+    if (debs.isEmpty()) return
     val blocklist = pluginBlocklist.get()
     val linuxDir = File(outRoot, "linux-amd64")
     if (!File(linuxDir, "libvlc.so.5").exists()) {
       logger.lifecycle("Extracting Linux natives...")
       val debStage = File(dlDir, "deb-stage")
       fs.delete { delete(debStage) }
-      downloadSpecs.get().filter { it["name"]!!.endsWith(".deb") }.forEach { spec ->
+      debs.forEach { spec ->
         extractDeb(files[spec["name"]]!!, debStage)
       }
       val usrLib = File(debStage, "usr/lib/x86_64-linux-gnu")
@@ -213,7 +212,7 @@ abstract class DownloadVlcNativesTask @Inject constructor(
   private fun extractMacOS(version: String, files: Map<String, File>, outRoot: File, dlDir: File) {
     val macDir = File(outRoot, "macos-universal")
     if (File(macDir, "lib/libvlc.dylib").exists()) return
-    val dmg = findFile(files, "-universal.dmg")
+    val dmg = findFile(files, "-universal.dmg") ?: return
     val sevenZip = listOf("7z", "7za").firstOrNull { tool ->
       try { ProcessBuilder(tool).start().waitFor(); true } catch (_: Exception) { false }
     }
@@ -223,13 +222,14 @@ abstract class DownloadVlcNativesTask @Inject constructor(
       fs.delete { delete(dmgStage) }
       dmgStage.mkdirs()
       val appPath = "VLC media player/VLC.app/Contents/MacOS"
-      val proc = ProcessBuilder(
+      val exitCode = ProcessBuilder(
         sevenZip, "x", "-y", "-o${dmgStage.absolutePath}", dmg.absolutePath,
         "$appPath/lib/*", "$appPath/plugins/*"
-      ).start()
-      proc.inputStream.use { }
-      proc.errorStream.use { }
-      proc.waitFor()
+      )
+        .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+        .redirectError(ProcessBuilder.Redirect.DISCARD)
+        .start()
+        .waitFor()
       val macSrc = File(dmgStage, appPath)
       if (File(macSrc, "lib").exists()) {
         fs.copy {

--- a/flixelgdx-video-lwjgl3/.gitignore
+++ b/flixelgdx-video-lwjgl3/.gitignore
@@ -1,1 +1,0 @@
-natives/

--- a/flixelgdx-video-lwjgl3/build.gradle.kts
+++ b/flixelgdx-video-lwjgl3/build.gradle.kts
@@ -12,7 +12,9 @@ dependencies {
   implementation(project(":flixelgdx-lwjgl3"))
   implementation(libs.gdx.backend.lwjgl3)
   implementation(libs.jetbrains.annotations)
-  runtimeOnly(project(":flixelgdx-video-vlc-natives"))
+  runtimeOnly(project(":flixelgdx-video-vlc-natives-windows-amd64"))
+  runtimeOnly(project(":flixelgdx-video-vlc-natives-linux-amd64"))
+  runtimeOnly(project(":flixelgdx-video-vlc-natives-macos-universal"))
 
   // Provides the Feature interface and RuntimeJNIAccess used by FlixelVideoGraalFeature.
   // Compile-only: the class runs inside native-image at build time, not in user runtimes.

--- a/flixelgdx-video-lwjgl3/build.gradle.kts
+++ b/flixelgdx-video-lwjgl3/build.gradle.kts
@@ -1,114 +1,9 @@
 // Desktop backend for the FlixelGDX video extension. Bridges libvlc into the framework through
-// JNA-registered JNI bindings and packages (optionally) the libvlc native libraries that
-// downloadVlcNatives fetches from upstream.
-
-import java.util.Locale
+// JNA-registered JNI bindings. The libvlc native libraries are provided at runtime by
+// flixelgdx-video-vlc-natives, which FlixelVlcDiscovery extracts from the classpath on first use.
 
 plugins {
   id("flixelgdx.java-library")
-}
-
-val vlcVersionString = libs.versions.vlc.get()
-
-val vlcDownloads = listOf(
-  mapOf(
-    "name" to "vlc-${vlcVersionString}-win64.zip",
-    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/win64/vlc-${vlcVersionString}-win64.zip",
-    "sha256" to "992d19dbd0b8a7cde9167d2f7780b1ef6f92acc8a71acfa736101a21f35181e1"
-  ),
-  mapOf(
-    "name" to "vlc-${vlcVersionString}-win64.7z",
-    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/win64/vlc-${vlcVersionString}-win64.7z",
-    "sha256" to "eb4fd8a28291da73608c733786a09610fea865fbe94113bcb60b91c1ebb8404a"
-  ),
-  mapOf(
-    "name" to "vlc-${vlcVersionString}-universal.dmg",
-    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/macosx/vlc-${vlcVersionString}-universal.dmg",
-    "sha256" to "56ee657c3aaf5c71b4ab7d6e4f4a77f6eca54633e0bf42a93b8116eb1d1f6ec9"
-  ),
-  mapOf(
-    "name" to "libvlc5_${vlcVersionString}-0+deb12u1_amd64.deb",
-    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/libvlc5_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
-    "sha256" to "07ad5c61dc41acf29c485224accf457b7632e68a910eee21badf30213e6ab359"
-  ),
-  mapOf(
-    "name" to "libvlccore9_${vlcVersionString}-0+deb12u1_amd64.deb",
-    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/libvlccore9_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
-    "sha256" to "a3114b86450777e4cbbd4620419b74d189367e5f5026286cc74c39c9e759bfa7"
-  ),
-  mapOf(
-    "name" to "vlc-plugin-base_${vlcVersionString}-0+deb12u1_amd64.deb",
-    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/vlc-plugin-base_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
-    "sha256" to "38b953a2a6355c5ba75e3e5d2015100d793fbf5a00211aaa78b2d705a9547cb1"
-  ),
-  mapOf(
-    "name" to "vlc-plugin-video-output_${vlcVersionString}-0+deb12u1_amd64.deb",
-    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/vlc-plugin-video-output_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
-    "sha256" to "de1d62487161efc62305b6e84cd364e71f109125d601401ee824d3291813e6e2"
-  )
-)
-
-// Plugin categories no game playback path needs (interface, scripting, streaming out,
-// discovery). Dropping them roughly halves the Windows natives payload.
-val vlcPluginBlocklist = listOf(
-  "gui", "lua", "control", "services_discovery", "visualization",
-  "mux", "stream_out", "access_output", "meta_engine", "keystore", "logger"
-)
-
-val vlcDownloadDir = layout.buildDirectory.dir("vlc-downloads")
-val vlcNativesDir = layout.projectDirectory.dir("natives")
-
-val downloadVlcNatives = tasks.register<DownloadVlcNativesTask>("downloadVlcNatives") {
-  group = "flixelgdx"
-  description = "Downloads libvlc $vlcVersionString natives (Windows, macOS, Linux) into natives/."
-  vlcVersion.set(vlcVersionString)
-  downloadSpecs.set(vlcDownloads)
-  pluginBlocklist.set(vlcPluginBlocklist)
-  downloadCacheDir.set(vlcDownloadDir)
-  nativesDir.set(vlcNativesDir)
-}
-
-val hostVlcPlatform = run {
-  val os = System.getProperty("os.name", "").lowercase(Locale.ROOT)
-  when {
-    os.contains("win") -> "windows-amd64"
-    os.contains("mac") -> "macos-universal"
-    else -> "linux-amd64"
-  }
-}
-
-fun vlcNativesComplete(platformDir: File): Boolean {
-  if (!platformDir.isDirectory) return false
-  fun hasLibIn(dir: File) = dir.isDirectory && (dir.listFiles()?.any { it.name.startsWith("libvlc") } ?: false)
-  val hasLib = hasLibIn(platformDir) || hasLibIn(File(platformDir, "lib"))
-  val pluginsDir = if (File(platformDir, "plugins").isDirectory) File(platformDir, "plugins")
-  else File(platformDir, "vlc/plugins")
-  val hasPlugins = pluginsDir.isDirectory && (pluginsDir.listFiles()?.isNotEmpty() ?: false)
-  return hasLib && hasPlugins
-}
-
-if ((findProperty("skipVlcNatives") ?: "false") != "true") {
-  tasks.processResources {
-    dependsOn(downloadVlcNatives)
-    // Fail loudly if the host platform's natives did not make it into natives/. Without this
-    // the jar is packaged silently and the missing libraries only surface at runtime as an
-    // unavailable video, which is exactly the failure this module tries to prevent.
-    doFirst {
-      val hostDir = File(vlcNativesDir.asFile, hostVlcPlatform)
-      if (!vlcNativesComplete(hostDir)) {
-        throw GradleException(
-          "flixelgdx-video-lwjgl3: libvlc natives for this platform ($hostVlcPlatform) are " +
-            "missing or incomplete under $hostDir. Run './gradlew " +
-            ":flixelgdx-video-lwjgl3:downloadVlcNatives' (needs network access), or pass " +
-            "-PskipVlcNatives=true to build a slim jar that relies on a system VLC install."
-        )
-      }
-    }
-    from(vlcNativesDir) {
-      into("org/flixelgdx/video/natives")
-      exclude("**/sdk/**")
-    }
-  }
 }
 
 dependencies {
@@ -117,6 +12,7 @@ dependencies {
   implementation(project(":flixelgdx-lwjgl3"))
   implementation(libs.gdx.backend.lwjgl3)
   implementation(libs.jetbrains.annotations)
+  runtimeOnly(project(":flixelgdx-video-vlc-natives"))
 
   // Provides the Feature interface and RuntimeJNIAccess used by FlixelVideoGraalFeature.
   // Compile-only: the class runs inside native-image at build time, not in user runtimes.

--- a/flixelgdx-video-vlc-natives-linux-amd64/build.gradle.kts
+++ b/flixelgdx-video-vlc-natives-linux-amd64/build.gradle.kts
@@ -1,11 +1,3 @@
-// Packages libvlc native libraries for Windows, macOS, and Linux into a single JAR.
-// flixelgdx-video-lwjgl3 pulls this as a runtimeOnly dependency; FlixelVlcDiscovery
-// extracts the correct platform's files to a per-user cache at runtime.
-//
-// Download and packaging are gated behind -PpackageVlcNatives=true so normal developer
-// builds stay fast and network-free. The publish workflow sets this flag when cutting a
-// release so that the natives JAR is always up to date on Maven Central.
-
 plugins {
   id("flixelgdx.java-library")
 }
@@ -13,21 +5,6 @@ plugins {
 val vlcVersionString = libs.versions.vlc.get()
 
 val vlcDownloads = listOf(
-  mapOf(
-    "name" to "vlc-${vlcVersionString}-win64.zip",
-    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/win64/vlc-${vlcVersionString}-win64.zip",
-    "sha256" to "992d19dbd0b8a7cde9167d2f7780b1ef6f92acc8a71acfa736101a21f35181e1"
-  ),
-  mapOf(
-    "name" to "vlc-${vlcVersionString}-win64.7z",
-    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/win64/vlc-${vlcVersionString}-win64.7z",
-    "sha256" to "eb4fd8a28291da73608c733786a09610fea865fbe94113bcb60b91c1ebb8404a"
-  ),
-  mapOf(
-    "name" to "vlc-${vlcVersionString}-universal.dmg",
-    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/macosx/vlc-${vlcVersionString}-universal.dmg",
-    "sha256" to "56ee657c3aaf5c71b4ab7d6e4f4a77f6eca54633e0bf42a93b8116eb1d1f6ec9"
-  ),
   mapOf(
     "name" to "libvlc5_${vlcVersionString}-0+deb12u1_amd64.deb",
     "url" to "https://deb.debian.org/debian/pool/main/v/vlc/libvlc5_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
@@ -50,8 +27,6 @@ val vlcDownloads = listOf(
   )
 )
 
-// Plugin categories no game playback path needs (interface, scripting, streaming out,
-// discovery). Dropping them roughly halves the Windows natives payload.
 val vlcPluginBlocklist = listOf(
   "gui", "lua", "control", "services_discovery", "visualization",
   "mux", "stream_out", "access_output", "meta_engine", "keystore", "logger"
@@ -63,7 +38,7 @@ val vlcNativesDir = layout.buildDirectory.dir("vlc-natives")
 if ((findProperty("packageVlcNatives") ?: "false") == "true") {
   val downloadVlcNatives = tasks.register<DownloadVlcNativesTask>("downloadVlcNatives") {
     group = "flixelgdx"
-    description = "Downloads libvlc $vlcVersionString natives (Windows, macOS, Linux) for JAR packaging."
+    description = "Downloads libvlc $vlcVersionString Linux natives for JAR packaging."
     vlcVersion.set(vlcVersionString)
     downloadSpecs.set(vlcDownloads)
     pluginBlocklist.set(vlcPluginBlocklist)
@@ -75,7 +50,6 @@ if ((findProperty("packageVlcNatives") ?: "false") == "true") {
     dependsOn(downloadVlcNatives)
     from(vlcNativesDir) {
       into("org/flixelgdx/video/natives")
-      exclude("**/sdk/**")
     }
   }
 }

--- a/flixelgdx-video-vlc-natives-macos-universal/build.gradle.kts
+++ b/flixelgdx-video-vlc-natives-macos-universal/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+  id("flixelgdx.java-library")
+}
+
+val vlcVersionString = libs.versions.vlc.get()
+
+val vlcDownloads = listOf(
+  mapOf(
+    "name" to "vlc-${vlcVersionString}-universal.dmg",
+    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/macosx/vlc-${vlcVersionString}-universal.dmg",
+    "sha256" to "56ee657c3aaf5c71b4ab7d6e4f4a77f6eca54633e0bf42a93b8116eb1d1f6ec9"
+  )
+)
+
+val vlcPluginBlocklist = listOf(
+  "gui", "lua", "control", "services_discovery", "visualization",
+  "mux", "stream_out", "access_output", "meta_engine", "keystore", "logger"
+)
+
+val vlcDownloadDir = layout.buildDirectory.dir("vlc-downloads")
+val vlcNativesDir = layout.buildDirectory.dir("vlc-natives")
+
+if ((findProperty("packageVlcNatives") ?: "false") == "true") {
+  val downloadVlcNatives = tasks.register<DownloadVlcNativesTask>("downloadVlcNatives") {
+    group = "flixelgdx"
+    description = "Downloads libvlc $vlcVersionString macOS natives for JAR packaging."
+    vlcVersion.set(vlcVersionString)
+    downloadSpecs.set(vlcDownloads)
+    pluginBlocklist.set(vlcPluginBlocklist)
+    downloadCacheDir.set(vlcDownloadDir)
+    nativesDir.set(vlcNativesDir)
+  }
+
+  tasks.processResources {
+    dependsOn(downloadVlcNatives)
+    from(vlcNativesDir) {
+      into("org/flixelgdx/video/natives")
+    }
+  }
+}

--- a/flixelgdx-video-vlc-natives-windows-amd64/build.gradle.kts
+++ b/flixelgdx-video-vlc-natives-windows-amd64/build.gradle.kts
@@ -1,0 +1,41 @@
+plugins {
+  id("flixelgdx.java-library")
+}
+
+val vlcVersionString = libs.versions.vlc.get()
+
+val vlcDownloads = listOf(
+  mapOf(
+    "name" to "vlc-${vlcVersionString}-win64.zip",
+    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/win64/vlc-${vlcVersionString}-win64.zip",
+    "sha256" to "992d19dbd0b8a7cde9167d2f7780b1ef6f92acc8a71acfa736101a21f35181e1"
+  )
+)
+
+val vlcPluginBlocklist = listOf(
+  "gui", "lua", "control", "services_discovery", "visualization",
+  "mux", "stream_out", "access_output", "meta_engine", "keystore", "logger"
+)
+
+val vlcDownloadDir = layout.buildDirectory.dir("vlc-downloads")
+val vlcNativesDir = layout.buildDirectory.dir("vlc-natives")
+
+if ((findProperty("packageVlcNatives") ?: "false") == "true") {
+  val downloadVlcNatives = tasks.register<DownloadVlcNativesTask>("downloadVlcNatives") {
+    group = "flixelgdx"
+    description = "Downloads libvlc $vlcVersionString Windows natives for JAR packaging."
+    vlcVersion.set(vlcVersionString)
+    downloadSpecs.set(vlcDownloads)
+    pluginBlocklist.set(vlcPluginBlocklist)
+    downloadCacheDir.set(vlcDownloadDir)
+    nativesDir.set(vlcNativesDir)
+  }
+
+  tasks.processResources {
+    dependsOn(downloadVlcNatives)
+    from(vlcNativesDir) {
+      into("org/flixelgdx/video/natives")
+      exclude("**/sdk/**")
+    }
+  }
+}

--- a/flixelgdx-video-vlc-natives/build.gradle.kts
+++ b/flixelgdx-video-vlc-natives/build.gradle.kts
@@ -1,0 +1,81 @@
+// Packages libvlc native libraries for Windows, macOS, and Linux into a single JAR.
+// flixelgdx-video-lwjgl3 pulls this as a runtimeOnly dependency; FlixelVlcDiscovery
+// extracts the correct platform's files to a per-user cache at runtime.
+//
+// Download and packaging are gated behind -PpackageVlcNatives=true so normal developer
+// builds stay fast and network-free. The publish workflow sets this flag when cutting a
+// release so that the natives JAR is always up to date on Maven Central.
+
+plugins {
+  id("flixelgdx.java-library")
+}
+
+val vlcVersionString = libs.versions.vlc.get()
+
+val vlcDownloads = listOf(
+  mapOf(
+    "name" to "vlc-${vlcVersionString}-win64.zip",
+    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/win64/vlc-${vlcVersionString}-win64.zip",
+    "sha256" to "992d19dbd0b8a7cde9167d2f7780b1ef6f92acc8a71acfa736101a21f35181e1"
+  ),
+  mapOf(
+    "name" to "vlc-${vlcVersionString}-win64.7z",
+    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/win64/vlc-${vlcVersionString}-win64.7z",
+    "sha256" to "eb4fd8a28291da73608c733786a09610fea865fbe94113bcb60b91c1ebb8404a"
+  ),
+  mapOf(
+    "name" to "vlc-${vlcVersionString}-universal.dmg",
+    "url" to "https://download.videolan.org/pub/videolan/vlc/${vlcVersionString}/macosx/vlc-${vlcVersionString}-universal.dmg",
+    "sha256" to "56ee657c3aaf5c71b4ab7d6e4f4a77f6eca54633e0bf42a93b8116eb1d1f6ec9"
+  ),
+  mapOf(
+    "name" to "libvlc5_${vlcVersionString}-0+deb12u1_amd64.deb",
+    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/libvlc5_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
+    "sha256" to "07ad5c61dc41acf29c485224accf457b7632e68a910eee21badf30213e6ab359"
+  ),
+  mapOf(
+    "name" to "libvlccore9_${vlcVersionString}-0+deb12u1_amd64.deb",
+    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/libvlccore9_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
+    "sha256" to "a3114b86450777e4cbbd4620419b74d189367e5f5026286cc74c39c9e759bfa7"
+  ),
+  mapOf(
+    "name" to "vlc-plugin-base_${vlcVersionString}-0+deb12u1_amd64.deb",
+    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/vlc-plugin-base_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
+    "sha256" to "38b953a2a6355c5ba75e3e5d2015100d793fbf5a00211aaa78b2d705a9547cb1"
+  ),
+  mapOf(
+    "name" to "vlc-plugin-video-output_${vlcVersionString}-0+deb12u1_amd64.deb",
+    "url" to "https://deb.debian.org/debian/pool/main/v/vlc/vlc-plugin-video-output_${vlcVersionString}-0%2Bdeb12u1_amd64.deb",
+    "sha256" to "de1d62487161efc62305b6e84cd364e71f109125d601401ee824d3291813e6e2"
+  )
+)
+
+// Plugin categories no game playback path needs (interface, scripting, streaming out,
+// discovery). Dropping them roughly halves the Windows natives payload.
+val vlcPluginBlocklist = listOf(
+  "gui", "lua", "control", "services_discovery", "visualization",
+  "mux", "stream_out", "access_output", "meta_engine", "keystore", "logger"
+)
+
+val vlcDownloadDir = layout.buildDirectory.dir("vlc-downloads")
+val vlcNativesDir = layout.buildDirectory.dir("vlc-natives")
+
+if ((findProperty("packageVlcNatives") ?: "false") == "true") {
+  val downloadVlcNatives = tasks.register<DownloadVlcNativesTask>("downloadVlcNatives") {
+    group = "flixelgdx"
+    description = "Downloads libvlc $vlcVersionString natives (Windows, macOS, Linux) for JAR packaging."
+    vlcVersion.set(vlcVersionString)
+    downloadSpecs.set(vlcDownloads)
+    pluginBlocklist.set(vlcPluginBlocklist)
+    downloadCacheDir.set(vlcDownloadDir)
+    nativesDir.set(vlcNativesDir)
+  }
+
+  tasks.processResources {
+    dependsOn(downloadVlcNatives)
+    from(vlcNativesDir) {
+      into("org/flixelgdx/video/natives")
+      exclude("**/sdk/**")
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xms256M -Xmx512M -Dfile.encoding=UTF-8 -Dconsole.encoding=UT
 # Documented at: https://docs.gradle.org/current/userguide/command_line_interface.html#sec:command_line_logging
 org.gradle.logging.level=quiet
 android.useAndroidX=true
-projectVersion=0.4.4
+projectVersion=0.5.1
 groupId=org.flixelgdx
 # Reflection safety profile used by Android and TeaVM build tooling.
 # SIMPLE: flixelgdx only
@@ -23,7 +23,7 @@ flixelReflectionExtraPackages=
 # Maven POM metadata (used by maven-publish). Required: the publish task fails fast if any
 # of these are missing. Override every value for your fork if you plan to publish from it.
 pomName=FlixelGDX
-pomDescription=High-level and powerful game development framework that brings the Flixel philosophy to Java and libGDX.
+pomDescription=High-level and powerful game development framework that brings the Flixel philosophy to Java.
 pomUrl=https://flixelgdx.org
 pomLicenseName=MIT License
 pomLicenseUrl=https://opensource.org/licenses/MIT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,6 +66,7 @@ include(
   "flixelgdx-logging-plugin",
   "flixelgdx-basisu-plugin",
   "flixelgdx-video-core",
+  "flixelgdx-video-vlc-natives",
   "flixelgdx-video-lwjgl3",
   "flixelgdx-video-teavm",
   "flixelgdx-test"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -66,7 +66,9 @@ include(
   "flixelgdx-logging-plugin",
   "flixelgdx-basisu-plugin",
   "flixelgdx-video-core",
-  "flixelgdx-video-vlc-natives",
+  "flixelgdx-video-vlc-natives-windows-amd64",
+  "flixelgdx-video-vlc-natives-linux-amd64",
+  "flixelgdx-video-vlc-natives-macos-universal",
   "flixelgdx-video-lwjgl3",
   "flixelgdx-video-teavm",
   "flixelgdx-test"


### PR DESCRIPTION
## Description

The desktop video extension previously fetched libvlc archives from VideoLAN servers during every build via a custom Gradle task. This made the build unreliable (live network dependency, VideoLAN server availability, potential link rot) and slow for contributors who just want to compile the framework.

This PR refactors the system so native packaging is fully decoupled from the normal build:

- **Three new per-platform subprojects** - `flixelgdx-video-vlc-natives-windows-amd64`, `flixelgdx-video-vlc-natives-linux-amd64`, and `flixelgdx-video-vlc-natives-macos-universal`. Each is a packaging-only module that downloads, strips (same blocklist as before), and bundles only its platform's libvlc natives into a JAR under `org/flixelgdx/video/natives/{platform}/`. Downloads are gated behind `-PpackageVlcNatives=true` so `./gradlew build` stays fast and network-free for contributors. Games can exclude individual platform JARs they don't ship for.
- **`flixelgdx-video-lwjgl3` simplified** - all download specs, the `DownloadVlcNativesTask` registration, and the `processResources` gate are removed. Three `runtimeOnly` project dependencies replace them. `FlixelVlcDiscovery` needs no changes - it already reads bundled natives from the classpath via `ClassLoader.getResource()`, which finds resources in any JAR on the classpath regardless of which one they come from.
- **Publish workflow updated** - installs `p7zip-full` (so the Ubuntu runner can extract the macOS DMG using 7z), then publishes with `-PpackageVlcNatives=true`. All three natives JARs publish alongside the rest of the framework artifacts under the same version number. Games get them transitively from `flixelgdx-video-lwjgl3` with no extra dependencies to declare.
- **Stale `natives/` directory removed** - the old project-directory extraction target in `flixelgdx-video-lwjgl3` is gone; output now lands in `build/vlc-natives/` in each new subproject (already covered by the root `.gitignore`).

The versioning follows the framework version (not the VLC version) for the same reason libGDX versions `gdx-platform:natives-desktop` by the framework release - it avoids re-publishing the same coordinates on every framework version bump.

### Bug fixes in `DownloadVlcNativesTask`

Testing the new subprojects surfaced three pre-existing bugs that would have broken CI:

- **`findFile()` now returns null instead of throwing** when a download spec is absent, so each subproject can pass only its own platform's specs and the task silently skips irrelevant extract methods.
- **`extractDeb()` rewritten to use system `ar`/`tar`** instead of commons-compress. The Android Gradle Plugin pulls commons-compress 1.21 into a shared parent classloader that shadows build-logic's 1.27.x at runtime, causing `NoSuchMethodError` on both `ArArchiveInputStream` and `SevenZFile.Builder.get()`. System tools are always available on Linux (the only OS where `.deb` extraction runs) and have no classpath ambiguity. The win64.7z download spec is also dropped from the Windows subproject for the same reason - the only content it held was SDK import `.lib` files excluded from the JAR by `exclude("**/sdk/**")` anyway.
- **macOS 7z subprocess now uses `Redirect.DISCARD`** instead of closing the stream after `start()`. Closing without consuming filled the OS pipe buffer and silently killed 7z mid-extraction, producing an empty output directory with a successful exit code.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor / Optimization
- [ ] Other (please specify in description)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added tests that prove my fix is effective or that my feature works (if any code was added or changed).

## Screenshots / Evidence (if applicable)

Normal build (no flag) - all modules build cleanly with no network access:

```
./gradlew :flixelgdx-video-lwjgl3:build :flixelgdx-video-vlc-natives-windows-amd64:build :flixelgdx-video-vlc-natives-linux-amd64:build :flixelgdx-video-vlc-natives-macos-universal:build
BUILD SUCCESSFUL
```

Packaging all three platform JARs and verifying contents:

```
./gradlew :flixelgdx-video-vlc-natives-windows-amd64:jar :flixelgdx-video-vlc-natives-linux-amd64:jar :flixelgdx-video-vlc-natives-macos-universal:jar -PpackageVlcNatives=true --no-daemon
BUILD SUCCESSFUL

# windows-amd64 JAR: 326 entries under org/flixelgdx/video/natives/windows-amd64/
# linux-amd64 JAR:   340 entries under org/flixelgdx/video/natives/linux-amd64/
# macos-universal JAR: 368 entries under org/flixelgdx/video/natives/macos-universal/
```