### PR TITLE
Fixed state factory corruption and stale camera snapshots on debugger reset

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -55,6 +55,5 @@ body:
         - Core (Every Platform)
         - Desktop (LWJGL3)
         - Android
-        - iOS (RoboVM)
         - Web (TeaVM)
         - Other (please specify in description)

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -19,17 +19,20 @@ The project is split into several modules, each serving a specific purpose:
 
 ## Build System
 
-FlixelGDX uses **Gradle** as its build system. 
+FlixelGDX uses **Gradle** with Kotlin DSL as its build system. 
 
-### Key Files
+### Key Files and Folders
 
-- **`build.gradle`**: The root aggregator where the build system enters. It triggers other task-specific scripts inside of [`gradle/`](./gradle).
-- **`settings.gradle`**: Defines all the modules included in the project.
-- **`gradle.properties`**: Contains version numbers for libGDX and other dependencies, as well as JVM settings for the build process.
+- **`build.gradle.kts`**: The root aggregator where the build system enters. It only registers the `javadocsAll` task, nothing else.
+- **`settings.gradle.kts`**: Defines all the modules included in the project. Note that `flixelgdx-android` is excluded by default unless
+  `includeAndroid` is set to true in a `local.properties` file or passed as a command argument in the terminal via `PincludeAndroid=true`.
+  Refer to the [COMPILING.md](COMPILING.md) file for more information.
+- **`gradle.properties`**: Contains JVM settings for the build process, Maven publishing details and various other properties.
+- **`build-logic/`**: Where the build system's logic lies. It contains various build scripts for systems like Maven central publishing and more.
 
 ### Dependency Management
 
-Dependencies are managed in the `build.gradle` file of each module. We use `api` and `implementation` configurations to control which dependencies are exposed to downstream projects.
+Dependencies are managed in the `build.gradle.kts` file of each module. We use `api` and `implementation` configurations to control which dependencies are exposed to downstream projects.
 For example, the `flixelgdx-core` module uses `api` for libGDX, which means any project using FlixelGDX will also have access to the underlying libGDX classes.
 
 ## GitHub Integration

--- a/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/Flixel.java
@@ -1241,9 +1241,10 @@ public final class Flixel {
    */
   public static void resetState() {
     Objects.requireNonNull(game, "Game is not initialized. Call initialize(...) first.");
-    FlixelState next = currentStateFactory != null ? currentStateFactory.get() : null;
+    Supplier<FlixelState> factory = currentStateFactory;
+    FlixelState next = factory != null ? factory.get() : null;
     if (next != null) {
-      switchState(next);
+      switchState(next, true, true, true, factory);
     }
   }
 

--- a/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
+++ b/flixelgdx-core/src/main/java/org/flixelgdx/FlixelGame.java
@@ -1208,6 +1208,10 @@ public abstract class FlixelGame implements ApplicationListener, FlixelUpdatable
     camera.update(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), camera.centerCameraOnResize);
     cameras.clear();
     cameras.add(camera);
+    // The debug-pause snapshot refers to cameras that no longer exist after this reset,
+    // so discard it. restoreCamerasAfterDebugPause() already handles null gracefully.
+    debugPauseCameraScroll = null;
+    debugPauseCameraZoom = null;
     if (desktopTransparencyActive) {
       applyDesktopTransparencyBackdropOnly();
     }

--- a/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMAnalogButtonReader.java
+++ b/flixelgdx-teavm/src/main/java/org/flixelgdx/backend/teavm/FlixelTeaVMAnalogButtonReader.java
@@ -26,6 +26,7 @@ package org.flixelgdx.backend.teavm;
 import com.badlogic.gdx.controllers.Controller;
 
 import org.flixelgdx.input.gamepad.FlixelAnalogButtonReader;
+import org.flixelgdx.input.gamepad.FlixelGamepadInput;
 import org.jetbrains.annotations.NotNull;
 import org.teavm.jso.JSBody;
 
@@ -40,8 +41,8 @@ import org.teavm.jso.JSBody;
  * {@code navigator.getGamepads()[index].buttons[buttonIndex].value} instead.
  *
  * <p>This reader is installed automatically by {@link FlixelTeaVMLauncher} and covers
- * {@link FlixelGamepadButton#AXIS_TRIGGER_L AXIS_TRIGGER_L} and
- * {@link FlixelGamepadButton#AXIS_TRIGGER_R AXIS_TRIGGER_R} on web.
+ * {@link FlixelGamepadInput#AXIS_TRIGGER_L AXIS_TRIGGER_L} and
+ * {@link FlixelGamepadInput#AXIS_TRIGGER_R AXIS_TRIGGER_R} on web.
  * You do not need to install it manually.
  */
 final class FlixelTeaVMAnalogButtonReader implements FlixelAnalogButtonReader {


### PR DESCRIPTION
## Description

Fixed two related bugs that caused camera follow to break whenever the debugger's Reset State button was used.

**Bug 1 - State factory corruption (`Flixel.java`)**

`resetState()` previously called `switchState(next)` (the single-argument overload), which internally chains to `switchState(next, true, true, true, () -> next)`. That final lambda captures the just-created instance, overwriting `currentStateFactory` with a supplier that always returns the same object. On the second reset, `currentStateFactory.get()` would return the currently active (and then immediately destroyed) state, so `create()` was being called on a destroyed object.

Fix: `resetState()` now captures the factory reference before getting the new state, then passes it explicitly to the full `switchState(...)` overload, so `currentStateFactory` is never replaced with a stale-instance lambda.

**Bug 2 - Stale debug-pause camera snapshot (`FlixelGame.java`)**

When the game was paused for debugging, `snapshotCamerasForDebugPause()` stored camera scroll and zoom values. If Reset State was then clicked, `resetCameras()` created a brand-new camera list, but the old snapshot was left intact. On unpause, `restoreCamerasAfterDebugPause()` would restore those pre-reset scroll positions to the new camera, overriding whatever the freshly created state had configured (including camera follow targets), making follow appear completely broken.

Fix: `resetCameras()` now nulls out `debugPauseCameraScroll` and `debugPauseCameraZoom` immediately after replacing the camera list. `restoreCamerasAfterDebugPause()` already handles null snapshots gracefully by returning early, so no additional changes were needed there.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My PR targets the **develop** branch, not master/main.
- [x] My code follows the code style of this project (if any code was added or changed).
- [x] I have performed a self-review of my own code (if any code was added or changed).
- [x] I have commented my code, particularly in hard-to-understand areas (if any code was added or changed).
- [x] My changes pass all automated build checks.
- [x] I have updated the documentation accordingly (if applicable).